### PR TITLE
fix: make sentinel auto-exec state reflect real execution

### DIFF
--- a/custom_components/home_generative_agent/sentinel/engine.py
+++ b/custom_components/home_generative_agent/sentinel/engine.py
@@ -556,24 +556,23 @@ class SentinelEngine:
                 RECOMMENDED_SENTINEL_AUTO_EXEC_CANARY_MODE,
             )
         )
-        exec_result = self._execution_service.evaluate(
+        # Use the side-effect-free evaluator here; live execution state is
+        # committed only after the HA service call actually succeeds.
+        exec_result = self._execution_service.evaluate_canary(
             finding, snapshot, effective_autonomy, now
         )
 
         # Canary: record would_auto_execute without acting.
         canary_would_execute: bool | None = None
         if canary_mode:
-            canary_result = self._execution_service.evaluate_canary(
-                finding, snapshot, effective_autonomy, now
-            )
             canary_would_execute = (
-                canary_result.action_policy_path == ACTION_POLICY_AUTO_EXECUTE
+                exec_result.action_policy_path == ACTION_POLICY_AUTO_EXECUTE
             )
             if canary_would_execute:
                 LOGGER.info(
                     "Canary: would auto-execute finding %s (execution_id=%s).",
                     finding.anomaly_id,
-                    canary_result.execution_id,
+                    exec_result.execution_id,
                 )
 
         # Live auto-execute: call HA services when policy approves and canary is off.
@@ -585,6 +584,13 @@ class SentinelEngine:
             action_outcome = await _auto_execute_finding(
                 self._hass, finding, exec_result.execution_id
             )
+            if exec_result.execution_id is not None and action_outcome["status"] in {
+                "success",
+                "partial",
+            }:
+                self._execution_service.commit_auto_execute(
+                    exec_result.execution_id, now
+                )
 
         register_finding(self._suppression.state, finding, now)
         register_prompt(self._suppression.state, finding, now)
@@ -685,17 +691,16 @@ class SentinelEngine:
                 RECOMMENDED_SENTINEL_AUTO_EXEC_CANARY_MODE,
             )
         )
