### PR TITLE
temporary fix for pycares 5.0.0 upgrade breaking changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ colorlog==6.10.1
 homeassistant>=2025.11.2
 pip>=21.3.1
 ruff==0.14.8
+pycares==4.11.0


### PR DESCRIPTION
pycares introduced breaking changes that prevent Home Assistant from running
https://pycares.readthedocs.io/latest/migration.html
This will become unnecessary when the home assistant package includes this fix:
https://github.com/home-assistant/core/pull/158695
(aiodns fixed it the same way - https://github.com/aio-libs/aiodns/pull/215)