### PR TITLE
Sentinel: structured suppression decision model

### DIFF
--- a/custom_components/home_generative_agent/sentinel/engine.py
+++ b/custom_components/home_generative_agent/sentinel/engine.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import inspect
 import logging
 from datetime import timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 
 from homeassistant.util import dt as dt_util
 
@@ -40,6 +41,9 @@ if TYPE_CHECKING:
     from custom_components.home_generative_agent.explain.llm_explain import LLMExplainer
     from custom_components.home_generative_agent.notify.dispatcher import (
         NotificationDispatcher,
+    )
+    from custom_components.home_generative_agent.snapshot.schema import (
+        FullStateSnapshot,
     )
 
     from .models import AnomalyFinding
@@ -169,13 +173,15 @@ class SentinelEngine:
             return
 
         for finding in all_findings:
-            if should_suppress(
+            suppression_decision = should_suppress(
                 self._suppression.state, finding, now, cooldown_type, cooldown_entity
-            ):
+            )
+            if suppression_decision.suppress:
                 LOGGER.debug(
-                    "Suppressed finding %s for %s.",
+                    "Suppressed finding %s for %s (%s).",
                     finding.anomaly_id,
                     finding.type,
+                    suppression_decision.reason_code,
                 )
                 continue
             register_finding(self._suppression.state, finding, now)
@@ -192,7 +198,13 @@ class SentinelEngine:
                 explanation = await self._explainer.async_explain(finding)
 
             await self._notifier.async_notify(finding, snapshot, explanation)
-            await self._audit_store.async_append_finding(snapshot, finding, explanation)
+            await _append_finding_audit(
+                self._audit_store,
+                snapshot,
+                finding,
+                explanation,
+                suppression_decision.reason_code,
+            )
         LOGGER.debug("Sentinel cycle completed with %s finding(s).", len(all_findings))
 
 
@@ -210,3 +222,38 @@ def _coerce_int(value: object | None, default: int) -> int:
         except ValueError:
             return default
     return default
+
+
+def _supports_suppression_reason_code(callable_obj: object) -> bool:
+    """Check whether an audit append callable can accept suppression reason metadata."""
+    try:
+        signature = inspect.signature(cast("Any", callable_obj))
+    except (TypeError, ValueError):
+        return False
+
+    if "suppression_reason_code" in signature.parameters:
+        return True
+
+    for parameter in signature.parameters.values():
+        if parameter.kind == inspect.Parameter.VAR_KEYWORD:
+            return True
+    return False
+
+
+async def _append_finding_audit(
+    audit_store: AuditStore,
+    snapshot: FullStateSnapshot,
+    finding: AnomalyFinding,
+    explanation: str | None,
+    suppression_reason_code: str,
+) -> None:
+    """Append a finding to audit with optional suppression reason metadata."""
+    if _supports_suppression_reason_code(audit_store.async_append_finding):
+        await cast("Any", audit_store).async_append_finding(
+            snapshot,
+            finding,
+            explanation,
+            suppression_reason_code=suppression_reason_code,
+        )
+        return
+    await audit_store.async_append_finding(snapshot, finding, explanation)

--- a/custom_components/home_generative_agent/sentinel/suppression.py
+++ b/custom_components/home_generative_agent/sentinel/suppression.py
@@ -22,6 +22,20 @@ STORE_KEY = "home_generative_agent_sentinel_suppression"
 
 LOGGER = logging.getLogger(__name__)
 
+SUPPRESSION_REASON_NOT_SUPPRESSED = "not_suppressed"
+SUPPRESSION_REASON_PENDING_PROMPT = "pending_prompt"
+SUPPRESSION_REASON_TYPE_COOLDOWN = "type_cooldown"
+SUPPRESSION_REASON_ENTITY_COOLDOWN = "entity_cooldown"
+
+
+@dataclass(frozen=True)
+class SuppressionDecision:
+    """Structured suppression decision."""
+
+    suppress: bool
+    reason_code: str
+    context: dict[str, Any] = field(default_factory=dict)
+
 
 @dataclass
 class SuppressionState:
@@ -66,15 +80,23 @@ def should_suppress(
     now: datetime,
     cooldown_type: timedelta,
     cooldown_entity: timedelta,
-) -> bool:
+) -> SuppressionDecision:
     """Determine whether a finding should be suppressed."""
+    pending_prompt_last_seen = state.pending_prompts.get(finding.anomaly_id)
     if finding.anomaly_id in state.pending_prompts:
         LOGGER.debug(
             "Suppressing %s (%s): pending prompt exists.",
             finding.anomaly_id,
             finding.type,
         )
-        return True
+        return SuppressionDecision(
+            suppress=True,
+            reason_code=SUPPRESSION_REASON_PENDING_PROMPT,
+            context={
+                "anomaly_id": finding.anomaly_id,
+                "last_seen": pending_prompt_last_seen,
+            },
+        )
 
     last_type = _parse_dt(state.last_by_type.get(finding.type))
     if last_type is not None and now - last_type < cooldown_type:
@@ -84,7 +106,14 @@ def should_suppress(
             finding.type,
             state.last_by_type.get(finding.type),
         )
-        return True
+        return SuppressionDecision(
+            suppress=True,
+            reason_code=SUPPRESSION_REASON_TYPE_COOLDOWN,
+            context={
+                "type": finding.type,
+                "last_seen": state.last_by_type.get(finding.type),
+            },
+        )
 
     for entity_id in finding.triggering_entities:
         last_entity = _parse_dt(
@@ -98,9 +127,23 @@ def should_suppress(
                 entity_id,
                 state.last_by_entity.get(entity_id, {}).get(finding.type),
             )
-            return True
+            return SuppressionDecision(
+                suppress=True,
+                reason_code=SUPPRESSION_REASON_ENTITY_COOLDOWN,
+                context={
+                    "entity_id": entity_id,
+                    "type": finding.type,
+                    "last_seen": state.last_by_entity.get(entity_id, {}).get(
+                        finding.type
+                    ),
+                },
+            )
 
-    return False
+    return SuppressionDecision(
+        suppress=False,
+        reason_code=SUPPRESSION_REASON_NOT_SUPPRESSED,
+        context={},
+    )
 
 
 def register_finding(

--- a/tests/custom_components/home_generative_agent/test_sentinel_end_to_end.py
+++ b/tests/custom_components/home_generative_agent/test_sentinel_end_to_end.py
@@ -56,8 +56,16 @@ class DummyAudit:
     def __init__(self) -> None:
         self.calls: list[dict[str, object]] = []
 
-    async def async_append_finding(self, snapshot, finding, explanation) -> None:  # type: ignore[no-untyped-def]
-        self.calls.append({"finding": finding, "snapshot": snapshot})
+    async def async_append_finding(  # type: ignore[no-untyped-def]
+        self, snapshot, finding, explanation, **kwargs: Any
+    ) -> None:
+        self.calls.append(
+            {
+                "finding": finding,
+                "snapshot": snapshot,
+                "suppression_reason_code": kwargs.get("suppression_reason_code"),
+            }
+        )
 
 
 @pytest.mark.asyncio
@@ -118,3 +126,4 @@ async def test_sentinel_end_to_end(monkeypatch: pytest.MonkeyPatch) -> None:
     audit_store = cast("DummyAudit", cast("Any", engine)._audit_store)
     assert notifier.calls
     assert audit_store.calls
+    assert audit_store.calls[0]["suppression_reason_code"] == "not_suppressed"

--- a/tests/custom_components/home_generative_agent/test_suppression.py
+++ b/tests/custom_components/home_generative_agent/test_suppression.py
@@ -9,6 +9,10 @@ from homeassistant.util import dt as dt_util
 
 from custom_components.home_generative_agent.sentinel.models import AnomalyFinding
 from custom_components.home_generative_agent.sentinel.suppression import (
+    SUPPRESSION_REASON_ENTITY_COOLDOWN,
+    SUPPRESSION_REASON_NOT_SUPPRESSED,
+    SUPPRESSION_REASON_PENDING_PROMPT,
+    SUPPRESSION_REASON_TYPE_COOLDOWN,
     SuppressionState,
     register_finding,
     register_prompt,
@@ -36,13 +40,16 @@ def test_cooldown_suppresses() -> None:
     now = dt_util.utcnow()
     register_finding(state, finding, now)
 
-    assert should_suppress(
+    decision = should_suppress(
         state,
         finding,
         now + timedelta(minutes=1),
         cooldown_type=timedelta(minutes=10),
         cooldown_entity=timedelta(minutes=5),
     )
+    assert decision.suppress
+    assert decision.reason_code == SUPPRESSION_REASON_TYPE_COOLDOWN
+    assert decision.context["type"] == finding.type
 
 
 def test_prompt_suppresses_until_resolved() -> None:
@@ -51,19 +58,42 @@ def test_prompt_suppresses_until_resolved() -> None:
     now = dt_util.utcnow()
     register_prompt(state, finding, now)
 
-    assert should_suppress(
+    decision = should_suppress(
         state,
         finding,
         now,
         cooldown_type=timedelta(minutes=0),
         cooldown_entity=timedelta(minutes=0),
     )
+    assert decision.suppress
+    assert decision.reason_code == SUPPRESSION_REASON_PENDING_PROMPT
 
     resolve_prompt(state, finding.anomaly_id)
-    assert not should_suppress(
+    decision = should_suppress(
         state,
         finding,
         now,
         cooldown_type=timedelta(minutes=0),
         cooldown_entity=timedelta(minutes=0),
     )
+    assert not decision.suppress
+    assert decision.reason_code == SUPPRESSION_REASON_NOT_SUPPRESSED
+
+
+def test_entity_cooldown_suppresses() -> None:
+    now = dt_util.utcnow()
+    state = SuppressionState(
+        last_by_entity={"lock.front": {"rule": dt_util.as_utc(now).isoformat()}}
+    )
+    finding = _finding()
+
+    decision = should_suppress(
+        state,
+        finding,
+        now + timedelta(minutes=1),
+        cooldown_type=timedelta(minutes=0),
+        cooldown_entity=timedelta(minutes=5),
+    )
+    assert decision.suppress
+    assert decision.reason_code == SUPPRESSION_REASON_ENTITY_COOLDOWN
+    assert decision.context["entity_id"] == "lock.front"


### PR DESCRIPTION
## Summary
Implements Sentinel plan Issue 1: structured suppression decision model, with no suppression behavior changes.

### What changed
- Refactored `should_suppress()` to return `SuppressionDecision(suppress, reason_code, context)` instead of `bool`.
- Added explicit suppression reason codes:
  - `pending_prompt`
  - `type_cooldown`
  - `entity_cooldown`
  - `not_suppressed`
- Updated `SentinelEngine` call sites to consume `SuppressionDecision`.
- Propagated suppression reason code into audit append calls when supported.
- Added compatibility handling so older audit append signatures still work.
- Extended tests to validate:
  - reason code per suppression path
  - engine propagation of `suppression_reason_code` to audit path

## Why
This establishes a structured suppression contract required by the Sentinel plan, enabling deterministic reason tracking and future audit/reporting expansion, while preserving existing runtime suppression logic.

## Scope and behavior
- No functional suppression logic changes.
- No config changes.
- No user-visible behavior changes expected.
- Internal API contract changed from `bool` to `SuppressionDecision` for suppression call sites.

## Validation
- `make test` passed (`132 passed`)
- `make typecheck` passed (`0 errors`)

Closes #251 