### PR TITLE
Add deterministic night-motion/disarmed template (issue #235)

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ When Sentinel notifications are enabled:
 - `open_entry_at_night_when_home`
 - `open_entry_at_night_while_away`
 - `open_any_window_at_night_while_away`
+- `motion_detected_at_night_while_alarm_disarmed`
 - `motion_without_camera_activity`
 - `motion_while_alarm_disarmed_and_home_present`
 
@@ -302,6 +303,8 @@ Compatibility note: `unavailable_sensors_while_home` supports re-approving legac
 `unavailable_sensors` is also supported for candidates without explicit occupancy context (for example `backyard_sensors_unavailable`). It triggers only when all listed sensors are `unavailable`; if any required sensor is missing or not unavailable, no finding is produced.
 
 `motion_while_alarm_disarmed_and_home_present` is supported for candidates that provide motion entities, an alarm entity, and one or more `person.*` entities in evidence paths. It triggers only when all required entities are present and states match exactly: alarm `disarmed`, motion `on`, and person `home`.
+
+`motion_detected_at_night_while_alarm_disarmed` is supported for candidates that provide motion entities, an alarm entity, and `derived.is_night` evidence (for example candidate `motion_at_night_disarmed`). It triggers only when all required entities referenced by the rule are present, snapshot `derived.is_night` is `true`, alarm state is `disarmed`, and at least one motion entity is `on`. It returns no findings when required entities are missing.
 
 `low_battery_sensors` is supported for battery entity candidates (for example `sensor.elias_t_h_battery` and `sensor.girls_t_h_battery`). It triggers when any listed sensor is at or below the configured threshold (default `40%`) and produces no findings if any required entity is missing or has a non-numeric state.
 

--- a/custom_components/home_generative_agent/sentinel/discovery_semantic.py
+++ b/custom_components/home_generative_agent/sentinel/discovery_semantic.py
@@ -146,6 +146,14 @@ def rule_semantic_key(rule: dict[str, Any]) -> str | None:  # noqa: PLR0911, PLR
             "v1|subject=motion|predicate=active|night=any|home=any|scope=any|"
             f"entities={','.join(motion_ids)}"
         )
+    if template_id == "motion_detected_at_night_while_alarm_disarmed":
+        motion_ids = sorted(set(_string_list(params.get("motion_entity_ids"))))
+        if not motion_ids:
+            return None
+        return (
+            "v1|subject=motion|predicate=active|night=1|home=any|scope=any|"
+            f"entities={','.join(motion_ids)}"
+        )
     if template_id == "unavailable_sensors_while_home":
         sensor_ids = sorted(set(_string_list(params.get("sensor_entity_ids"))))
         if not sensor_ids:

--- a/custom_components/home_generative_agent/sentinel/dynamic_rules.py
+++ b/custom_components/home_generative_agent/sentinel/dynamic_rules.py
@@ -36,6 +36,11 @@ def evaluate_dynamic_rules(
             snapshot, rule, entity_map
         ),
         "low_battery_sensors": lambda rule: _eval_low_battery_sensors(rule, entity_map),
