### PR TITLE
feat(sentinel): DOW baselines + learned suppressions count (v3.9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.9.0] - 2026-04-06
+
+### Added
+
+- **Day-of-week (DOW) baselines** — Sentinel's time-of-day anomaly detector now
+  supports per-(DOW, hour) baselines in addition to the existing global hourly
+  averages. Enable via `sentinel_baseline_weekly_patterns` in the Sentinel subentry.
+  Uses Welford's online algorithm for exact running mean + variance per slot without
+  storing all past values. Detection uses a weighted blend that transitions smoothly
+  from global to DOW baselines as data accumulates (`w = min(count / dow_min_samples,
+  1.0)`), so there is no hard cliff when switching. Entity-specific stddev thresholds
+  prevent washer/dryer power sensors from triggering on the same absolute deviation
+  that would flag a door sensor. DOW buckets use local time so weekend/weekday
+  schedules align with the user's actual timezone.
+
+- **DOW min-samples config** — New `sentinel_baseline_dow_min_samples` option
+  (default 4 weeks) controls how many observations per DOW-hour slot are required
+  before the blend weight reaches 1.0. Configurable via a NumberSelector in the
+  Sentinel subentry UI. Intentionally lower than the global `sentinel_baseline_min_samples`
+  (20) because DOW slots update at most once per week per entity.
+
+- **`learned_suppressions_active` health sensor attribute** — Exposes the count of
+  distinct `{rule_type}:{entity_id}` pairs that have accumulated learned cooldown
+  multipliers via snooze/dismiss feedback. Makes the feedback-learning loop
+  observable in the health dashboard.
+
+- **DB performance index** — `CREATE INDEX IF NOT EXISTS idx_sentinel_baselines_entity_metric`
+  added to `async_initialize()` for fast per-entity/metric lookups. Idempotent;
+  safe on existing installations.
+
 ## [3.8.0] - 2026-04-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ When `sentinel_baseline_enabled` is `true` **and** `sentinel_enabled` is `true`,
 On each detection cycle the engine calls `async_fetch_baselines()` to read current baseline values from PostgreSQL and passes them to the dynamic-rule evaluators. Two temporal templates are always registered:
 
 - `baseline_deviation` — fires when a numeric entity state deviates from its rolling average by more than `threshold_pct` percent (default `50.0`).
-- `time_of_day_anomaly` — fires when a numeric entity state differs from the expected hour-of-day rolling average by more than `threshold_pct` percent (default `50.0`).
+- `time_of_day_anomaly` — fires when a numeric entity state differs from the expected hour-of-day rolling average by more than `threshold_pct` percent (default `50.0`). When day-of-week baselines are enabled (`sentinel_baseline_weekly_patterns`), this template uses a weighted blend of the DOW-hour mean and the global hourly mean, transitioning smoothly from global to DOW baselines as data accumulates per slot.
 
 `threshold_pct`, `entity_id`, and `metric` are per-rule `params` stored in the rule registry — they are set when a rule is created via discovery or the `hga_sentinel_add_rule` service, not in the subentry. Both templates produce no findings while the table is empty (baselines accumulate over time).
 
@@ -271,9 +271,11 @@ Configuration options (in the Sentinel subentry):
 - `sentinel_baseline_enabled` — enable baseline collection (default: `false`); has no effect unless `sentinel_enabled` is also `true`
 - `sentinel_baseline_update_interval_minutes` — how often baselines are recalculated (default: `15`)
 - `sentinel_baseline_freshness_threshold_seconds` — age after which a baseline is considered stale (default: `3600`)
-- `sentinel_baseline_min_samples` — minimum number of samples before a baseline is considered usable (default: `10`)
-- `sentinel_baseline_max_samples` — rolling window size; older samples are discarded when this is reached (default: `288`)
-- `sentinel_baseline_drift_threshold_pct` — default percent deviation that triggers a `baseline_deviation` or `time_of_day_anomaly` finding (default: `50.0`)
+- `sentinel_baseline_min_samples` — minimum number of samples before a global baseline is usable (default: `20`)
+- `sentinel_baseline_max_samples` — rolling window size; older samples are discarded when this is reached (default: `500`)
+- `sentinel_baseline_drift_threshold_pct` — default percent deviation that triggers a `baseline_deviation` or `time_of_day_anomaly` finding (default: `30.0`)
+- `sentinel_baseline_weekly_patterns` — enable per-(day-of-week, hour) baselines for `time_of_day_anomaly` (default: `false`); requires `sentinel_baseline_enabled`
+- `sentinel_baseline_dow_min_samples` — observations per DOW-hour slot before blend weight reaches 1.0 (default: `4` weeks); separate from the global `sentinel_baseline_min_samples` because DOW slots update at most once per week
 
 ### Sentinel Action Flows
 
@@ -595,6 +597,7 @@ Attributes:
 | `baseline_stale_count` | Number of entities whose baseline exists but is older than the freshness threshold |
 | `baseline_rules_waiting` | Number of active baseline rules whose entity has not yet reached `sentinel_baseline_min_samples` |
 | `baseline_last_update` | UTC ISO 8601 timestamp of the most recent baseline write (null if no baselines yet) |
+| `learned_suppressions_active` | Number of distinct `{rule_type}:{entity_id}` pairs with learned cooldown multipliers (from dismiss/snooze feedback) |
 
 Example Lovelace Markdown card:
 

--- a/custom_components/home_generative_agent/const.py
+++ b/custom_components/home_generative_agent/const.py
@@ -226,6 +226,13 @@ RECOMMENDED_SENTINEL_BASELINE_FRESHNESS_THRESHOLD_SECONDS: int = 3600
 RECOMMENDED_SENTINEL_BASELINE_MIN_SAMPLES: int = 20
 RECOMMENDED_SENTINEL_BASELINE_MAX_SAMPLES: int = 500
 RECOMMENDED_SENTINEL_BASELINE_DRIFT_THRESHOLD_PCT: float = 30.0
+# DOW (day-of-week) baseline extensions — Sprint 3 PR2
+CONF_SENTINEL_BASELINE_WEEKLY_PATTERNS = "sentinel_baseline_weekly_patterns"
+CONF_SENTINEL_BASELINE_DOW_MIN_SAMPLES = "sentinel_baseline_dow_min_samples"
+RECOMMENDED_SENTINEL_BASELINE_WEEKLY_PATTERNS: bool = False
+# DOW slots update once/week; 4 weeks separates weekend/weekday patterns.
+# Lower than RECOMMENDED_SENTINEL_BASELINE_MIN_SAMPLES (20) for global EMA.
+RECOMMENDED_SENTINEL_BASELINE_DOW_MIN_SAMPLES: int = 4
 
 # ---- Sentinel daily digest notification ----
 CONF_SENTINEL_DAILY_DIGEST_ENABLED = "sentinel_daily_digest_enabled"

--- a/custom_components/home_generative_agent/core/sentinel_health_sensor.py
+++ b/custom_components/home_generative_agent/core/sentinel_health_sensor.py
@@ -287,6 +287,13 @@ class SentinelHealthSensor(SensorEntity):
         # Baseline health statistics.
         await self._refresh_baseline_attrs()
 
+        # Learned suppression feedback count (from suppression state).
+        self._attrs["learned_suppressions_active"] = (
+            self._sentinel.learned_suppressions_count
+            if self._sentinel is not None
+            else None
+        )
+
         self._attr_native_value = "ok"
         self.async_write_ha_state()
 

--- a/custom_components/home_generative_agent/flows/sentinel_subentry_flow.py
+++ b/custom_components/home_generative_agent/flows/sentinel_subentry_flow.py
@@ -31,9 +31,11 @@ from ..const import (  # noqa: TID252
     CONF_CRITICAL_ACTION_PIN,
     CONF_EXPLAIN_ENABLED,
     CONF_NOTIFY_SERVICE,
+    CONF_SENTINEL_BASELINE_DOW_MIN_SAMPLES,
     CONF_SENTINEL_BASELINE_ENABLED,
     CONF_SENTINEL_BASELINE_FRESHNESS_THRESHOLD_SECONDS,
     CONF_SENTINEL_BASELINE_UPDATE_INTERVAL_MINUTES,
+    CONF_SENTINEL_BASELINE_WEEKLY_PATTERNS,
     CONF_SENTINEL_CAMERA_ENTRY_LINKS,
     CONF_SENTINEL_COOLDOWN_MINUTES,
     CONF_SENTINEL_DAILY_DIGEST_ENABLED,
@@ -51,9 +53,11 @@ from ..const import (  # noqa: TID252
     CRITICAL_PIN_MAX_LEN,
     CRITICAL_PIN_MIN_LEN,
     RECOMMENDED_EXPLAIN_ENABLED,
+    RECOMMENDED_SENTINEL_BASELINE_DOW_MIN_SAMPLES,
     RECOMMENDED_SENTINEL_BASELINE_ENABLED,
     RECOMMENDED_SENTINEL_BASELINE_FRESHNESS_THRESHOLD_SECONDS,
     RECOMMENDED_SENTINEL_BASELINE_UPDATE_INTERVAL_MINUTES,
+    RECOMMENDED_SENTINEL_BASELINE_WEEKLY_PATTERNS,
     RECOMMENDED_SENTINEL_CAMERA_ENTRY_LINKS,
     RECOMMENDED_SENTINEL_COOLDOWN_MINUTES,
     RECOMMENDED_SENTINEL_DAILY_DIGEST_ENABLED,
@@ -242,6 +246,24 @@ class SentinelSubentryFlow(ConfigSubentryFlow):
                     )
                 ),
             ): NumberSelector(NumberSelectorConfig(min=60, max=86400, step=60)),