-        exec_result = self._execution_service.evaluate(
+        # Use the side-effect-free evaluator here; live execution state is
+        # committed only after the HA service call actually succeeds.
+        exec_result = self._execution_service.evaluate_canary(
             best, snapshot, effective_autonomy, now
         )
 
         canary_would_execute: bool | None = None
         if canary_mode:
-            canary_result = self._execution_service.evaluate_canary(
-                best, snapshot, effective_autonomy, now
-            )
             canary_would_execute = (
-                canary_result.action_policy_path == ACTION_POLICY_AUTO_EXECUTE
+                exec_result.action_policy_path == ACTION_POLICY_AUTO_EXECUTE
             )
 
         action_outcome: dict[str, Any] | None = None
@@ -706,6 +711,13 @@ class SentinelEngine:
             action_outcome = await _auto_execute_finding(
                 self._hass, best, exec_result.execution_id
             )
+            if exec_result.execution_id is not None and action_outcome["status"] in {
+                "success",
+                "partial",
+            }:
+                self._execution_service.commit_auto_execute(
+                    exec_result.execution_id, now
+                )
 
         explanation = None
         if explain_enabled and self._explainer is not None:
@@ -775,7 +787,7 @@ async def _auto_execute_finding(
                 domain,
                 service,
                 service_data,
-                blocking=False,
+                blocking=True,
             )
             results.append({"service": action, "status": "ok", "error": None})
             LOGGER.info(

--- a/custom_components/home_generative_agent/sentinel/execution.py
+++ b/custom_components/home_generative_agent/sentinel/execution.py
@@ -108,6 +108,22 @@ class SentinelExecutionService:
     # Public API
     # ---------------------------------------------------------------------- #
 
+    def commit_auto_execute(self, execution_id: str, now: datetime) -> None:
+        """
+        Record a successful live auto-execution after the service call completes.
+
+        This is used by the engine's live path so rate-limit and idempotency
+        state reflect actual completed actions rather than optimistic approval.
+        """
+        window_start = now - timedelta(hours=1)
+        self._recent_action_times = [
+            t for t in self._recent_action_times if t > window_start
+        ]
+        self._refresh_idempotency_window()
+        self._recent_action_times.append(now)
+        self._idempotency_seen.add(execution_id)
+        LOGGER.info("Recorded auto-execute completion (execution_id=%s).", execution_id)
+
     def evaluate(  # noqa: PLR0911
         self,
         finding: AnomalyFinding,

--- a/tests/custom_components/home_generative_agent/test_execution_service.py
+++ b/tests/custom_components/home_generative_agent/test_execution_service.py
@@ -526,3 +526,57 @@ def test_canary_rate_limit_is_read_only() -> None:
     assert result.block_reason == "rate_limit_exceeded"
     # Still the same count — canary didn't add another slot.
     assert len(svc._recent_action_times) == max_actions
+
+
+def test_commit_auto_execute_records_state_after_pure_evaluation() -> None:
+    """Pure evaluation stays read-only until commit_auto_execute() is called."""
+    recent = "2025-01-01T00:59:50+00:00"
+    snapshot = _make_snapshot(last_changed=recent)
+    svc = SentinelExecutionService(
+        {
+            **_FULL_OPTIONS,
+            CONF_SENTINEL_AUTO_EXECUTE_ALLOWED_SERVICES: [],
+        }
+    )
+    finding = _make_finding(
+        anomaly_id="commit_me",
+        confidence=0.95,
+        suggested_actions=[],
+    )
+
+    result = svc.evaluate_canary(finding, snapshot, 2, _NOW)
+
+    assert result.action_policy_path == ACTION_POLICY_AUTO_EXECUTE
+    assert result.execution_id is not None
+    assert not svc._recent_action_times
+    assert not svc._idempotency_seen
+
+    svc.commit_auto_execute(cast("str", result.execution_id), _NOW)
+
+    assert len(svc._recent_action_times) == 1
+    assert result.execution_id in svc._idempotency_seen
+
+
+def test_commit_auto_execute_enables_future_duplicate_block() -> None:
+    """Once committed, the same decision is blocked by idempotency."""
+    recent = "2025-01-01T00:59:50+00:00"
+    snapshot = _make_snapshot(last_changed=recent)
+    svc = SentinelExecutionService(
+        {
+            **_FULL_OPTIONS,
+            CONF_SENTINEL_AUTO_EXECUTE_ALLOWED_SERVICES: [],
+        }
+    )
+    finding = _make_finding(
+        anomaly_id="dup_after_commit",
+        confidence=0.95,
+        suggested_actions=[],
+    )
+
+    first = svc.evaluate_canary(finding, snapshot, 2, _NOW)
+    svc.commit_auto_execute(cast("str", first.execution_id), _NOW)
+    second = svc.evaluate_canary(finding, snapshot, 2, _NOW)
+
+    assert first.action_policy_path == ACTION_POLICY_AUTO_EXECUTE
+    assert second.action_policy_path == ACTION_POLICY_PROMPT_USER
+    assert second.block_reason == "idempotency_duplicate"

--- a/tests/custom_components/home_generative_agent/test_sentinel_auto_execute.py
+++ b/tests/custom_components/home_generative_agent/test_sentinel_auto_execute.py
@@ -97,7 +97,7 @@ async def test_auto_execute_domain_service_calls_ha() -> None:
         "lock",
         "lock",
         {"entity_id": "lock.front_door"},
-        blocking=False,
+        blocking=True,
     )
 
 
@@ -117,7 +117,7 @@ async def test_auto_execute_multiple_triggering_entities_passed_as_list() -> Non
         "lock",
         "lock",
         {"entity_id": ["lock.front_door", "lock.back_door"]},
-        blocking=False,
+        blocking=True,
     )
 
 
@@ -193,5 +193,5 @@ async def test_auto_execute_no_triggering_entities_omits_entity_id() -> None:
         "lock",
         "lock",
         {},
-        blocking=False,
+        blocking=True,
     )

