### PR TITLE
Add unknown_person_camera_when_home template support (fix #278)

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ Tip: if your script needs the raw mobile action callback details, read `sentinel
 - `motion_without_camera_activity`
 - `motion_while_alarm_disarmed_and_home_present`
 - `unknown_person_camera_no_home`
+- `unknown_person_camera_when_home`
 
 ### Discovery Novelty and Dedupe
 

--- a/custom_components/home_generative_agent/sentinel/discovery_semantic.py
+++ b/custom_components/home_generative_agent/sentinel/discovery_semantic.py
@@ -155,6 +155,14 @@ def rule_semantic_key(rule: dict[str, Any]) -> str | None:  # noqa: PLR0911, PLR
             "v1|subject=camera|predicate=unknown_person|night=any|home=0|scope=any|"
             f"entities={camera_id}"
         )
+    if template_id == "unknown_person_camera_when_home":
+        camera_id = str(params.get("camera_entity_id", ""))
+        if not camera_id:
+            return None
+        return (
+            "v1|subject=camera|predicate=unknown_person|night=any|home=1|scope=any|"
+            f"entities={camera_id}"
+        )
     if template_id == "motion_without_camera_activity":
         motion_ids = sorted(set(_string_list(params.get("motion_entity_ids"))))
         if not motion_ids:

--- a/custom_components/home_generative_agent/sentinel/dynamic_rules.py
+++ b/custom_components/home_generative_agent/sentinel/dynamic_rules.py
@@ -105,6 +105,11 @@ def evaluate_dynamic_rules(
         "unknown_person_camera_no_home": (
             lambda rule: _eval_unknown_person_camera_no_home(snapshot, rule, camera_map)
         ),
+        "unknown_person_camera_when_home": (
+            lambda rule: _eval_unknown_person_camera_when_home(
+                snapshot, rule, camera_map
+            )
+        ),
         "unavailable_sensors_while_home": (
             lambda rule: _eval_unavailable_sensors_while_home(
                 snapshot, rule, entity_map
@@ -337,6 +342,39 @@ def _eval_unknown_person_camera_no_home(
     camera_map: Mapping[str, CameraActivity],
 ) -> list[AnomalyFinding]:
     if snapshot["derived"]["anyone_home"]:
+        return []
+    params = _rule_params(rule)
+    camera_id = params.get("camera_entity_id")
+    camera = camera_map.get(camera_id) if camera_id else None
+    if not camera or camera_id is None:
+        return []
+    if not camera.get("last_activity"):
+        return []
+    if not camera.get("motion_entities") and not camera.get("vmd_entities"):
+        return []
+    if camera.get("recognized_people"):
+        return []
+    evidence = {
+        "rule_id": rule.get("rule_id"),
+        "template_id": rule.get("template_id"),
+        "camera_entity_id": camera_id,
+        "area": camera.get("area"),
+        "last_activity": camera.get("last_activity"),
+        "recognized_people": camera.get("recognized_people", []),
+        "motion_entities": camera.get("motion_entities", []),
+        "vmd_entities": camera.get("vmd_entities", []),
+        "anyone_home": snapshot["derived"]["anyone_home"],
+        "is_night": snapshot["derived"]["is_night"],
+    }
+    return [_build_finding(rule, [camera_id], evidence)]
+
+
+def _eval_unknown_person_camera_when_home(
+    snapshot: FullStateSnapshot,
+    rule: dict[str, Any],
+    camera_map: Mapping[str, CameraActivity],
+) -> list[AnomalyFinding]:
+    if not snapshot["derived"]["anyone_home"]:
         return []
     params = _rule_params(rule)
     camera_id = params.get("camera_entity_id")

--- a/custom_components/home_generative_agent/sentinel/proposal_templates.py
+++ b/custom_components/home_generative_agent/sentinel/proposal_templates.py
@@ -21,6 +21,7 @@ SUPPORTED_TEMPLATES = {
     "unlocked_lock_when_home",
     "motion_without_camera_activity",
     "unknown_person_camera_no_home",
+    "unknown_person_camera_when_home",
     # Issue #265 — baseline-driven detectors
     "baseline_deviation",
     "time_of_day_anomaly",
@@ -217,6 +218,27 @@ def normalize_candidate(  # noqa: PLR0911, PLR0912
             severity="low",
             confidence=float(candidate.get("confidence_hint", 0.85)),
             is_sensitive=True,
+            suggested_actions=["close_entry"],
+        )
+    if (
+        camera_id
+        and presence == "home"
+        and _contains_any(text, ("unknown", "unrecognized", "stranger"))
+        and _contains_any(text, ("person", "people", "face"))
+    ):
+        default_rule_id = (
+            f"unknown_person_camera_when_home_{camera_id.replace('.', '_')}"
+        )
+        return NormalizedRule(
+            rule_id=_candidate_rule_id(
+                candidate,
+                default=default_rule_id,
+            ),
+            template_id="unknown_person_camera_when_home",
+            params={"camera_entity_id": camera_id},
+            severity="low",
+            confidence=float(candidate.get("confidence_hint", 0.7)),
+            is_sensitive=False,
             suggested_actions=["close_entry"],
         )
 

--- a/tests/custom_components/home_generative_agent/test_discovery_semantic.py
+++ b/tests/custom_components/home_generative_agent/test_discovery_semantic.py
@@ -153,3 +153,16 @@ def test_rule_semantic_key_motion_night_alarm_disarmed_issue_235() -> None:
     assert "subject=motion" in key
     assert "predicate=active" in key
     assert "night=1" in key
+
+
+def test_rule_semantic_key_unknown_person_camera_when_home_issue_278() -> None:
+    rule = {
+        "rule_id": "unknown_person_camera_when_home",
+        "template_id": "unknown_person_camera_when_home",
+        "params": {"camera_entity_id": "camera.backyard"},
+    }
+    key = rule_semantic_key(rule)
+    assert key is not None
+    assert "subject=camera" in key
+    assert "predicate=unknown_person" in key
+    assert "home=1" in key

--- a/tests/custom_components/home_generative_agent/test_dynamic_rules.py
+++ b/tests/custom_components/home_generative_agent/test_dynamic_rules.py
@@ -167,6 +167,88 @@ def test_dynamic_rule_motion_without_camera_activity() -> None:
     assert findings[0].type == "motion_rule_1"
 
 
+def test_dynamic_rule_unknown_person_camera_when_home() -> None:
+    snapshot = _snapshot(
+        [],
+        [
+            {
+                "camera_entity_id": "camera.backyard",
+                "area": "Backyard",
+                "last_activity": "2026-02-01T00:00:00+00:00",
+                "motion_entities": ["binary_sensor.backyard_motion"],
+                "vmd_entities": [],
+                "snapshot_summary": None,
+                "recognized_people": [],
+                "latest_path": None,
+            }
+        ],
+        {
+            "now": "2026-02-01T00:00:00+00:00",
+            "timezone": "UTC",
+            "is_night": False,
+            "anyone_home": True,
+            "people_home": [],
+            "people_away": [],
+            "last_motion_by_area": {},
+        },
+    )
+    rules = [
+        {
+            "rule_id": "unknown_person_camera_when_home",
+            "template_id": "unknown_person_camera_when_home",
+            "params": {"camera_entity_id": "camera.backyard"},
+            "severity": "low",
+            "confidence": 0.7,
+            "is_sensitive": False,
+            "suggested_actions": ["close_entry"],
+        }
+    ]
+    findings = evaluate_dynamic_rules(snapshot, rules)
+    assert len(findings) == 1
+    assert findings[0].type == "unknown_person_camera_when_home"
+    assert findings[0].evidence["anyone_home"] is True
+
+
+def test_dynamic_rule_unknown_person_camera_when_home_no_trigger_when_away() -> None:
+    snapshot = _snapshot(
+        [],
+        [
+            {
+                "camera_entity_id": "camera.backyard",
+                "area": "Backyard",
+                "last_activity": "2026-02-01T00:00:00+00:00",
+                "motion_entities": ["binary_sensor.backyard_motion"],
+                "vmd_entities": [],
+                "snapshot_summary": None,
+                "recognized_people": [],
+                "latest_path": None,
+            }
+        ],
+        {
+            "now": "2026-02-01T00:00:00+00:00",
+            "timezone": "UTC",
+            "is_night": False,
+            "anyone_home": False,
+            "people_home": [],
+            "people_away": [],
+            "last_motion_by_area": {},
+        },
+    )
+    rules = [
+        {
+            "rule_id": "unknown_person_camera_when_home",
+            "template_id": "unknown_person_camera_when_home",
+            "params": {"camera_entity_id": "camera.backyard"},
+            "severity": "low",
+            "confidence": 0.7,
+            "is_sensitive": False,
+            "suggested_actions": ["close_entry"],
+        }
+    ]
+    findings = evaluate_dynamic_rules(snapshot, rules)
+    assert findings == []
+
+
 def test_dynamic_rule_open_entry_at_night_when_home() -> None:
     snapshot = _snapshot(
         [

--- a/tests/custom_components/home_generative_agent/test_proposal_templates.py
+++ b/tests/custom_components/home_generative_agent/test_proposal_templates.py
@@ -283,3 +283,26 @@ def test_normalize_candidate_motion_night_alarm_disarmed_issue_235() -> None:
         ],
         "required_entity_ids": ["person.lindo_st_angel"],
     }
+
+
+def test_normalize_candidate_unknown_person_camera_when_home_issue_278() -> None:
+    candidate = {
+        "candidate_id": "unknown_person_camera_when_home",
+        "title": "Unknown person detected by camera while someone is home",
+        "summary": (
+            "A camera reports an unknown person while a person is present at home."
+        ),
+        "pattern": "recognized_people contains 'Indeterminate' and derived.anyone_home",
+        "suggested_type": "security",
+        "confidence_hint": 0.7,
+        "evidence_paths": [
+            "camera_activity[entity_id=camera.backyard].recognized_people",
+            "derived.anyone_home",
+        ],
+    }
+    normalized = normalize_candidate(candidate)
+    assert normalized is not None
+    assert normalized.template_id == "unknown_person_camera_when_home"
+    assert normalized.rule_id == "unknown_person_camera_when_home"
+    assert normalized.params == {"camera_entity_id": "camera.backyard"}
+    assert normalized.is_sensitive is False


### PR DESCRIPTION
## Summary
- add support for the unknown_person_camera_when_home generated rule template
- wire deterministic evaluation for dynamic rules when someone is home
- add semantic-key mapping, tests, and README template-list update

Closes #278