+            vol.Required(
+                CONF_SENTINEL_BASELINE_WEEKLY_PATTERNS,
+                default=bool(
+                    payload.get(
+                        CONF_SENTINEL_BASELINE_WEEKLY_PATTERNS,
+                        RECOMMENDED_SENTINEL_BASELINE_WEEKLY_PATTERNS,
+                    )
+                ),
+            ): BooleanSelector(),
+            vol.Required(
+                CONF_SENTINEL_BASELINE_DOW_MIN_SAMPLES,
+                default=int(
+                    payload.get(
+                        CONF_SENTINEL_BASELINE_DOW_MIN_SAMPLES,
+                        RECOMMENDED_SENTINEL_BASELINE_DOW_MIN_SAMPLES,
+                    )
+                ),
+            ): NumberSelector(NumberSelectorConfig(min=1, max=52, step=1)),
             vol.Required(
                 CONF_EXPLAIN_ENABLED,
                 default=bool(

--- a/custom_components/home_generative_agent/manifest.json
+++ b/custom_components/home_generative_agent/manifest.json
@@ -33,5 +33,5 @@
     "transformers==4.57.1",
     "langchain-google-genai==3.1.0"
   ],
-  "version": "3.8.0"
+  "version": "3.9.0"
 }

--- a/custom_components/home_generative_agent/sentinel/baseline.py
+++ b/custom_components/home_generative_agent/sentinel/baseline.py
@@ -261,16 +261,8 @@ ON CONFLICT (entity_id, metric, period) DO UPDATE SET
 
 # Fetch all DOW rows (both mean and stddev) — no min-samples filter because
 # the blend weight formula handles sparse slots gracefully (w → 0 as count → 0).
+# Also used for warm-restart reconstruction of Welford state on HA restart.
 _FETCH_DOW_SQL = """
-SELECT entity_id, metric, value, sample_count
-FROM sentinel_baselines
-WHERE period = 'dow'
-"""
-
-# Warm-restart query: fetch existing DOW mean + stddev rows on startup so
-# Welford's _dow_state (mean, m2, count) can be reconstructed without full
-# retraining.
-_FETCH_DOW_WARMUP_SQL = """
 SELECT entity_id, metric, value, sample_count
 FROM sentinel_baselines
 WHERE period = 'dow'
@@ -350,7 +342,7 @@ class SentinelBaselineUpdater:
                         self._established.add(str(eid))
                 # Warm-restart Welford _dow_state from existing DB rows so that
                 # historical variance is preserved across HA restarts.
-                await cur.execute(_FETCH_DOW_WARMUP_SQL)
+                await cur.execute(_FETCH_DOW_SQL)
                 dow_rows = await cur.fetchall()
                 mean_rows: dict[str, dict[str, tuple[float, int]]] = {}
                 std_rows: dict[str, dict[str, float]] = {}
@@ -369,9 +361,7 @@ class SentinelBaselineUpdater:
                         )
                     if not eid or not metric or val is None:
                         continue
-                    if metric.startswith(
-                        METRIC_DOW_STD_PREFIX
-                    ) and not metric.startswith(METRIC_DOW_AVG_PREFIX):
+                    if metric.startswith(METRIC_DOW_STD_PREFIX):
                         std_rows.setdefault(eid, {})[metric] = float(val)
                     elif metric.startswith(METRIC_DOW_AVG_PREFIX):
                         # hourly_avg_{dow}_{hour} rows have two numeric suffixes
@@ -1260,16 +1250,22 @@ def evaluate_time_of_day_anomaly(  # noqa: PLR0913
         now_dt = datetime.fromisoformat(now_str)
         if now_dt.tzinfo is None:
             now_dt = now_dt.replace(tzinfo=UTC)
+        # snapshot["derived"]["now"] is always UTC (see snapshot/derived.py).
+        # Global hourly baselines are also written in UTC, so hour_str stays UTC.
         hour_str = str(now_dt.hour)
-        dow = now_dt.weekday()  # 0=Monday, 6=Sunday
+        # DOW baselines are written in local time (dt_util.now() in
+        # _update_baselines), so DOW key lookups must also use local time.
+        local_dt = dt_util.as_local(now_dt)
+        dow = local_dt.weekday()  # 0=Monday, 6=Sunday, local time
+        local_hour = local_dt.hour
     except (TypeError, ValueError):
         return []
 
     # --- DOW-blended path ---
     if dow_data is not None:
         entity_dow = dow_data.get(entity_id, {})
-        dow_mean_key = f"{METRIC_DOW_AVG_PREFIX}{dow}_{now_dt.hour}"
-        dow_std_key = f"{METRIC_DOW_STD_PREFIX}{dow}_{now_dt.hour}"
+        dow_mean_key = f"{METRIC_DOW_AVG_PREFIX}{dow}_{local_hour}"
+        dow_std_key = f"{METRIC_DOW_STD_PREFIX}{dow}_{local_hour}"
 
         dow_mean_entry = entity_dow.get(dow_mean_key)
         dow_std_entry = entity_dow.get(dow_std_key)
@@ -1282,7 +1278,7 @@ def evaluate_time_of_day_anomaly(  # noqa: PLR0913
                 entity_id=entity_id,
                 hour_str=hour_str,
                 dow=dow,
-                local_hour=now_dt.hour,
+                local_hour=local_hour,
                 dow_mean=dow_mean_entry[0],
                 dow_count=dow_mean_entry[1],
                 dow_std=dow_std_entry[0] if dow_std_entry is not None else None,

--- a/custom_components/home_generative_agent/sentinel/baseline.py
+++ b/custom_components/home_generative_agent/sentinel/baseline.py
@@ -40,11 +40,14 @@ from custom_components.home_generative_agent.const import (
     CONF_SENTINEL_BASELINE_MAX_SAMPLES,
     CONF_SENTINEL_BASELINE_MIN_SAMPLES,
     CONF_SENTINEL_BASELINE_UPDATE_INTERVAL_MINUTES,
+    CONF_SENTINEL_BASELINE_WEEKLY_PATTERNS,
+    RECOMMENDED_SENTINEL_BASELINE_DOW_MIN_SAMPLES,
     RECOMMENDED_SENTINEL_BASELINE_DRIFT_THRESHOLD_PCT,
     RECOMMENDED_SENTINEL_BASELINE_FRESHNESS_THRESHOLD_SECONDS,
     RECOMMENDED_SENTINEL_BASELINE_MAX_SAMPLES,
     RECOMMENDED_SENTINEL_BASELINE_MIN_SAMPLES,
     RECOMMENDED_SENTINEL_BASELINE_UPDATE_INTERVAL_MINUTES,
+    RECOMMENDED_SENTINEL_BASELINE_WEEKLY_PATTERNS,
 )
 
 from .models import AnomalyFinding, Severity, build_anomaly_id
@@ -108,8 +111,19 @@ BASELINE_UNAVAILABLE = "unavailable"
 
 # Rolling metric name written for the global time-window average.
 METRIC_ROLLING_AVG = "rolling_avg"
-# Rolling metric name keyed by hour-of-day (e.g. "hourly_avg_14").
+# Global hourly metric keyed by hour-of-day (e.g. "hourly_avg_14").
 METRIC_HOURLY_PREFIX = "hourly_avg_"
+# DOW (day-of-week) metric prefixes — per (DOW, hour) slot.
+# Examples: "hourly_avg_5_14" = Friday 14:00 mean, "hourly_stddev_5_14" = stddev.
+# DOW follows Python weekday(): 0=Monday, 6=Sunday.
+# DST note: buckets use local time via dt_util.now(). The ambiguous fall-back
+# hour during DST transitions double-counts one slot once per year — acceptable;
+# do not "fix" by converting to UTC (would break weekly pattern separation).
+METRIC_DOW_AVG_PREFIX = "hourly_avg_"  # same prefix, but with two numeric suffixes
+METRIC_DOW_STD_PREFIX = "hourly_stddev_"
+# Number of numeric parts in a DOW metric name (e.g. "5_14" = DOW 5, hour 14).
+# Global hourly metrics have one part ("14"); DOW metrics have two ("5_14").
+_DOW_METRIC_PARTS = 2
 
 # DDL for the baseline table.
 _CREATE_TABLE_SQL = """
@@ -224,6 +238,44 @@ _DELETE_ALL_SQL = """
 DELETE FROM sentinel_baselines
 """
 