+        "motion_detected_at_night_while_alarm_disarmed": (
+            lambda rule: _eval_motion_detected_at_night_while_alarm_disarmed(
+                snapshot, rule, entity_map
+            )
+        ),
         "motion_while_alarm_disarmed_and_home_present": (
             lambda rule: _eval_motion_while_alarm_disarmed_and_home_present(
                 snapshot, rule, entity_map
@@ -191,6 +196,60 @@ def _eval_motion_while_alarm_disarmed_and_home_present(
         },
     }
     return [_build_finding(rule, [alarm_id, *motion_ids, *home_ids], evidence)]
+
+
+def _eval_motion_detected_at_night_while_alarm_disarmed(
+    snapshot: FullStateSnapshot,
+    rule: dict[str, Any],
+    entity_map: Mapping[str, SnapshotEntity],
+) -> list[AnomalyFinding]:
+    params = _rule_params(rule)
+    alarm_id = params.get("alarm_entity_id")
+    motion_ids = params.get("motion_entity_ids")
+    required_ids = params.get("required_entity_ids", [])
+    if (
+        not alarm_id
+        or not isinstance(motion_ids, list)
+        or not motion_ids
+        or not isinstance(required_ids, list)
+    ):
+        return []
+
+    if not snapshot["derived"]["is_night"]:
+        return []
+
+    alarm = entity_map.get(alarm_id)
+    if alarm is None or alarm.get("state") != "disarmed":
+        return []
+
+    motion_entities = _resolve_required_entities(motion_ids, entity_map)
+    required_entities = _resolve_required_entities(required_ids, entity_map)
+    if motion_entities is None or required_entities is None:
+        return []
+
+    if not any(motion.get("state") == "on" for motion in motion_entities):
+        return []
+
+    evidence = {
+        "rule_id": rule.get("rule_id"),
+        "template_id": rule.get("template_id"),
+        "is_night": snapshot["derived"]["is_night"],
+        "alarm_entity_id": alarm_id,
+        "alarm_state": alarm.get("state"),
+        "motion_entity_ids": list(motion_ids),
+        "motion_states": {
+            motion_id: motion.get("state")
+            for motion_id, motion in zip(motion_ids, motion_entities, strict=False)
+        },
+        "required_entity_ids": list(required_ids),
+        "required_states": {
+            required_id: required_entity.get("state")
+            for required_id, required_entity in zip(
+                required_ids, required_entities, strict=False
+            )
+        },
+    }
+    return [_build_finding(rule, [alarm_id, *motion_ids, *required_ids], evidence)]
 
 
 def _eval_unlocked_lock_when_home(

--- a/tests/custom_components/home_generative_agent/test_discovery_semantic.py
+++ b/tests/custom_components/home_generative_agent/test_discovery_semantic.py
@@ -133,3 +133,23 @@ def test_rule_semantic_key_low_battery_sensors() -> None:
     assert "subject=sensor" in key
     assert "predicate=low_battery" in key
     assert "home=any" in key
+
+
+def test_rule_semantic_key_motion_night_alarm_disarmed_issue_235() -> None:
+    rule = {
+        "rule_id": "motion_at_night_disarmed",
+        "template_id": "motion_detected_at_night_while_alarm_disarmed",
+        "params": {
+            "alarm_entity_id": "alarm_control_panel.home_alarm",
+            "motion_entity_ids": [
+                "binary_sensor.backyard_vmd3_0",
+                "binary_sensor.backyard_vmd4_camera1profile1",
+            ],
+            "required_entity_ids": ["person.lindo_st_angel"],
+        },
+    }
+    key = rule_semantic_key(rule)
+    assert key is not None
+    assert "subject=motion" in key
+    assert "predicate=active" in key
+    assert "night=1" in key

--- a/tests/custom_components/home_generative_agent/test_dynamic_rules.py
+++ b/tests/custom_components/home_generative_agent/test_dynamic_rules.py
@@ -606,6 +606,141 @@ def test_dynamic_rule_motion_alarm_disarmed_home_issue_225_non_trigger() -> None
     assert findings == []
 
 
+def test_dynamic_rule_motion_night_alarm_disarmed_issue_235_triggers() -> None:
+    snapshot = _snapshot(
+        [
+            _base_entity(
+                "alarm_control_panel.home_alarm", "alarm_control_panel", "disarmed"
+            ),
+            _base_entity("binary_sensor.backyard_vmd3_0", "binary_sensor", "on"),
+            _base_entity(
+                "binary_sensor.backyard_vmd4_camera1profile1", "binary_sensor", "off"
+            ),
+            _base_entity("person.lindo_st_angel", "person", "home"),
+        ],
+        [],
+        {
+            "now": "2026-02-01T00:00:00+00:00",
+            "timezone": "UTC",
+            "is_night": True,
+            "anyone_home": True,
+            "last_motion_by_area": {},
+        },
+    )
+    rules = [
+        {
+            "rule_id": "motion_at_night_disarmed",
+            "template_id": "motion_detected_at_night_while_alarm_disarmed",
+            "params": {
+                "alarm_entity_id": "alarm_control_panel.home_alarm",
+                "motion_entity_ids": [
+                    "binary_sensor.backyard_vmd3_0",
+                    "binary_sensor.backyard_vmd4_camera1profile1",
+                ],
+                "required_entity_ids": ["person.lindo_st_angel"],
+            },
+            "severity": "low",
+            "confidence": 0.8,
+            "is_sensitive": False,
+            "suggested_actions": ["close_entry"],
+        }
+    ]
+    findings = evaluate_dynamic_rules(snapshot, rules)
+    assert len(findings) == 1
+    assert findings[0].type == "motion_at_night_disarmed"
+    assert findings[0].triggering_entities == [
+        "alarm_control_panel.home_alarm",
+        "binary_sensor.backyard_vmd3_0",
+        "binary_sensor.backyard_vmd4_camera1profile1",
+        "person.lindo_st_angel",
+    ]
+
+
+def test_dynamic_rule_motion_night_alarm_disarmed_issue_235_non_trigger() -> None:
+    snapshot = _snapshot(
+        [
+            _base_entity(
+                "alarm_control_panel.home_alarm", "alarm_control_panel", "disarmed"
+            ),
+            _base_entity("binary_sensor.backyard_vmd3_0", "binary_sensor", "off"),
+            _base_entity(
+                "binary_sensor.backyard_vmd4_camera1profile1", "binary_sensor", "off"
+            ),
+            _base_entity("person.lindo_st_angel", "person", "home"),
+        ],
+        [],
+        {
+            "now": "2026-02-01T00:00:00+00:00",
+            "timezone": "UTC",
+            "is_night": True,
+            "anyone_home": True,
+            "last_motion_by_area": {},
+        },
+    )
+    rules = [
+        {
+            "rule_id": "motion_at_night_disarmed",
+            "template_id": "motion_detected_at_night_while_alarm_disarmed",
+            "params": {
+                "alarm_entity_id": "alarm_control_panel.home_alarm",
+                "motion_entity_ids": [
+                    "binary_sensor.backyard_vmd3_0",
+                    "binary_sensor.backyard_vmd4_camera1profile1",
+                ],
+                "required_entity_ids": ["person.lindo_st_angel"],
+            },
+            "severity": "low",
+            "confidence": 0.8,
+            "is_sensitive": False,
+            "suggested_actions": ["close_entry"],
+        }
+    ]
+    findings = evaluate_dynamic_rules(snapshot, rules)
+    assert findings == []
+
+
+def test_dynamic_rule_motion_night_alarm_disarmed_issue_235_missing_required() -> None:
+    snapshot = _snapshot(
+        [
+            _base_entity(
+                "alarm_control_panel.home_alarm", "alarm_control_panel", "disarmed"
+            ),
+            _base_entity("binary_sensor.backyard_vmd3_0", "binary_sensor", "on"),
+            _base_entity(
+                "binary_sensor.backyard_vmd4_camera1profile1", "binary_sensor", "off"
+            ),
+        ],
+        [],
+        {
+            "now": "2026-02-01T00:00:00+00:00",
+            "timezone": "UTC",
+            "is_night": True,
+            "anyone_home": True,
+            "last_motion_by_area": {},
+        },
+    )
+    rules = [
+        {
+            "rule_id": "motion_at_night_disarmed",
+            "template_id": "motion_detected_at_night_while_alarm_disarmed",
+            "params": {
+                "alarm_entity_id": "alarm_control_panel.home_alarm",
+                "motion_entity_ids": [
+                    "binary_sensor.backyard_vmd3_0",
+                    "binary_sensor.backyard_vmd4_camera1profile1",
+                ],
+                "required_entity_ids": ["person.lindo_st_angel"],
+            },
+            "severity": "low",
+            "confidence": 0.8,
+            "is_sensitive": False,
+            "suggested_actions": ["close_entry"],
+        }
+    ]
+    findings = evaluate_dynamic_rules(snapshot, rules)
+    assert findings == []
+
+
 @pytest.mark.asyncio
 async def test_rule_registry_add_duplicate(hass) -> None:
     registry = RuleRegistry(hass=cast("HomeAssistant", hass))

--- a/tests/custom_components/home_generative_agent/test_proposal_templates.py
+++ b/tests/custom_components/home_generative_agent/test_proposal_templates.py
@@ -250,3 +250,36 @@ def test_normalize_candidate_motion_alarm_disarmed_home_issue_225() -> None:
         ],
         "home_entity_ids": ["person.lindo_st_angel"],
     }