--- a/tests/custom_components/home_generative_agent/test_sentinel_end_to_end.py
+++ b/tests/custom_components/home_generative_agent/test_sentinel_end_to_end.py
@@ -227,6 +227,35 @@ async def test_sentinel_canary_mode_records_would_execute(
     assert any(v is not None for v in canary_values)
 
 
+@pytest.mark.asyncio
+async def test_sentinel_canary_mode_does_not_consume_live_auto_execute(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A canary-only pass must not burn the later live auto-execute slot."""
+    engine, hass = _make_ae_engine(monkeypatch)
+    engine._options[CONF_SENTINEL_AUTO_EXEC_CANARY_MODE] = True
+
+    await engine._run_once()
+
+    hass.services.async_call.assert_not_called()
+    audit = cast("DummyAudit", cast("Any", engine)._audit_store)
+    assert audit.calls
+    assert audit.calls[0]["canary_would_execute"] is True
+    assert audit.calls[0]["action_policy_path"] == "auto_execute"
+
+    engine._options[CONF_SENTINEL_AUTO_EXEC_CANARY_MODE] = False
+    await engine._run_once()
+
+    hass.services.async_call.assert_called_once_with(
+        "lock",
+        "lock",
+        {"entity_id": "lock.front_door"},
+        blocking=True,
+    )
+    assert len(audit.calls) >= 2
+    assert audit.calls[-1]["action_policy_path"] == "auto_execute"
+
+
 # ---------------------------------------------------------------------------
 # Issue #264 — Level 2 live auto-execute integration tests
 # ---------------------------------------------------------------------------
@@ -290,6 +319,7 @@ def _make_ae_engine(
     *,
     autonomy_level: int = 2,
     max_actions_per_hour: int = 5,
+    service_side_effect: Any = None,
 ) -> tuple[SentinelEngine, MagicMock]:
     """
     Build a live-auto-execute engine backed by a MagicMock hass.
@@ -302,7 +332,10 @@ def _make_ae_engine(
     reach the execution-policy layer without being short-circuited by suppression.
     """
     hass = MagicMock()
-    hass.services.async_call = AsyncMock(return_value=None)
+    if service_side_effect is None:
+        hass.services.async_call = AsyncMock(return_value=None)
+    else:
+        hass.services.async_call = AsyncMock(side_effect=service_side_effect)
 
     # Freeze time so snapshot entities are always fresh and guardrails are deterministic.
     monkeypatch.setattr(
@@ -358,7 +391,7 @@ async def test_live_auto_execute_calls_ha_service(
         "lock",
         "lock",
         {"entity_id": "lock.front_door"},
-        blocking=False,
+        blocking=True,
     )
 
 
@@ -425,3 +458,47 @@ async def test_live_auto_execute_rate_limit_blocks(
     paths = [c["action_policy_path"] for c in audit.calls]
     assert "auto_execute" in paths
     assert "prompt_user" in paths
+
+
+@pytest.mark.asyncio
+async def test_live_auto_execute_failure_does_not_consume_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed service call must not burn idempotency or the rate-limit slot."""
+    first_call = True
+
+    async def _service_side_effect(*_args: Any, **_kwargs: Any) -> None:
+        nonlocal first_call
+        if first_call:
+            first_call = False
+            msg = "temporary HA failure"
+            raise RuntimeError(msg)
+
+    engine, hass = _make_ae_engine(
+        monkeypatch,
+        service_side_effect=_service_side_effect,
+    )
+
+    await engine._run_once()
+    await engine._run_once()
+
+    assert hass.services.async_call.call_count == 2
+    audit = cast("DummyAudit", cast("Any", engine)._audit_store)
+    first_outcome = cast("dict[str, Any]", audit.calls[0]["action_outcome"])
+    second_outcome = cast("dict[str, Any]", audit.calls[1]["action_outcome"])
+    assert first_outcome == {
+        "status": "error",
+        "actions": [
+            {
+                "service": "lock.lock",
+                "status": "error",
+                "error": "temporary HA failure",
+            }
+        ],
+        "execution_id": first_outcome["execution_id"],
+    }
+    assert second_outcome == {
+        "status": "success",
+        "actions": [{"service": "lock.lock", "status": "ok", "error": None}],
+        "execution_id": second_outcome["execution_id"],
+    }


### PR DESCRIPTION
## Summary
- make sentinel canary evaluation side-effect free in the engine path
- commit auto-execution idempotency and rate-limit state only after real service completion
- add regression coverage for canary/live sequencing, retry-after-failure, and blocking service calls

## Verification
- make all