+# DOW index for fast per-(entity, metric) lookups added in async_initialize().
+_CREATE_DOW_INDEX_SQL = """
+CREATE INDEX IF NOT EXISTS idx_sentinel_baselines_entity_metric
+ON sentinel_baselines (entity_id, metric)
+"""
+
+# Direct upsert for DOW slots — bypasses EMA because DOW slots are sparse
+# (each updated at most once per week per entity).  EMA on sparse slots
+# produces interpolation artefacts; Welford's algorithm gives exact running
+# mean + variance without requiring continuous data.
+_DOW_UPSERT_SQL = """
+INSERT INTO sentinel_baselines
+    (entity_id, metric, period, value, sample_count, updated_at)
+VALUES
+    (%s, %s, 'dow', %s, %s, %s)
+ON CONFLICT (entity_id, metric, period) DO UPDATE SET
+    value        = EXCLUDED.value,
+    sample_count = EXCLUDED.sample_count,
+    updated_at   = EXCLUDED.updated_at
+"""
+
+# Fetch all DOW rows (both mean and stddev) — no min-samples filter because
+# the blend weight formula handles sparse slots gracefully (w → 0 as count → 0).
+_FETCH_DOW_SQL = """
+SELECT entity_id, metric, value, sample_count
+FROM sentinel_baselines
+WHERE period = 'dow'
+"""
+
+# Warm-restart query: fetch existing DOW mean + stddev rows on startup so
+# Welford's _dow_state (mean, m2, count) can be reconstructed without full
+# retraining.
+_FETCH_DOW_WARMUP_SQL = """
+SELECT entity_id, metric, value, sample_count
+FROM sentinel_baselines
+WHERE period = 'dow'
+"""
+
 # Aggregate stats query for health sensor — avoids full table scan.
 # Params: (metric, freshness_threshold_seconds, min_samples).
 _FETCH_STATS_SQL = """
@@ -262,12 +314,17 @@ class SentinelBaselineUpdater:
         self._stop_event = asyncio.Event()
         # entity_ids that crossed MIN_SAMPLES (no re-notification on restart).
         self._established: set[str] = set()
+        # In-memory Welford state for DOW slots: key = "entity_id:dow:hour",
+        # value = (mean, m2, count).  m2 is the sum of squared deviations
+        # (Welford's accumulator for variance).  Populated on async_initialize()
+        # from DB values and updated on every _update_baselines() call.
+        self._dow_state: dict[str, tuple[float, float, int]] = {}
 
     # ---------------------------------------------------------------------- #
     # Lifecycle
     # ---------------------------------------------------------------------- #
 
-    async def async_initialize(self) -> None:
+    async def async_initialize(self) -> None:  # noqa: PLR0912
         """Create/migrate the ``sentinel_baselines`` table and seed state."""
         try:
             async with self._pool.connection() as conn, conn.cursor() as cur:
@@ -275,6 +332,8 @@ class SentinelBaselineUpdater:
                 # Idempotent migrations for columns added after initial release.
                 await cur.execute(_MIGRATE_REFERENCE_VALUE_SQL)
                 await cur.execute(_MIGRATE_REFERENCE_AT_SQL)
+                # DOW index — fast per-(entity, metric) lookups.
+                await cur.execute(_CREATE_DOW_INDEX_SQL)
                 await conn.commit()
                 # Seed the established set so restarts don't re-fire notifications.
                 min_samples = _coerce_int(
@@ -289,9 +348,58 @@ class SentinelBaselineUpdater:
                     eid = row.get("entity_id") if isinstance(row, dict) else row[0]
                     if eid:
                         self._established.add(str(eid))
+                # Warm-restart Welford _dow_state from existing DB rows so that
+                # historical variance is preserved across HA restarts.
+                await cur.execute(_FETCH_DOW_WARMUP_SQL)
+                dow_rows = await cur.fetchall()
+                mean_rows: dict[str, dict[str, tuple[float, int]]] = {}
+                std_rows: dict[str, dict[str, float]] = {}
+                for row in dow_rows:
+                    if isinstance(row, dict):
+                        eid = str(row.get("entity_id", "") or "")
+                        metric = str(row.get("metric", "") or "")
+                        val = row.get("value")
+                        cnt = row.get("sample_count", 0)
+                    else:
+                        eid, metric, val, cnt = (
+                            str(row[0] or ""),
+                            str(row[1] or ""),
+                            row[2],
+                            row[3],
+                        )
+                    if not eid or not metric or val is None:
+                        continue
+                    if metric.startswith(
+                        METRIC_DOW_STD_PREFIX
+                    ) and not metric.startswith(METRIC_DOW_AVG_PREFIX):
+                        std_rows.setdefault(eid, {})[metric] = float(val)
+                    elif metric.startswith(METRIC_DOW_AVG_PREFIX):
+                        # hourly_avg_{dow}_{hour} rows have two numeric suffixes
+                        parts = metric[len(METRIC_DOW_AVG_PREFIX) :].split("_")
+                        if (
+                            len(parts) == _DOW_METRIC_PARTS
+                        ):  # DOW (not global hourly_avg_{H})
+                            mean_rows.setdefault(eid, {})[metric] = (
+                                float(val),
+                                int(cnt or 0),
+                            )
+                # Reconstruct _dow_state: key = "entity_id:dow:hour"
+                for eid, metrics in mean_rows.items():
+                    for metric, (mean_val, count) in metrics.items():
+                        parts = metric[len(METRIC_DOW_AVG_PREFIX) :].split("_")
+                        if len(parts) != _DOW_METRIC_PARTS:
+                            continue
+                        dow_str, hour_str = parts
+                        std_metric = f"{METRIC_DOW_STD_PREFIX}{dow_str}_{hour_str}"
+                        stddev = (std_rows.get(eid) or {}).get(std_metric, 0.0)
+                        m2 = stddev**2 * max(count - 1, 0)
+                        key = f"{eid}:{dow_str}:{hour_str}"
+                        self._dow_state[key] = (mean_val, m2, count)
             LOGGER.debug(
-                "sentinel_baselines table ready; %d baselines already established.",
+                "sentinel_baselines table ready; %d baselines established; "
+                "%d DOW slots warmed.",
                 len(self._established),
+                len(self._dow_state),
             )
         except Exception:
             LOGGER.exception(
@@ -357,6 +465,10 @@ class SentinelBaselineUpdater:
     async def _update_baselines(self, snapshot: FullStateSnapshot) -> None:  # noqa: PLR0912, PLR0915
         """Upsert rolling stats for all numeric entities in *snapshot*."""
         now = dt_util.utcnow()
+        # Use local time for DOW bucket assignment so that weekday patterns align with
+        # the user's actual schedule.  UTC-based bucketing would produce cross-timezone
+        # artefacts (e.g. Saturday night classified as Sunday morning).
+        local_now = dt_util.now()
         hour_str = str(now.hour)
 
         min_samples = _coerce_int(
@@ -373,6 +485,12 @@ class SentinelBaselineUpdater:
         drift_threshold_pct = _coerce_float(
             self._options.get(CONF_SENTINEL_BASELINE_DRIFT_THRESHOLD_PCT),
             default=RECOMMENDED_SENTINEL_BASELINE_DRIFT_THRESHOLD_PCT,
+        )
+        weekly_patterns = bool(
+            self._options.get(
+                CONF_SENTINEL_BASELINE_WEEKLY_PATTERNS,
+                RECOMMENDED_SENTINEL_BASELINE_WEEKLY_PATTERNS,
+            )
         )
 
         # Collect numeric entities and their current values.
@@ -477,6 +595,27 @@ class SentinelBaselineUpdater:
                     )
                     # Discard hourly RETURNING row (not used for establishment).
                     await cur.fetchone()
+
+                    # --- DOW (day-of-week) Welford upsert (when enabled) ---
+                    if weekly_patterns:
+                        dow = local_now.weekday()  # 0=Monday, 6=Sunday
+                        local_hour = local_now.hour
+                        dow_mean, dow_stddev = self._update_dow_welford(
+                            entity_id, dow, local_hour, value
+                        )
+                        dow_mean_metric = f"{METRIC_DOW_AVG_PREFIX}{dow}_{local_hour}"
+                        dow_std_metric = f"{METRIC_DOW_STD_PREFIX}{dow}_{local_hour}"
+                        _, _, dow_count = self._dow_state[
+                            f"{entity_id}:{dow}:{local_hour}"
+                        ]
+                        await cur.execute(
+                            _DOW_UPSERT_SQL,
+                            (entity_id, dow_mean_metric, dow_mean, dow_count, now),
+                        )
+                        await cur.execute(
+                            _DOW_UPSERT_SQL,
+                            (entity_id, dow_std_metric, dow_stddev, dow_count, now),
+                        )
 
                 await conn.commit()
 
@@ -584,6 +723,81 @@ class SentinelBaselineUpdater:
             )
         except Exception:  # noqa: BLE001
             LOGGER.debug("Could not fire drift notification for %s.", entity_id)
+
+    # ---------------------------------------------------------------------- #
+    # DOW Welford helpers
+    # ---------------------------------------------------------------------- #
+
+    def _update_dow_welford(
+        self,
+        entity_id: str,
+        dow: int,
+        hour: int,
+        new_value: float,
+    ) -> tuple[float, float]:
+        """
+        Update Welford's online mean/variance for the given (entity, DOW, hour) slot.
+
+        Returns ``(mean, stddev)`` after incorporating *new_value*.
+
+        Welford's algorithm accumulates mean and M2 (sum of squared deviations)
+        without storing all past values.  This is correct for sparse slots that
+        update at most once per week; EMA would produce interpolation artefacts.
+
+        The in-memory state ``_dow_state`` is the only source of M2; DB stores
+        only mean, stddev, and count.  On restart, M2 is reconstructed from
+        ``stddev**2 * (count - 1)`` in ``async_initialize()``.
+        """
+        key = f"{entity_id}:{dow}:{hour}"
+        mean, m2, count = self._dow_state.get(key, (0.0, 0.0, 0))
+        count += 1
+        delta = new_value - mean
+        mean = mean + delta / count
+        delta2 = new_value - mean
+        m2 = m2 + delta * delta2
+        stddev = (m2 / (count - 1)) ** 0.5 if count > 1 else 0.0
+        self._dow_state[key] = (mean, m2, count)
+        return mean, stddev
+
+    async def async_fetch_dow_data(
+        self,
+    ) -> dict[str, dict[str, tuple[float, int]]]:
+        """
+        Return DOW mean/stddev values and sample counts for all entities.
+
+        Returns ``{entity_id: {metric_key: (value, count)}}``.
+        No min-samples filter — the blend-weight formula handles sparse slots
+        (``w = min(count / dow_min_samples, 1.0)``; w=0 ⟹ pure global mean).
+        Returns an empty dict on any DB error.
+        """
+        try:
+            async with self._pool.connection() as conn, conn.cursor() as cur:
+                await cur.execute(_FETCH_DOW_SQL)
+                rows = await cur.fetchall()
+        except Exception:  # noqa: BLE001
+            LOGGER.debug("DOW baseline fetch failed; returning empty dict.")
+            return {}
+
+        result: dict[str, dict[str, tuple[float, int]]] = {}
+        for row in rows:
+            if isinstance(row, dict):
+                entity_id = str(row.get("entity_id", "") or "")
+                metric = str(row.get("metric", "") or "")
+                value = row.get("value")
+                count = row.get("sample_count", 0)
+            else:
+                entity_id, metric, value, count = (
+                    str(row[0] or ""),
+                    str(row[1] or ""),
+                    row[2],
+                    row[3],
+                )
+            if not entity_id or not metric or value is None:
+                continue
+            result.setdefault(entity_id, {})[metric] = (float(value), int(count or 0))
+
+        LOGGER.debug("Fetched DOW baseline data for %d entities.", len(result))
+        return result
 
     # ---------------------------------------------------------------------- #
     # Freshness query
@@ -1006,16 +1220,32 @@ def evaluate_baseline_deviation(  # noqa: PLR0911, PLR0912, PLR0915
     ]
 
 
-def evaluate_time_of_day_anomaly(
+def evaluate_time_of_day_anomaly(  # noqa: PLR0913
     snapshot: FullStateSnapshot,
     rule: dict[str, Any],
     baselines: dict[str, dict[str, float]],
+    dow_data: dict[str, dict[str, tuple[float, int]]] | None = None,
+    dow_min_samples: int = RECOMMENDED_SENTINEL_BASELINE_DOW_MIN_SAMPLES,
+    global_drift_pct: float = RECOMMENDED_SENTINEL_BASELINE_DRIFT_THRESHOLD_PCT,
 ) -> list[AnomalyFinding]:
     """
     Detect when an entity's state differs from the expected hour-of-day average.
 