+
+
+def test_normalize_candidate_motion_night_alarm_disarmed_issue_235() -> None:
+    candidate = {
+        "candidate_id": "motion_at_night_disarmed",
+        "title": "Motion detected at night while alarm disarmed",
+        "summary": (
+            "Detects any motion sensor activation during nighttime when the home "
+            "alarm is disarmed."
+        ),
+        "pattern": "motion active & night & alarm disarmed",
+        "suggested_type": "security",
+        "confidence_hint": 0.8,
+        "evidence_paths": [
+            "derived.is_night",
+            "entities[entity_id=alarm_control_panel.home_alarm].state",
+            "entities[entity_id=binary_sensor.backyard_vmd3_0].state",
+            "entities[entity_id=binary_sensor.backyard_vmd4_camera1profile1].state",
+            "entities[entity_id=person.lindo_st_angel].state",
+        ],
+    }
+    normalized = normalize_candidate(candidate)
+    assert normalized is not None
+    assert normalized.template_id == "motion_detected_at_night_while_alarm_disarmed"
+    assert normalized.rule_id == "motion_at_night_disarmed"
+    assert normalized.params == {
+        "alarm_entity_id": "alarm_control_panel.home_alarm",
+        "motion_entity_ids": [
+            "binary_sensor.backyard_vmd3_0",
+            "binary_sensor.backyard_vmd4_camera1profile1",
+        ],
+        "required_entity_ids": ["person.lindo_st_angel"],
+    }


