### PR TITLE
docs: refresh AGENTS guidance and setup script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,8 +8,14 @@ Home Assistant custom integration providing a generative agent. Core code lives 
 - `custom_components/home_generative_agent/` — integration code
 - `tests/` — pytest suite
 - `blueprints/` — HA blueprints used by the integration
-- `scripts/` — helper scripts (deps, lint)
+- `scripts/` — helper scripts (notably `gen_manifest_requirements.py`)
 - `requirements/` + `requirements_runtime_manifest.txt` — dependency management
+
+## Integration module map
+- `sentinel/` — anomaly detection engine, dynamic rules, proposals, suppression
+- `snapshot/` — snapshot schema/builders/reducers used by Sentinel and explain flows
+- `notify/` — mobile notification dispatch and action helpers
+- `explain/` — prompt templates and LLM-backed explanation/discovery helpers
 
 ## Development environment
 - Python: 3.13
@@ -52,3 +58,5 @@ Runtime dependencies are sourced from
 
 ## Notes
 - The integration is a Home Assistant service integration (`manifest.json`).
+- Prefer the Makefile workflow for setup/tasks (`make devdeps`, `make testdeps`,
+  `make runtimedeps`) over legacy helper scripts.

--- a/scripts/setup
+++ b/scripts/setup
@@ -4,4 +4,6 @@ set -e
 
 cd "$(dirname "$0")/.."
 
-python3 -m pip install --requirement requirements.txt
+make devdeps
+make testdeps
+make runtimedeps


### PR DESCRIPTION
## Summary
This PR updates project guidance and setup flow to match the current repository state.

## Changes
- Updated `AGENTS.md`:
  - Clarified `scripts/` to highlight `scripts/gen_manifest_requirements.py`
  - Added an `Integration module map` section for:
    - `sentinel/`
    - `snapshot/`
    - `notify/`
    - `explain/`
  - Added guidance to prefer Makefile-based setup tasks over legacy helper scripts
- Updated `scripts/setup`:
  - Removed stale `requirements.txt` install step
  - Replaced with current workflow:
    - `make devdeps`
    - `make testdeps`
    - `make runtimedeps`

## Why
- `scripts/setup` referenced `requirements.txt`, which no longer exists.
- `AGENTS.md` needed small updates to better reflect the current module structure and dependency workflow.

## Files Changed
- `AGENTS.md`
- `scripts/setup`

## Testing
- Not applicable (documentation and setup script workflow update only).