-    Rule params are identical to ``evaluate_baseline_deviation`` but the
-    metric compared is the hour-of-day rolling average for the current hour.
+    When *dow_data* is provided and the entity has DOW baseline data, the
+    expected value is a weighted blend of the DOW-hour mean and the global
+    hourly mean:
+
+        w = min(count / dow_min_samples, 1.0)
+        expected = w * dow_mean + (1 - w) * global_mean
+
+    At ``count = 0``: pure global.  At ``count >= dow_min_samples``: pure DOW.
+
+    The anomaly threshold is entity-specific when a DOW stddev is available:
+
+        threshold = max(dow_std * 2.0, abs(expected) * drift_pct / 100)
+
+    Without DOW data the function falls back to the existing global-hourly
+    behaviour (delegates to ``evaluate_baseline_deviation``).
     """
     params: dict[str, Any] = rule.get("params") or {}
     entity_id = params.get("entity_id")
@@ -1031,9 +1261,36 @@ def evaluate_time_of_day_anomaly(
         if now_dt.tzinfo is None:
             now_dt = now_dt.replace(tzinfo=UTC)
         hour_str = str(now_dt.hour)
+        dow = now_dt.weekday()  # 0=Monday, 6=Sunday
     except (TypeError, ValueError):
         return []
 
+    # --- DOW-blended path ---
+    if dow_data is not None:
+        entity_dow = dow_data.get(entity_id, {})
+        dow_mean_key = f"{METRIC_DOW_AVG_PREFIX}{dow}_{now_dt.hour}"
+        dow_std_key = f"{METRIC_DOW_STD_PREFIX}{dow}_{now_dt.hour}"
+
+        dow_mean_entry = entity_dow.get(dow_mean_key)
+        dow_std_entry = entity_dow.get(dow_std_key)
+
+        if dow_mean_entry is not None:
+            return _evaluate_dow_anomaly(
+                snapshot=snapshot,
+                rule=rule,
+                baselines=baselines,
+                entity_id=entity_id,
+                hour_str=hour_str,
+                dow=dow,
+                local_hour=now_dt.hour,
+                dow_mean=dow_mean_entry[0],
+                dow_count=dow_mean_entry[1],
+                dow_std=dow_std_entry[0] if dow_std_entry is not None else None,
+                dow_min_samples=dow_min_samples,
+                global_drift_pct=global_drift_pct,
+            )
+
+    # --- Global-hourly fallback (no DOW data) ---
     hourly_rule = dict(rule)
     hourly_params = dict(params)
     hourly_params["metric"] = f"{METRIC_HOURLY_PREFIX}{hour_str}"
@@ -1044,6 +1301,107 @@ def evaluate_time_of_day_anomaly(
         hourly_rule["template_id"] = "time_of_day_anomaly"
 
     return evaluate_baseline_deviation(snapshot, hourly_rule, baselines)
+
+
+def _evaluate_dow_anomaly(  # noqa: PLR0913
+    snapshot: FullStateSnapshot,
+    rule: dict[str, Any],
+    baselines: dict[str, dict[str, float]],
+    entity_id: str,
+    hour_str: str,
+    dow: int,
+    local_hour: int,
+    dow_mean: float,
+    dow_count: int,
+    dow_std: float | None,
+    dow_min_samples: int,
+    global_drift_pct: float,
+) -> list[AnomalyFinding]:
+    """
+    Compute a DOW-blended time-of-day anomaly finding.
+
+    Called only when a DOW mean row exists for the given entity/DOW/hour.
+    The blend weight is proportional to DOW observation count, so the model
+    transitions smoothly from global-hourly to DOW-specific baselines as data
+    accumulates.  No hard cliff at dow_min_samples.
+    """
+    entity_map = {e["entity_id"]: e for e in snapshot.get("entities", [])}
+    entity = entity_map.get(entity_id)
+    if entity is None:
+        return []
+
+    try:
+        current_value = float(str(entity.get("state", "")))
+    except (TypeError, ValueError):
+        return []
+
+    # Global hourly mean for this hour (the fallback anchor).
+    global_mean = (baselines.get(entity_id) or {}).get(
+        f"{METRIC_HOURLY_PREFIX}{hour_str}"
+    )
+    if global_mean is None:
+        global_mean = dow_mean  # no global baseline yet — use DOW mean as anchor
+
+    # Weighted blend: w=0 ⟹ pure global; w=1 ⟹ pure DOW.
+    w = min(dow_count / dow_min_samples, 1.0) if dow_min_samples > 0 else 1.0
+    expected = w * dow_mean + (1.0 - w) * global_mean
+
+    # Entity-specific threshold: use DOW stddev when the slot is warm enough.
+    if dow_std is not None and dow_count >= dow_min_samples and dow_std > 0.0:
+        threshold = max(dow_std * 2.0, abs(expected) * (global_drift_pct / 100.0))
+    else:
+        threshold = abs(expected) * (global_drift_pct / 100.0)
+
+    deviation = abs(current_value - expected)
+    if deviation <= threshold:
+        return []
+
+    rule_id = str(rule.get("rule_id") or "time_of_day_anomaly")
+    deviation_pct = deviation / abs(expected) * 100.0 if expected != 0.0 else 100.0
+    evidence = {
+        "rule_id": rule_id,
+        "template_id": rule.get("template_id", "time_of_day_anomaly"),
+        "entity_id": entity_id,
+        "friendly_name": entity.get("friendly_name") or "",
+        "current_value": current_value,
+        "expected_value": round(expected, 4),
+        "dow_mean": dow_mean,
+        "global_mean": global_mean,
+        "blend_weight": round(w, 4),
+        "dow_count": dow_count,
+        "dow_stddev": round(dow_std, 4) if dow_std is not None else None,
+        "deviation": round(deviation, 4),
+        "deviation_pct": round(deviation_pct, 2),
+        "deviation_direction": "above" if current_value > expected else "below",
+        "threshold": round(threshold, 4),
+        "dow": dow,
+        "hour": local_hour,
+        "last_changed": entity.get("last_changed"),
+    }
+
+    severity_raw = str(rule.get("severity") or "low")
+    severity: Severity = (  # type: ignore[assignment]
+        severity_raw if severity_raw in {"low", "medium", "high"} else "low"
+    )
+    confidence = _coerce_float(rule.get("confidence"), default=0.7)
+    _hash_evidence = {k: v for k, v in evidence.items() if k != "friendly_name"}
+    anomaly_id = build_anomaly_id(rule_id, [entity_id], _hash_evidence)
+    suggested_actions = rule.get("suggested_actions") or []
+
+    return [
+        AnomalyFinding(
+            anomaly_id=anomaly_id,
+            type=rule_id,
+            severity=severity,
+            confidence=confidence,
+            triggering_entities=[entity_id],
+            evidence=evidence,
+            suggested_actions=(
+                list(suggested_actions) if isinstance(suggested_actions, list) else []
+            ),
+            is_sensitive=bool(rule.get("is_sensitive", False)),
+        )
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/custom_components/home_generative_agent/sentinel/dynamic_rules.py
+++ b/custom_components/home_generative_agent/sentinel/dynamic_rules.py
@@ -26,10 +26,13 @@ LOGGER = logging.getLogger(__name__)
 _SEVERITIES = {"low", "medium", "high"}
 
 
-def evaluate_dynamic_rules(
+def evaluate_dynamic_rules(  # noqa: PLR0913
     snapshot: FullStateSnapshot,
     rules: Iterable[dict[str, Any]],
     baselines: dict[str, dict[str, float]] | None = None,
+    dow_data: dict[str, dict[str, tuple[float, int]]] | None = None,
+    dow_min_samples: int = 4,
+    global_drift_pct: float = 30.0,
 ) -> list[AnomalyFinding]:
     """
     Evaluate generated rules deterministically.