### PR DESCRIPTION
## Summary
This PR implements support for issue [#235](https://github.com/goruck/home-generative-agent/issues/235) by adding a deterministic Sentinel template for:

`motion_detected_at_night_while_alarm_disarmed`

It also updates documentation and adds regression coverage for normalization, evaluation, and semantic keys.

## What Changed

### Sentinel template normalization
- Added new supported template:
  - `motion_detected_at_night_while_alarm_disarmed`
- Added candidate mapping logic for motion + night + alarm disarmed candidates.
- Normalized params now include:
  - `alarm_entity_id`
  - `motion_entity_ids`
  - `required_entity_ids`

**File**
- `custom_components/home_generative_agent/sentinel/proposal_templates.py`

### Dynamic rule evaluation
- Added evaluator dispatch for the new template.
- Added deterministic evaluation behavior:
  - Requires `derived.is_night == true`
  - Requires alarm state `disarmed`
  - Requires all referenced entities to exist
  - Triggers when **any** motion entity is `on`
  - Returns no findings if required entities are missing

**File**
- `custom_components/home_generative_agent/sentinel/dynamic_rules.py`

### Discovery semantic key support
- Added `rule_semantic_key` support for the new template with `night=1`.

**File**
- `custom_components/home_generative_agent/sentinel/discovery_semantic.py`

### Tests
- Added normalization test for issue #235 candidate mapping.
- Added dynamic rule tests:
  - trigger case
  - non-trigger case
  - missing-required-entity case
- Added semantic key test for the new template.

**Files**
- `tests/custom_components/home_generative_agent/test_proposal_templates.py`
- `tests/custom_components/home_generative_agent/test_dynamic_rules.py`
- `tests/custom_components/home_generative_agent/test_discovery_semantic.py`

### Documentation
- Updated README supported template list.
- Added behavior notes for `motion_detected_at_night_while_alarm_disarmed`.

**File**
- `README.md`

## Validation
Ran:
- `./hga/bin/pytest tests/custom_components/home_generative_agent/test_proposal_templates.py tests/custom_components/home_generative_agent/test_dynamic_rules.py tests/custom_components/home_generative_agent/test_discovery_semantic.py`
- `hga/bin/ruff check` on modified files

Result:
- Tests passed
- Ruff checks passed

## Linked Issue
- Closes #235