@@ -38,6 +41,10 @@ def evaluate_dynamic_rules(
     populated by ``SentinelBaselineUpdater``.  When ``None``, baseline-driven
     templates (``baseline_deviation``, ``time_of_day_anomaly``) return empty
     lists silently.
+
+    *dow_data* is an optional mapping ``{entity_id: {metric_key: (value, count)}}``
+    for DOW (day-of-week) per-slot baselines.  When provided, ``time_of_day_anomaly``
+    rules use a weighted blend of the DOW mean and the global hourly mean.
     """
     _baselines: dict[str, dict[str, float]] = baselines or {}
     entity_map = {entity["entity_id"]: entity for entity in snapshot["entities"]}
@@ -126,7 +133,14 @@ def evaluate_dynamic_rules(
             lambda rule: evaluate_baseline_deviation(snapshot, rule, _baselines)
         ),
         "time_of_day_anomaly": (
-            lambda rule: evaluate_time_of_day_anomaly(snapshot, rule, _baselines)
+            lambda rule: evaluate_time_of_day_anomaly(
+                snapshot,
+                rule,
+                _baselines,
+                dow_data=dow_data,
+                dow_min_samples=dow_min_samples,
+                global_drift_pct=global_drift_pct,
+            )
         ),
         # Flexible templates
         "unlocked_lock_while_away": lambda rule: _eval_unlocked_lock_while_away(

--- a/custom_components/home_generative_agent/sentinel/dynamic_rules.py
+++ b/custom_components/home_generative_agent/sentinel/dynamic_rules.py
@@ -8,6 +8,11 @@ from typing import TYPE_CHECKING, Any, cast
 
 from homeassistant.util import dt as dt_util
 
+from custom_components.home_generative_agent.const import (
+    RECOMMENDED_SENTINEL_BASELINE_DOW_MIN_SAMPLES,
+    RECOMMENDED_SENTINEL_BASELINE_DRIFT_THRESHOLD_PCT,
+)
+
 from .baseline import evaluate_baseline_deviation, evaluate_time_of_day_anomaly
 from .models import AnomalyFinding, Severity, build_anomaly_id
 from .proposal_templates import SUPPORTED_TEMPLATES
@@ -31,8 +36,8 @@ def evaluate_dynamic_rules(  # noqa: PLR0913
     rules: Iterable[dict[str, Any]],
     baselines: dict[str, dict[str, float]] | None = None,
     dow_data: dict[str, dict[str, tuple[float, int]]] | None = None,
-    dow_min_samples: int = 4,
-    global_drift_pct: float = 30.0,
+    dow_min_samples: int = RECOMMENDED_SENTINEL_BASELINE_DOW_MIN_SAMPLES,
+    global_drift_pct: float = RECOMMENDED_SENTINEL_BASELINE_DRIFT_THRESHOLD_PCT,
 ) -> list[AnomalyFinding]:
     """
     Evaluate generated rules deterministically.

--- a/custom_components/home_generative_agent/sentinel/engine.py
+++ b/custom_components/home_generative_agent/sentinel/engine.py
@@ -20,6 +20,9 @@ from custom_components.home_generative_agent.const import (
     CONF_EXPLAIN_ENABLED,
     CONF_SENTINEL_AUTO_EXEC_CANARY_MODE,
     CONF_SENTINEL_AUTONOMY_LEVEL,
+    CONF_SENTINEL_BASELINE_DOW_MIN_SAMPLES,
+    CONF_SENTINEL_BASELINE_DRIFT_THRESHOLD_PCT,
+    CONF_SENTINEL_BASELINE_WEEKLY_PATTERNS,
     CONF_SENTINEL_CAMERA_ENTRY_LINKS,
     CONF_SENTINEL_COOLDOWN_MINUTES,
     CONF_SENTINEL_ENTITY_COOLDOWN_MINUTES,
@@ -35,6 +38,9 @@ from custom_components.home_generative_agent.const import (
     CONF_SENTINEL_RUNTIME_OVERRIDE_TTL_MINUTES,
     RECOMMENDED_SENTINEL_AUTO_EXEC_CANARY_MODE,
     RECOMMENDED_SENTINEL_AUTONOMY_LEVEL,
+    RECOMMENDED_SENTINEL_BASELINE_DOW_MIN_SAMPLES,
+    RECOMMENDED_SENTINEL_BASELINE_DRIFT_THRESHOLD_PCT,
+    RECOMMENDED_SENTINEL_BASELINE_WEEKLY_PATTERNS,
     RECOMMENDED_SENTINEL_PENDING_PROMPT_TTL_MINUTES,
     RECOMMENDED_SENTINEL_PRESENCE_GRACE_MINUTES,
     RECOMMENDED_SENTINEL_QUIET_HOURS_SEVERITIES,
@@ -192,6 +198,17 @@ class SentinelEngine:
         self._last_people_home: set[str] = set()
         # Run telemetry exposed to SentinelHealthSensor.
         self.run_stats: dict[str, Any] = {}
+
+    @property
+    def learned_suppressions_count(self) -> int:
+        """
+        Count of distinct ``{rule_type}:{entity_id}`` pairs with learned multipliers.
+
+        Each entry represents a finding type+entity that was snoozed or dismissed,
+        extending its cooldown.  Exposed on the health sensor as
+        ``learned_suppressions_active``.
+        """
+        return len(self._suppression.state.learned_cooldown_multipliers)
 
     # ---------------------------------------------------------------------- #
     # Autonomy level management
@@ -395,7 +412,7 @@ class SentinelEngine:
             self.run_stats["scheduler"] = self._trigger_scheduler.stats
             async_dispatcher_send(self._hass, SIGNAL_SENTINEL_RUN_COMPLETE)
 
-    async def _run_once(self, trigger_source: str = "poll") -> None:
+    async def _run_once(self, trigger_source: str = "poll") -> None:  # noqa: PLR0912
         try:
             snapshot = await async_build_full_state_snapshot(self._hass)
         except (ValueError, TypeError, KeyError):
@@ -470,6 +487,7 @@ class SentinelEngine:
             )
             if dynamic_rules:
                 baselines: dict[str, dict[str, float]] = {}
+                dow_data: dict[str, dict[str, tuple[float, int]]] | None = None
                 if self._baseline_updater is not None:
                     baselines = await self._baseline_updater.async_fetch_baselines()
                     # Inject baseline_ready_entities into derived so the discovery
@@ -478,8 +496,30 @@ class SentinelEngine:
                         await self._baseline_updater.async_fetch_ready_entity_ids()
                     )
                     snapshot["derived"]["baseline_ready_entities"] = ready_ids
+                    # Fetch DOW data when weekly_patterns is enabled.
+                    weekly_patterns = bool(
+                        self._options.get(
+                            CONF_SENTINEL_BASELINE_WEEKLY_PATTERNS,
+                            RECOMMENDED_SENTINEL_BASELINE_WEEKLY_PATTERNS,
+                        )
+                    )
+                    if weekly_patterns:
+                        dow_data = await self._baseline_updater.async_fetch_dow_data()
+                dow_min_samples = _coerce_int(
+                    self._options.get(CONF_SENTINEL_BASELINE_DOW_MIN_SAMPLES),
+                    RECOMMENDED_SENTINEL_BASELINE_DOW_MIN_SAMPLES,
+                )
+                global_drift_pct = _coerce_float(
+                    self._options.get(CONF_SENTINEL_BASELINE_DRIFT_THRESHOLD_PCT),
+                    RECOMMENDED_SENTINEL_BASELINE_DRIFT_THRESHOLD_PCT,
+                )
                 dynamic_findings = evaluate_dynamic_rules(
-                    snapshot, dynamic_rules, baselines=baselines
+                    snapshot,
+                    dynamic_rules,
+                    baselines=baselines,
+                    dow_data=dow_data,
+                    dow_min_samples=dow_min_samples,
+                    global_drift_pct=global_drift_pct,
                 )
                 LOGGER.debug(
                     "Sentinel evaluated %s dynamic rule(s), produced %s finding(s).",
@@ -991,6 +1031,18 @@ def _coerce_int(value: object | None, default: int) -> int:
     if isinstance(value, str):
         try:
             return int(value)
+        except ValueError:
+            return default
+    return default
+
+
+def _coerce_float(value: object | None, default: float) -> float:
+    """Coerce option values to float with a deterministic fallback."""
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
         except ValueError:
             return default
     return default

--- a/custom_components/home_generative_agent/strings.json
+++ b/custom_components/home_generative_agent/strings.json
@@ -163,6 +163,8 @@
             "sentinel_baseline_enabled": "Enable baseline collection (requires anomaly alerting)",
             "sentinel_baseline_update_interval_minutes": "Baseline update interval (minutes)",
             "sentinel_baseline_freshness_threshold_seconds": "Baseline freshness threshold (seconds)",
+            "sentinel_baseline_weekly_patterns": "Enable day-of-week baselines (reduces weekend false positives)",
+            "sentinel_baseline_dow_min_samples": "DOW baseline minimum samples (weeks of data per slot)",
             "explain_enabled": "Enable LLM explanations for sentinel findings",
             "sentinel_require_pin_for_level_increase": "Require PIN for autonomy level increases",
             "sentinel_daily_digest_enabled": "Enable daily digest notification",

--- a/custom_components/home_generative_agent/translations/en.json
+++ b/custom_components/home_generative_agent/translations/en.json
@@ -160,6 +160,8 @@
             "sentinel_baseline_enabled": "Enable baseline collection (requires anomaly alerting)",
             "sentinel_baseline_update_interval_minutes": "Baseline update interval (minutes)",
             "sentinel_baseline_freshness_threshold_seconds": "Baseline freshness threshold (seconds)",
+            "sentinel_baseline_weekly_patterns": "Enable day-of-week baselines (reduces weekend false positives)",
+            "sentinel_baseline_dow_min_samples": "DOW baseline minimum samples (weeks of data per slot)",
             "explain_enabled": "Enable LLM explanations for sentinel findings",
             "sentinel_require_pin_for_level_increase": "Require PIN for autonomy level increases",
             "sentinel_daily_digest_enabled": "Enable daily digest notification",

--- a/tests/custom_components/home_generative_agent/test_sentinel_baseline.py
+++ b/tests/custom_components/home_generative_agent/test_sentinel_baseline.py
@@ -1884,3 +1884,94 @@ async def test_update_baselines_skips_dow_rows_when_disabled() -> None:
     assert not dow_std_written, (
         f"DOW stddev should not be written; got: {written_metrics}"
     )
+
+
+# ---------------------------------------------------------------------------
+# DOW warm-restart — _dow_state reconstructed from DB rows in async_initialize
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_initialize_reconstructs_dow_state_from_db() -> None:
+    """
+    async_initialize() must reconstruct _dow_state from existing DB rows.
+
+    Simulates a restart: DB contains a mean row and a stddev row for entity
+    sensor.power at DOW=0 (Monday), hour=9. Verifies that _dow_state is
+    populated with the correct (mean, m2, count) tuple where
+    m2 = stddev**2 * (count - 1).
+    """
+    # Pre-existing DB rows: mean=100.0 (count=5) and stddev=10.0 for Mon 09:00.
+    dow, hour = 0, 9
+    mean_metric = f"{METRIC_DOW_AVG_PREFIX}{dow}_{hour}"
+    std_metric = f"{METRIC_DOW_STD_PREFIX}{dow}_{hour}"
+    db_rows = [
+        {
+            "entity_id": "sensor.power",
+            "metric": mean_metric,
+            "value": 100.0,
+            "sample_count": 5,
+        },
+        {
+            "entity_id": "sensor.power",
+            "metric": std_metric,
+            "value": 10.0,
+            "sample_count": 5,
+        },
+    ]
+
+    call_count = 0
+
+    mock_cursor = MagicMock()
+
+    async def _exec(_sql: str, *_args: Any) -> None:
+        pass
+
+    async def _fetchall() -> list[Any]:
+        nonlocal call_count
+        call_count += 1
+        # First fetchall: established-set query (returns empty).
+        # Second fetchall: DOW warm-restart query (returns pre-populated rows).
+        if call_count == 1:
+            return []
+        return db_rows
+
+    mock_cursor.execute = _exec
+    mock_cursor.fetchall = _fetchall
+    mock_cursor.fetchone = AsyncMock(return_value=None)
+
+    mock_conn = MagicMock()
+    mock_conn.commit = AsyncMock()
+    mock_conn.cursor = MagicMock(
+        return_value=MagicMock(
+            __aenter__=AsyncMock(return_value=mock_cursor),
+            __aexit__=AsyncMock(return_value=False),
+        )
+    )
+    mock_pool = MagicMock()
+    mock_pool.connection = MagicMock(
+        return_value=MagicMock(
+            __aenter__=AsyncMock(return_value=mock_conn),
+            __aexit__=AsyncMock(return_value=False),
+        )
+    )
+
+    mock_hass = MagicMock()
+    updater = SentinelBaselineUpdater(mock_hass, mock_pool, {})
+
+    assert updater._dow_state == {}, "State must be empty before init"
+
+    await updater.async_initialize()
+
+    key = f"sensor.power:{dow}:{hour}"
+    assert key in updater._dow_state, f"Expected key {key!r} in _dow_state"
+
+    reconstructed_mean, reconstructed_m2, reconstructed_count = updater._dow_state[key]
+
+    # mean should equal the DB value exactly.
+    assert reconstructed_mean == pytest.approx(100.0)
+    # count should equal the DB sample_count.
+    assert reconstructed_count == 5
+    # m2 = stddev**2 * (count - 1) = 10**2 * 4 = 400.
+    expected_m2 = 10.0**2 * (5 - 1)
+    assert reconstructed_m2 == pytest.approx(expected_m2)

--- a/tests/custom_components/home_generative_agent/test_sentinel_baseline.py
+++ b/tests/custom_components/home_generative_agent/test_sentinel_baseline.py
@@ -14,12 +14,16 @@ from custom_components.home_generative_agent.const import (
     CONF_SENTINEL_BASELINE_DRIFT_THRESHOLD_PCT,
     CONF_SENTINEL_BASELINE_MAX_SAMPLES,
     CONF_SENTINEL_BASELINE_MIN_SAMPLES,
+    CONF_SENTINEL_BASELINE_WEEKLY_PATTERNS,
     RECOMMENDED_SENTINEL_BASELINE_MIN_SAMPLES,
 )
 from custom_components.home_generative_agent.sentinel.baseline import (
+    _DOW_METRIC_PARTS,
     BASELINE_FRESH,
     BASELINE_STALE,
     BASELINE_UNAVAILABLE,
+    METRIC_DOW_AVG_PREFIX,
+    METRIC_DOW_STD_PREFIX,
     METRIC_HOURLY_PREFIX,
     METRIC_ROLLING_AVG,
     SentinelBaselineUpdater,
@@ -1397,3 +1401,486 @@ def test_baseline_deviation_non_power_entity_no_completion() -> None:
 
     assert len(findings) == 1
     assert "is_completion" not in findings[0].evidence
+
+
+# ---------------------------------------------------------------------------
+# DOW (day-of-week) baseline tests — Sprint 3 PR2
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Welford's algorithm — _update_dow_welford
+# ---------------------------------------------------------------------------
+
+
+def test_dow_welford_single_observation() -> None:
+    """After one observation, mean equals the value and stddev is 0."""
+    mock_hass = MagicMock()
+    mock_pool = MagicMock()
+    updater = SentinelBaselineUpdater(mock_hass, mock_pool, {})
+
+    mean, stddev = updater._update_dow_welford(
+        "sensor.temp", dow=0, hour=14, new_value=20.0
+    )
+
+    assert mean == pytest.approx(20.0)
+    assert stddev == pytest.approx(0.0)
+    assert updater._dow_state["sensor.temp:0:14"] == pytest.approx((20.0, 0.0, 1))
+
+
+def test_dow_welford_multiple_observations_converge() -> None:
+    """After N observations, running mean and stddev converge correctly."""
+    mock_hass = MagicMock()
+    mock_pool = MagicMock()
+    updater = SentinelBaselineUpdater(mock_hass, mock_pool, {})
+
+    values = [10.0, 20.0, 30.0, 40.0]
+    final_mean = 0.0
+    final_stddev = 0.0
+    for v in values:
+        final_mean, final_stddev = updater._update_dow_welford(
+            "sensor.temp", dow=5, hour=8, new_value=v
+        )
+
+    # Population mean = 25; sample stddev = sqrt(((10-25)^2+(20-25)^2+(30-25)^2+(40-25)^2)/3)
+    # = sqrt((225+25+25+225)/3) = sqrt(500/3) ≈ 12.91
+    assert final_mean == pytest.approx(25.0)
+    assert final_stddev == pytest.approx((500.0 / 3) ** 0.5, rel=1e-4)
+    _, _, count = updater._dow_state["sensor.temp:5:8"]
+    assert count == 4
+
+
+def test_dow_welford_separate_slots_are_independent() -> None:
+    """DOW slots for different entities/hours don't interfere."""
+    mock_hass = MagicMock()
+    mock_pool = MagicMock()
+    updater = SentinelBaselineUpdater(mock_hass, mock_pool, {})
+
+    updater._update_dow_welford("sensor.a", dow=0, hour=0, new_value=100.0)
+    updater._update_dow_welford("sensor.b", dow=0, hour=0, new_value=5.0)
+
+    mean_a, _, count_a = updater._dow_state["sensor.a:0:0"]
+    mean_b, _, count_b = updater._dow_state["sensor.b:0:0"]
+
+    assert mean_a == pytest.approx(100.0)
+    assert mean_b == pytest.approx(5.0)
+    assert count_a == 1
+    assert count_b == 1
+
+
+# ---------------------------------------------------------------------------
+# evaluate_time_of_day_anomaly — DOW blending
+# ---------------------------------------------------------------------------
+
+
+def _dow_rule(entity_id: str = "sensor.temp") -> dict[str, Any]:
+    return {
+        "rule_id": "time_of_day_anomaly",
+        "template_id": "time_of_day_anomaly",
+        "params": {"entity_id": entity_id},
+        "severity": "low",
+        "confidence": 0.7,
+        "is_sensitive": False,
+        "suggested_actions": [],
+    }
+
+
+def _dow_snapshot(entity_id: str, state: str, hour: int, dow: int) -> Any:
+    """Snapshot with a single entity and a specific local datetime."""
+    # Create an ISO string matching the given DOW and hour.
+    # We use a fixed base date (2026-01-05 = Monday) and offset by dow days.
+    base_monday = datetime(2026, 1, 5, 0, 0, 0, tzinfo=UTC)
+    dt = base_monday.replace(hour=hour) + timedelta(days=dow)
+    now_str = dt.isoformat()
+    return cast(
+        "FullStateSnapshot",
+        {
+            "schema_version": 1,
+            "generated_at": now_str,
+            "entities": [
+                {
+                    "entity_id": entity_id,
+                    "state": state,
+                    "domain": entity_id.split(".", maxsplit=1)[0],
+                    "area": "Living Room",
+                    "attributes": {},
+                    "last_changed": now_str,
+                    "last_updated": now_str,
+                }
+            ],
+            "camera_activity": [],
+            "derived": {
+                "now": now_str,
+                "timezone": "UTC",
+                "is_night": False,
+                "anyone_home": True,
+                "people_home": [],
+                "people_away": [],
+                "last_motion_by_area": {},
+            },
+        },
+    )
+
+
+def test_dow_blend_at_zero_samples_uses_global_mean() -> None:
+    """With count=0 (no DOW data), falls back fully to global hourly mean."""
+    # No DOW data — dow_data is empty — should fall back to global hourly detection.
+    snapshot = _dow_snapshot("sensor.temp", "200", hour=14, dow=0)
+    # Global hourly mean of 20 at hour 14; current=200 → 900% deviation
+    baselines = {"sensor.temp": {f"{METRIC_HOURLY_PREFIX}14": 20.0}}
+    rule = _dow_rule()
+
+    # With no DOW data at all, evaluates as pure global
+    findings = evaluate_time_of_day_anomaly(
+        snapshot, rule, baselines, dow_data={}, dow_min_samples=4
+    )
+
+    assert len(findings) == 1
+
+
+def test_dow_blend_at_full_samples_uses_dow_mean() -> None:
+    """With count >= dow_min_samples, expected is entirely the DOW mean."""
+    dow_min_samples = 4
+    entity_id = "sensor.temp"
+    dow, hour = 0, 14  # Monday 14:00
+
+    snapshot = _dow_snapshot(entity_id, "25", hour=hour, dow=dow)
+    # DOW mean=20, global mean=50 (very different to confirm DOW is used)
+    dow_mean_key = f"{METRIC_DOW_AVG_PREFIX}{dow}_{hour}"
+    dow_std_key = f"{METRIC_DOW_STD_PREFIX}{dow}_{hour}"
+    global_key = f"{METRIC_HOURLY_PREFIX}{hour}"
+    baselines = {entity_id: {global_key: 50.0}}
+    dow_data = {
+        entity_id: {
+            dow_mean_key: (20.0, dow_min_samples),  # (value, count) — fully warm
+            dow_std_key: (1.0, dow_min_samples),  # tight stddev
+        }
+    }
+
+    findings = evaluate_time_of_day_anomaly(
+        snapshot,
+        rule=_dow_rule(entity_id),
+        baselines=baselines,
+        dow_data=dow_data,
+        dow_min_samples=dow_min_samples,
+    )
+
+    # expected = 20.0 (DOW), deviation = |25-20| = 5, threshold = max(1*2, 20*0.3)=6 → no fire
+    assert findings == []
+
+
+def test_dow_blend_fires_for_genuine_outlier_vs_dow_mean() -> None:
+    """A genuine outlier relative to the DOW mean fires even if near the global mean."""
+    dow_min_samples = 4
+    entity_id = "sensor.temp"
+    dow, hour = 5, 20  # Saturday 20:00
+
+    snapshot = _dow_snapshot(entity_id, "100", hour=hour, dow=dow)
+    dow_mean_key = f"{METRIC_DOW_AVG_PREFIX}{dow}_{hour}"
+    dow_std_key = f"{METRIC_DOW_STD_PREFIX}{dow}_{hour}"
+    global_key = f"{METRIC_HOURLY_PREFIX}{hour}"
+    # DOW mean=20, stddev=2; global=90 (close to current); current=100
+    baselines = {entity_id: {global_key: 90.0}}
+    dow_data = {
+        entity_id: {
+            dow_mean_key: (20.0, dow_min_samples),
+            dow_std_key: (2.0, dow_min_samples),
+        }
+    }
+
+    findings = evaluate_time_of_day_anomaly(
+        snapshot,
+        rule=_dow_rule(entity_id),
+        baselines=baselines,
+        dow_data=dow_data,
+        dow_min_samples=dow_min_samples,
+    )
+
+    # expected=20 (fully DOW), threshold=max(2*2,20*0.3)=6, deviation=|100-20|=80 → fires
+    assert len(findings) == 1
+    ev = findings[0].evidence
+    assert ev["dow_mean"] == pytest.approx(20.0)
+    assert ev["blend_weight"] == pytest.approx(1.0)
+    assert ev["deviation_direction"] == "above"
+
+
+def test_dow_blend_no_fire_for_in_range_value() -> None:
+    """A value within DOW mean ± 2*stddev does NOT fire."""
+    dow_min_samples = 4
+    entity_id = "sensor.temp"
+    dow, hour = 6, 9  # Sunday 09:00
+
+    snapshot = _dow_snapshot(entity_id, "22", hour=hour, dow=dow)
+    dow_mean_key = f"{METRIC_DOW_AVG_PREFIX}{dow}_{hour}"
+    dow_std_key = f"{METRIC_DOW_STD_PREFIX}{dow}_{hour}"
+    global_key = f"{METRIC_HOURLY_PREFIX}{hour}"
+    baselines = {entity_id: {global_key: 20.0}}
+    dow_data = {
+        entity_id: {
+            dow_mean_key: (20.0, dow_min_samples),
+            dow_std_key: (3.0, dow_min_samples),  # threshold = max(6, 20*0.3) = 6
+        }
+    }
+
+    findings = evaluate_time_of_day_anomaly(
+        snapshot,
+        rule=_dow_rule(entity_id),
+        baselines=baselines,
+        dow_data=dow_data,
+        dow_min_samples=dow_min_samples,
+    )
+
+    # deviation=2, threshold=6 → no fire
+    assert findings == []
+
+
+def test_dow_partial_blend_midpoint() -> None:
+    """At count = dow_min_samples/2, blend weight is 0.5."""
+    dow_min_samples = 4
+    entity_id = "sensor.temp"
+    dow, hour = 1, 7  # Tuesday 07:00
+    half_count = dow_min_samples // 2  # 2
+
+    snapshot = _dow_snapshot(entity_id, "200", hour=hour, dow=dow)
+    dow_mean_key = f"{METRIC_DOW_AVG_PREFIX}{dow}_{hour}"
+    global_key = f"{METRIC_HOURLY_PREFIX}{hour}"
+    # DOW mean=10, global mean=10; both at 10; current=200 → fires regardless of blend
+    baselines = {entity_id: {global_key: 10.0}}
+    dow_data = {
+        entity_id: {
+            dow_mean_key: (10.0, half_count),  # w=0.5
+        }
+    }
+
+    findings = evaluate_time_of_day_anomaly(
+        snapshot,
+        rule=_dow_rule(entity_id),
+        baselines=baselines,
+        dow_data=dow_data,
+        dow_min_samples=dow_min_samples,
+    )
+
+    # expected=0.5*10 + 0.5*10 = 10; deviation=190 → fires
+    assert len(findings) == 1
+    assert findings[0].evidence["blend_weight"] == pytest.approx(0.5)
+
+
+def test_dow_fallback_to_global_when_no_dow_data() -> None:
+    """When dow_data=None, falls back to global hourly comparison."""
+    entity_id = "sensor.temp"
+    dow, hour = 0, 10  # Monday 10:00
+
+    snapshot = _dow_snapshot(entity_id, "100", hour=hour, dow=dow)
+    global_key = f"{METRIC_HOURLY_PREFIX}{hour}"
+    baselines = {entity_id: {global_key: 20.0}}
+
+    findings = evaluate_time_of_day_anomaly(
+        snapshot,
+        rule=_dow_rule(entity_id),
+        baselines=baselines,
+        dow_data=None,
+    )
+
+    # Global: deviation = 80/20 = 400% > 30% → fires
+    assert len(findings) == 1
+
+
+# ---------------------------------------------------------------------------
+# DOW migration index — idempotency via CREATE INDEX IF NOT EXISTS
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_initialize_dow_index_idempotent() -> None:
+    """async_initialize() must succeed when called twice (index DDL is IF NOT EXISTS)."""
+    executed: list[str] = []
+    mock_cursor = MagicMock()
+
+    async def _exec(sql: str, *_args: Any) -> None:
+        executed.append(sql.strip().split("\n")[0])
+
+    mock_cursor.execute = _exec
+    mock_cursor.fetchall = AsyncMock(return_value=[])
+    mock_cursor.fetchone = AsyncMock(return_value=None)
+
+    mock_conn = MagicMock()
+    mock_conn.commit = AsyncMock()
+    mock_conn.cursor = MagicMock(
+        return_value=MagicMock(
+            __aenter__=AsyncMock(return_value=mock_cursor),
+            __aexit__=AsyncMock(return_value=False),
+        )
+    )
+    mock_pool = MagicMock()
+    mock_pool.connection = MagicMock(
+        return_value=MagicMock(
+            __aenter__=AsyncMock(return_value=mock_conn),
+            __aexit__=AsyncMock(return_value=False),
+        )
+    )
+
+    mock_hass = MagicMock()
+    updater = SentinelBaselineUpdater(mock_hass, mock_pool, {})
+
+    # First init
+    await updater.async_initialize()
+    # Second init — must not raise (idempotent DDL)
+    await updater.async_initialize()
+
+    # The index DDL should have been executed twice (once per init call).
+    index_calls = [s for s in executed if "idx_sentinel_baselines" in s]
+    assert len(index_calls) == 2
+
+
+# ---------------------------------------------------------------------------
+# DOW upserts written when weekly_patterns=True
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_baselines_writes_dow_rows_when_enabled() -> None:
+    """When weekly_patterns=True, _update_baselines writes DOW mean+stddev rows."""
+    written_metrics: list[str] = []
+
+    mock_cursor = MagicMock()
+
+    async def _exec(_sql: str, params: Any = None) -> None:
+        if params and len(params) >= 2:
+            written_metrics.append(str(params[1]))
+
+    mock_cursor.execute = _exec
+    mock_cursor.fetchone = AsyncMock(return_value={"sample_count": 5})
+    mock_cursor.fetchall = AsyncMock(return_value=[])
+
+    mock_conn = MagicMock()
+    mock_conn.commit = AsyncMock()
+    mock_conn.cursor = MagicMock(
+        return_value=MagicMock(
+            __aenter__=AsyncMock(return_value=mock_cursor),
+            __aexit__=AsyncMock(return_value=False),
+        )
+    )
+    mock_pool = MagicMock()
+    mock_pool.connection = MagicMock(
+        return_value=MagicMock(
+            __aenter__=AsyncMock(return_value=mock_conn),
+            __aexit__=AsyncMock(return_value=False),
+        )
+    )
+    mock_hass = MagicMock()
+    updater = SentinelBaselineUpdater(
+        mock_hass,
+        mock_pool,
+        {CONF_SENTINEL_BASELINE_WEEKLY_PATTERNS: True},
+    )
+
+    snapshot = cast(
+        "FullStateSnapshot",
+        {
+            "schema_version": 1,
+            "generated_at": "2026-01-05T14:00:00+00:00",
+            "entities": [
+                {
+                    "entity_id": "sensor.temp",
+                    "state": "22.0",
+                    "domain": "sensor",
+                    "area": "Living Room",
+                    "attributes": {},
+                    "last_changed": "2026-01-05T14:00:00+00:00",
+                    "last_updated": "2026-01-05T14:00:00+00:00",
+                }
+            ],
+            "camera_activity": [],
+            "derived": {
+                "now": "2026-01-05T14:00:00+00:00",
+                "timezone": "UTC",
+                "is_night": False,
+                "anyone_home": True,
+                "people_home": [],
+                "people_away": [],
+                "last_motion_by_area": {},
+            },
+        },
+    )
+
+    await updater._update_baselines(snapshot)
+
+    # Should write rolling_avg, hourly_avg_<H>, hourly_avg_<DOW>_<H>, hourly_stddev_<DOW>_<H>
+    dow_mean_written = any(
+        METRIC_DOW_AVG_PREFIX in m and m.count("_") >= _DOW_METRIC_PARTS + 1
+        for m in written_metrics
+    )
+    dow_std_written = any(METRIC_DOW_STD_PREFIX in m for m in written_metrics)
+
+    assert dow_mean_written, f"No DOW mean metric written; got: {written_metrics}"
+    assert dow_std_written, f"No DOW stddev metric written; got: {written_metrics}"
+
+
+@pytest.mark.asyncio
+async def test_update_baselines_skips_dow_rows_when_disabled() -> None:
+    """When weekly_patterns=False (default), no DOW rows are written."""
+    written_metrics: list[str] = []
+
+    mock_cursor = MagicMock()
+
+    async def _exec(_sql: str, params: Any = None) -> None:
+        if params and len(params) >= 2:
+            written_metrics.append(str(params[1]))
+
+    mock_cursor.execute = _exec
+    mock_cursor.fetchone = AsyncMock(return_value={"sample_count": 5})
+    mock_cursor.fetchall = AsyncMock(return_value=[])
+
+    mock_conn = MagicMock()
+    mock_conn.commit = AsyncMock()
+    mock_conn.cursor = MagicMock(
+        return_value=MagicMock(
+            __aenter__=AsyncMock(return_value=mock_cursor),
+            __aexit__=AsyncMock(return_value=False),
+        )
+    )
+    mock_pool = MagicMock()
+    mock_pool.connection = MagicMock(
+        return_value=MagicMock(
+            __aenter__=AsyncMock(return_value=mock_conn),
+            __aexit__=AsyncMock(return_value=False),
+        )
+    )
+    mock_hass = MagicMock()
+    # weekly_patterns NOT set (defaults to False)
+    updater = SentinelBaselineUpdater(mock_hass, mock_pool, {})
+
+    snapshot = cast(
+        "FullStateSnapshot",
+        {
+            "schema_version": 1,
+            "generated_at": "2026-01-05T14:00:00+00:00",
+            "entities": [
+                {
+                    "entity_id": "sensor.temp",
+                    "state": "22.0",
+                    "domain": "sensor",
+                    "area": "Living Room",
+                    "attributes": {},
+                    "last_changed": "2026-01-05T14:00:00+00:00",
+                    "last_updated": "2026-01-05T14:00:00+00:00",
+                }
+            ],
+            "camera_activity": [],
+            "derived": {
+                "now": "2026-01-05T14:00:00+00:00",
+                "timezone": "UTC",
+                "is_night": False,
+                "anyone_home": True,
+                "people_home": [],
+                "people_away": [],
+                "last_motion_by_area": {},
+            },
+        },
+    )
+
+    await updater._update_baselines(snapshot)
+
+    dow_std_written = any(METRIC_DOW_STD_PREFIX in m for m in written_metrics)
+    assert not dow_std_written, (
+        f"DOW stddev should not be written; got: {written_metrics}"
+    )


### PR DESCRIPTION
## Summary

- **DOW (day-of-week) baselines** — `time_of_day_anomaly` rules now support per-(DOW, hour) slots using Welford's online algorithm. A weighted blend (`w = min(count/dow_min_samples, 1.0)`) transitions smoothly from global hourly to DOW-specific baselines as data accumulates — no hard cliff at the threshold. Entity-specific stddev thresholds mean a washer bouncing 0–2400 W won't over-fire vs a door sensor.
- **Config UI** — Two new fields in the Sentinel subentry: `sentinel_baseline_weekly_patterns` (bool, default false) and `sentinel_baseline_dow_min_samples` (NumberSelector, default 4 weeks).
- **`learned_suppressions_active`** — New health sensor attribute counting distinct `{rule_type}:{entity_id}` pairs with learned cooldown multipliers. Makes the dismiss/snooze feedback loop observable.
- **DB index** — `CREATE INDEX IF NOT EXISTS idx_sentinel_baselines_entity_metric` added idempotently in `async_initialize()` for fast per-(entity, metric) lookups.

## Implementation notes

- DOW upserts use direct Python-side Welford writes (`_DOW_UPSERT_SQL`) bypassing the EMA SQL — EMA assumes continuous sampling; DOW slots update at most once/week so EMA would produce interpolation artefacts.
- `_dow_state: dict[str, tuple[float, float, int]]` (mean, m2, count) is in-memory only; DB stores mean + stddev per slot. On restart, `m2 = stddev² * (count - 1)` reconstructs the accumulator (Welford warm-restart).
- `async_fetch_dow_data()` fetches DOW rows with no min-samples filter — the blend formula already handles sparse slots (w=0 → pure global).
- DOW buckets use local time (`dt_util.now().weekday()` / `.hour`) so patterns align with the user's timezone. DST fall-back hour double-counts one slot once/year — documented in code comment, not fixed.
- Discovery `_filter_novel_candidates()` derived-only-paths guard and entity-backed evidence path prompt instruction were already shipped in a prior PR.

## Test plan

- [x] 12 new tests in `test_sentinel_baseline.py` covering:
  - Welford convergence (single obs, N obs, independent slots)
  - Blend weights at 0 / half / full `dow_min_samples`
  - Genuine outlier fires vs DOW mean even when near global mean
  - In-range value with stddev threshold does not fire
  - Fallback to global when `dow_data=None`
  - DOW upserts written when `weekly_patterns=True`; skipped when `False`
  - Migration index DDL is idempotent (called twice → no error)
- [x] `make lint` — all checks passed
- [x] `make typecheck` — 0 errors
- [x] `make test` — 700 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)