### PR TITLE
feat: cyclical load sustained deviation gate (v3.11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.11.0] - 2026-04-14
+
+### Added
+
+- **Cyclical load sustained deviation gate** — refrigerators, freezers, and
+  compressors now require sustained anomalous power draw before Sentinel fires
+  a notification. Normal compressor cycling (e.g. ~944 W on/off every 30
+  minutes) no longer triggers repeated "High energy consumption away" alerts.
+  The gate duration is configurable in Sentinel settings (default 20 minutes,
+  range 0–120 in 5-minute steps; set to 0 to disable).
+
+- **Baseline minimum samples UI** — the "Baseline minimum samples before
+  deviation alerts fire" setting is now exposed in the Sentinel configuration
+  flow (range 1–500, default 20). Previously this required editing config
+  entries directly.
+
+- **Health sensor `cyclical_entities_gated` attribute** — the Sentinel health
+  sensor now reports how many cyclical entities are currently held by the
+  sustained deviation gate, useful for dashboards and debugging.
+
 ## [3.10.0] - 2026-04-13
 
 ### Added

--- a/TODOS.md
+++ b/TODOS.md
@@ -81,15 +81,47 @@
 
 ### Config flow UI for CONF_SENTINEL_BASELINE_MIN_SAMPLES
 
-**What:** Add a `NumberSelector` to the Sentinel subentry options flow for `sentinel_baseline_min_samples` (min: 1, max: 500, step: 1, default: 20). Update `sentinel_subentry_flow.py` and `const.py`.
+**Completed:** v3.11.0 (2026-04-14)
 
-**Why:** Without a UI control, users can't tune how many samples are required before baseline rules fire. The feature is invisible to anyone who doesn't read the source code. A user who enables baseline collection and sees no rule firings needs a way to discover and adjust this threshold.
+`NumberSelector` added to `sentinel_subentry_flow.py` (min: 1, max: 500, step: 1, default: 20). Also added `sentinel_baseline_sustained_minutes` selector in the same PR.
 
-**How to apply:** Add `CONF_SENTINEL_BASELINE_MIN_SAMPLES` to `const.py` (if not already added by the baseline enhancement PR). In `sentinel_subentry_flow.py`, add a `NumberSelector` in the baseline section alongside the existing update interval and freshness threshold controls.
+---
+
+### Incident lifecycle control for repeated deviation notifications
+
+**What:** Replace per-entity-run notification tracking with a stable incident abstraction: key per `entity_id + template_id`, hold incident open until entity returns below threshold, notify once per incident. Suppresses repeated alerts for any entity, not just named cyclers. Clear incident when the entity is absent from findings for one full run.
+
+**Why:** The v3.11.0 cyclical load gate (fridge/freezer/compressor) fixes the immediate fridge spam problem, but the root cause is deeper: Sentinel lacks any concept of "same condition still active." Every run where an entity is above threshold produces a new finding, and only the cooldown prevents repeated notification. The incident abstraction fixes this for all entities without requiring appliance name classification.
+
+**How to apply:** Add `_open_incidents: dict[str, IncidentState]` to `SentinelEngine.__init__`. `IncidentState` holds `opened_at`, `last_seen_at`, `notified: bool`. In a new `_apply_incident_control()` method, gate all findings: suppress if `notified=True` and entity still in `_open_incidents`; fire if not yet notified; clear if entity absent this run.
+
+**Effort:** M
+**Priority:** P2
+**Depends on:** Cyclical load gate (v3.11.0)
+
+---
+
+### Cyclical load gate: notification body with duration
+
+**What:** When the sustained gate fires, include elapsed time in the notification body ("Fridge compressor has been running for 22 minutes — possible problem?"). Reads `_cyclical_deviation_above_since[entity_id]` and formats elapsed time.
 
 **Effort:** S
-**Priority:** P2
-**Depends on:** Baseline enhancement PR (sentinel-baseline-enhancement)
+**Priority:** P3
+**Depends on:** Cyclical load gate (v3.11.0)
+
+---
+
+### Expand CYCLICAL_LOAD_HINTS to include HVAC/heat/AC/water heater
+
+**What:** Add `hvac`, `heat`, `heatpump`, `aircon`, `airconditioner`, `waterheater`, `tankless` to `CYCLICAL_LOAD_HINTS` in `sentinel/baseline.py`.
+
+**Why:** These appliances cycle normally (HVAC compressor, water heater element) and can generate the same notification spam as fridges. Deferred from v3.11.0 because an HVAC running at 3am away-mode IS an anomaly worth surfacing — the suppression tradeoff is non-trivial and needs evaluation before gating.
+
+**How to apply:** Before expanding hints, evaluate false-negative rate by checking whether any real HVAC away-mode anomalies have been observed in production. Add hint only if HVAC cycling during normal occupancy is reliably distinguishable from anomalous HVAC usage.
+
+**Effort:** S
+**Priority:** P3
+**Depends on:** Cyclical load gate (v3.11.0), field observation data
 
 ---
 
@@ -126,15 +158,9 @@
 
 ### Tighten discovery prompt to require entity-backed evidence paths
 
-**What:** Add an instruction to `USER_PROMPT_TEMPLATE` in `explain/discovery_prompts.py` requiring that each candidate cite at least one `entities[entity_ids contains <entity_id>].state` path referencing a concrete entity from the snapshot. Candidates that concern a specific entity but can only cite `derived.*` paths (e.g. `derived.anyone_home`) should be omitted rather than submitted with abstract evidence.
+**Completed:** v3.9.0 (2026-04-06)
 
-**Why:** The LLM currently generates candidates like "Stale Person Tracking While Away" with `evidence_paths` containing only `derived.*` entries and no concrete entity IDs. The normalization engine (`proposal_templates.py:explain_normalize_candidate`) requires at least one extractable entity ID to map a candidate to a supported rule template. Without it, approval always fails with `unsupported_pattern`, leaving a stuck proposal in the card that can only be dismissed by rejection and eventually expires via the 30-day TTL. The prompt is the only enforcement point — the schema validates structure but not content.
-
-**How to apply:** In `USER_PROMPT_TEMPLATE`, add after the current `evidence_paths` instruction: *"If a candidate concerns specific entities, at least one evidence_path MUST reference a concrete entity_id using the format `entities[entity_ids contains domain.object_id].state`. Omit the candidate entirely if no such entity can be cited from the snapshot."* Add a corresponding test in `tests/` that verifies a candidate with only `derived.*` paths and no concrete entity references is not generated (or is filtered pre-store).
-
-**Effort:** S
-**Priority:** P2
-**Depends on:** Discovery deduplication fix PR (fix/discovery-dedup-noise)
+Entity-backed evidence path instruction added to `USER_PROMPT_TEMPLATE` in `explain/discovery_prompts.py`. `_filter_novel_candidates()` in `explain/discovery_engine.py` now guards against derived-only paths. Tests added for the filter.
 
 ---
 
@@ -194,15 +220,9 @@
 
 ### Add `learned_suppressions_active` attribute to health sensor
 
-**What:** Expose a `learned_suppressions_active: int` attribute on `sensor.sentinel_health` — the count of `{rule_type}:{entity_id}` keys in `learned_cooldown_multipliers` where the value is greater than 1 (i.e., at least one doubling has occurred for that rule+entity combination).
+**Completed:** v3.9.0 (2026-04-06)
 
-**Why:** Without this attribute, there is no external visibility into how much Sentinel has self-tuned. Operators cannot tell whether the feedback-trained cooldown feature is doing anything. After v3.7.0 wires the feedback signal, this count becomes the primary signal that learning is occurring.
-
-**How to apply:** Pass `suppression: SuppressionManager | None = None` to `SentinelHealthSensor.__init__()`. In `_async_refresh()`, read `self._suppression.state.learned_cooldown_multipliers` and count entries where `value > 1`. Set `self._attrs["learned_suppressions_active"] = count` (or `None` if no suppression manager is available). Add a test asserting the count is correct for a pre-seeded state with known multipliers.
-
-**Effort:** S
-**Priority:** P2
-**Depends on:** Fix 2+3 (compound key scheme v5, feedback wired in notifier + actions)
+`learned_suppressions_active` attribute exposed on `sensor.sentinel_health`. Count reads `learned_cooldown_multipliers` from suppression state via `engine.learned_suppressions_count` property.
 
 ---
 

--- a/custom_components/home_generative_agent/const.py
+++ b/custom_components/home_generative_agent/const.py
@@ -233,6 +233,11 @@ RECOMMENDED_SENTINEL_BASELINE_WEEKLY_PATTERNS: bool = False
 # DOW slots update once/week; 4 weeks separates weekend/weekday patterns.
 # Lower than RECOMMENDED_SENTINEL_BASELINE_MIN_SAMPLES (20) for global EMA.
 RECOMMENDED_SENTINEL_BASELINE_DOW_MIN_SAMPLES: int = 4
+# Cyclical load sustained deviation gate — Sprint 4
+# Entities matching CYCLICAL_LOAD_HINTS (fridge/freezer/compressor) must stay
+# above the deviation threshold for this many minutes before firing.  0 = disabled.
+CONF_SENTINEL_BASELINE_SUSTAINED_MINUTES = "sentinel_baseline_sustained_minutes"
+RECOMMENDED_SENTINEL_BASELINE_SUSTAINED_MINUTES: int = 20
 
 # ---- Sentinel daily digest notification ----
 CONF_SENTINEL_DAILY_DIGEST_ENABLED = "sentinel_daily_digest_enabled"

--- a/custom_components/home_generative_agent/core/sentinel_health_sensor.py
+++ b/custom_components/home_generative_agent/core/sentinel_health_sensor.py
@@ -294,6 +294,13 @@ class SentinelHealthSensor(SensorEntity):
             else None
         )
 
+        # Cyclical load sustained deviation gate count.
+        self._attrs["cyclical_entities_gated"] = (
+            self._sentinel.cyclical_entities_gated_count
+            if self._sentinel is not None
+            else None
+        )
+
         self._attr_native_value = "ok"
         self.async_write_ha_state()
 

--- a/custom_components/home_generative_agent/flows/sentinel_subentry_flow.py
+++ b/custom_components/home_generative_agent/flows/sentinel_subentry_flow.py
@@ -34,6 +34,8 @@ from ..const import (  # noqa: TID252
     CONF_SENTINEL_BASELINE_DOW_MIN_SAMPLES,
     CONF_SENTINEL_BASELINE_ENABLED,
     CONF_SENTINEL_BASELINE_FRESHNESS_THRESHOLD_SECONDS,
+    CONF_SENTINEL_BASELINE_MIN_SAMPLES,
+    CONF_SENTINEL_BASELINE_SUSTAINED_MINUTES,
     CONF_SENTINEL_BASELINE_UPDATE_INTERVAL_MINUTES,
     CONF_SENTINEL_BASELINE_WEEKLY_PATTERNS,
     CONF_SENTINEL_CAMERA_ENTRY_LINKS,
@@ -56,6 +58,8 @@ from ..const import (  # noqa: TID252
     RECOMMENDED_SENTINEL_BASELINE_DOW_MIN_SAMPLES,
     RECOMMENDED_SENTINEL_BASELINE_ENABLED,
     RECOMMENDED_SENTINEL_BASELINE_FRESHNESS_THRESHOLD_SECONDS,
+    RECOMMENDED_SENTINEL_BASELINE_MIN_SAMPLES,
+    RECOMMENDED_SENTINEL_BASELINE_SUSTAINED_MINUTES,
     RECOMMENDED_SENTINEL_BASELINE_UPDATE_INTERVAL_MINUTES,
     RECOMMENDED_SENTINEL_BASELINE_WEEKLY_PATTERNS,
     RECOMMENDED_SENTINEL_CAMERA_ENTRY_LINKS,
@@ -127,6 +131,10 @@ def _default_payload() -> dict[str, Any]:
         ),
         CONF_SENTINEL_BASELINE_FRESHNESS_THRESHOLD_SECONDS: (
             RECOMMENDED_SENTINEL_BASELINE_FRESHNESS_THRESHOLD_SECONDS
+        ),
+        CONF_SENTINEL_BASELINE_MIN_SAMPLES: RECOMMENDED_SENTINEL_BASELINE_MIN_SAMPLES,
+        CONF_SENTINEL_BASELINE_SUSTAINED_MINUTES: (
+            RECOMMENDED_SENTINEL_BASELINE_SUSTAINED_MINUTES
         ),
         CONF_EXPLAIN_ENABLED: RECOMMENDED_EXPLAIN_ENABLED,
         CONF_SENTINEL_REQUIRE_PIN_FOR_LEVEL_INCREASE: (
@@ -264,6 +272,24 @@ class SentinelSubentryFlow(ConfigSubentryFlow):
                     )
                 ),
             ): NumberSelector(NumberSelectorConfig(min=1, max=52, step=1)),
+            vol.Required(
+                CONF_SENTINEL_BASELINE_MIN_SAMPLES,
+                default=int(
+                    payload.get(
+                        CONF_SENTINEL_BASELINE_MIN_SAMPLES,
+                        RECOMMENDED_SENTINEL_BASELINE_MIN_SAMPLES,
+                    )
+                ),
+            ): NumberSelector(NumberSelectorConfig(min=1, max=500, step=1)),
+            vol.Required(
+                CONF_SENTINEL_BASELINE_SUSTAINED_MINUTES,
+                default=int(
+                    payload.get(
+                        CONF_SENTINEL_BASELINE_SUSTAINED_MINUTES,
+                        RECOMMENDED_SENTINEL_BASELINE_SUSTAINED_MINUTES,
+                    )
+                ),
+            ): NumberSelector(NumberSelectorConfig(min=0, max=120, step=5)),
             vol.Required(
                 CONF_EXPLAIN_ENABLED,
                 default=bool(

--- a/custom_components/home_generative_agent/manifest.json
+++ b/custom_components/home_generative_agent/manifest.json
@@ -33,5 +33,5 @@
     "transformers==4.57.1",
     "langchain-google-genai==3.1.0"
   ],
-  "version": "3.10.0"
+  "version": "3.11.0"
 }

--- a/custom_components/home_generative_agent/sentinel/baseline.py
+++ b/custom_components/home_generative_agent/sentinel/baseline.py
@@ -83,6 +83,25 @@ COMPLETION_RECENCY_SECS = 900
 # regardless of the configured threshold_pct.
 MINIMUM_POWER_DEVIATION_WATTS = 50.0
 
+# Entities that exhibit normal high-power cycling and should be gated by the
+# sustained deviation gate before firing baseline_deviation or time_of_day_anomaly
+# notifications.  Distinct from _APPLIANCE_HINTS (cycle-completion detection).
+#
+# v1 scope: unambiguous cyclers only.  HVAC/heat/AC/water-heater hints are
+# deferred because they can also indicate genuine away-energy anomalies.
+#
+# Matching uses dot-and-word-boundary-aware tokenisation in _is_cyclical():
+# re.split(r"[._\s]+", entity_id) so sensor.refrigerator_power correctly
+# produces the token "refrigerator".
+CYCLICAL_LOAD_HINTS: frozenset[str] = frozenset(
+    {
+        "fridge",
+        "refrigerator",
+        "freezer",
+        "compressor",
+    }
+)
+
 # Entity-name keywords that identify dedicated appliance circuits.  Only these
 # entities qualify for completion detection; generic power sensors (UPS, fridge,
 # whole-home, server rack) are intentionally excluded.

--- a/custom_components/home_generative_agent/sentinel/engine.py
+++ b/custom_components/home_generative_agent/sentinel/engine.py
@@ -708,6 +708,17 @@ class SentinelEngine:
                 continue
 
             elapsed = (now - first_seen).total_seconds() / 60.0
+            if elapsed < 0:
+                # Clock went backward (NTP correction, VM migration).  Reset
+                # the gate clock to avoid permanent suppression.
+                LOGGER.warning(
+                    "Cyclical gate: clock skew detected for %s "
+                    "(elapsed=%.1f min); resetting gate clock.",
+                    entity_id,
+                    elapsed,
+                )
+                self._cyclical_deviation_above_since[entity_id] = now
+                continue
             if elapsed < sustained_minutes:
                 # Still within the gate window — suppress.
                 LOGGER.debug(

--- a/custom_components/home_generative_agent/sentinel/engine.py
+++ b/custom_components/home_generative_agent/sentinel/engine.py
@@ -605,6 +605,12 @@ class SentinelEngine:
     # Cyclical load sustained deviation gate
     # ---------------------------------------------------------------------- #
 
+    # Template IDs subject to the cyclical load gate.  Any new dynamic rule
+    # template that represents a deviation-style alert (not a point-in-time
+    # anomaly) should be added here so cyclical entities are gated correctly.
+    # Template IDs are defined in sentinel/dynamic_rules.py (TEMPLATE_ID
+    # constants) and sentinel/baseline.py (evaluate_baseline_deviation /
+    # evaluate_time_of_day_anomaly).
     _GATED_TEMPLATE_IDS: frozenset[str] = frozenset(
         {"baseline_deviation", "time_of_day_anomaly"}
     )
@@ -670,12 +676,18 @@ class SentinelEngine:
 
             # Determine the entity_id for gate tracking.  Use the first entry
             # in triggering_entities (baseline rules always produce a single-
-            # entity finding).
-            entity_id = (
-                finding.triggering_entities[0]
-                if finding.triggering_entities
-                else finding.anomaly_id
-            )
+            # entity finding).  If the list is empty, pass the finding through
+            # unchanged — tokenising the anomaly_id would be unreliable and
+            # could produce false positive or false negative gate matches.
+            if not finding.triggering_entities:
+                LOGGER.warning(
+                    "Cyclical gate: finding %s has no triggering_entities; "
+                    "skipping gate for this finding.",
+                    finding.anomaly_id,
+                )
+                passed.append(finding)
+                continue
+            entity_id = finding.triggering_entities[0]
             friendly_name = finding.evidence.get("friendly_name", "")
 
             if not _is_cyclical(entity_id, str(friendly_name)):

--- a/custom_components/home_generative_agent/sentinel/engine.py
+++ b/custom_components/home_generative_agent/sentinel/engine.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import re
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, cast
 
@@ -22,6 +23,7 @@ from custom_components.home_generative_agent.const import (
     CONF_SENTINEL_AUTONOMY_LEVEL,
     CONF_SENTINEL_BASELINE_DOW_MIN_SAMPLES,
     CONF_SENTINEL_BASELINE_DRIFT_THRESHOLD_PCT,
+    CONF_SENTINEL_BASELINE_SUSTAINED_MINUTES,
     CONF_SENTINEL_BASELINE_WEEKLY_PATTERNS,
     CONF_SENTINEL_CAMERA_ENTRY_LINKS,
     CONF_SENTINEL_COOLDOWN_MINUTES,
@@ -40,6 +42,7 @@ from custom_components.home_generative_agent.const import (
     RECOMMENDED_SENTINEL_AUTONOMY_LEVEL,
     RECOMMENDED_SENTINEL_BASELINE_DOW_MIN_SAMPLES,
     RECOMMENDED_SENTINEL_BASELINE_DRIFT_THRESHOLD_PCT,
+    RECOMMENDED_SENTINEL_BASELINE_SUSTAINED_MINUTES,
     RECOMMENDED_SENTINEL_BASELINE_WEEKLY_PATTERNS,
     RECOMMENDED_SENTINEL_PENDING_PROMPT_TTL_MINUTES,
     RECOMMENDED_SENTINEL_PRESENCE_GRACE_MINUTES,
@@ -53,6 +56,7 @@ from custom_components.home_generative_agent.snapshot.builder import (
     async_build_full_state_snapshot,
 )
 
+from .baseline import CYCLICAL_LOAD_HINTS
 from .correlator import SentinelCorrelator
 from .dynamic_rules import evaluate_dynamic_rules
 from .execution import (
@@ -141,6 +145,25 @@ def _anomaly_type_for_state(entity_id: str, new_state: State) -> str | None:
     return None
 
 
+def _is_cyclical(entity_id: str, friendly_name: str) -> bool:
+    """
+    Return True if this entity is a known normal high-power cycler.
+
+    Splits on dots, underscores, and spaces so that entity IDs like
+    ``sensor.refrigerator_power`` correctly tokenise to ``{"sensor",
+    "refrigerator", "power"}``.  Matching is token-exact (no substring),
+    which prevents short hints from matching unrelated tokens.
+
+    Entities matching CYCLICAL_LOAD_HINTS undergo the sustained deviation gate
+    before firing baseline_deviation or time_of_day_anomaly findings.
+    """
+    tokens = set(
+        re.split(r"[._\s]+", entity_id.lower())
+        + re.split(r"[._\s]+", friendly_name.lower())
+    )
+    return bool(tokens & CYCLICAL_LOAD_HINTS)
+
+
 class SentinelEngine:
     """Periodic sentinel evaluation loop."""
 
@@ -196,6 +219,12 @@ class SentinelEngine:
         # Presence tracking for grace-window registration.
         # Stores the set of person entity IDs known to be home from the last run.
         self._last_people_home: set[str] = set()
+        # Cyclical load sustained deviation gate (Sprint 4).
+        # Maps entity_id -> datetime when entity first exceeded the deviation
+        # threshold in the current sustained episode.  Reset on engine stop.
+        # Note: HA restart clears this dict; the first compressor-on cycle after
+        # restart waits the full sustained_minutes before notifying (acceptable).
+        self._cyclical_deviation_above_since: dict[str, datetime] = {}
         # Run telemetry exposed to SentinelHealthSensor.
         self.run_stats: dict[str, Any] = {}
 
@@ -209,6 +238,17 @@ class SentinelEngine:
         ``learned_suppressions_active``.
         """
         return len(self._suppression.state.learned_cooldown_multipliers)
+
+    @property
+    def cyclical_entities_gated_count(self) -> int:
+        """
+        Count of cyclical entities currently held by the sustained deviation gate.
+
+        Each entry is an entity_id whose deviation finding is being suppressed
+        while waiting for the sustained_minutes threshold to elapse.  Exposed on
+        the health sensor as ``cyclical_entities_gated``.
+        """
+        return len(self._cyclical_deviation_above_since)
 
     # ---------------------------------------------------------------------- #
     # Autonomy level management
@@ -412,7 +452,7 @@ class SentinelEngine:
             self.run_stats["scheduler"] = self._trigger_scheduler.stats
             async_dispatcher_send(self._hass, SIGNAL_SENTINEL_RUN_COMPLETE)
 
-    async def _run_once(self, trigger_source: str = "poll") -> None:  # noqa: PLR0912
+    async def _run_once(self, trigger_source: str = "poll") -> None:  # noqa: PLR0912, PLR0915
         try:
             snapshot = await async_build_full_state_snapshot(self._hass)
         except (ValueError, TypeError, KeyError):
@@ -526,6 +566,14 @@ class SentinelEngine:
                     len(dynamic_rules),
                     len(dynamic_findings),
                 )
+                sustained_minutes = _coerce_int(
+                    self._options.get(CONF_SENTINEL_BASELINE_SUSTAINED_MINUTES),
+                    RECOMMENDED_SENTINEL_BASELINE_SUSTAINED_MINUTES,
+                )
+                if sustained_minutes > 0:
+                    dynamic_findings = self._apply_sustained_gate(
+                        dynamic_findings, now, sustained_minutes
+                    )
                 if dynamic_findings:
                     LOGGER.info(
                         "Sentinel dynamic rules produced %s finding(s).",
@@ -552,6 +600,131 @@ class SentinelEngine:
                 trigger_source=trigger_source,
             )
         LOGGER.debug("Sentinel cycle completed with %s finding(s).", len(all_findings))
+
+    # ---------------------------------------------------------------------- #
+    # Cyclical load sustained deviation gate
+    # ---------------------------------------------------------------------- #
+
+    _GATED_TEMPLATE_IDS: frozenset[str] = frozenset(
+        {"baseline_deviation", "time_of_day_anomaly"}
+    )
+
+    def _apply_sustained_gate(
+        self,
+        findings: list[AnomalyFinding],
+        now: datetime,
+        sustained_minutes: int,
+    ) -> list[AnomalyFinding]:
+        """
+        Apply a sustained-presence gate to cyclical-entity deviation findings.
+
+        For each finding whose ``template_id`` is ``baseline_deviation`` or
+        ``time_of_day_anomaly`` and whose entity matches
+        :data:`CYCLICAL_LOAD_HINTS`:
+
+        * First appearance: record ``now`` in
+          ``_cyclical_deviation_above_since`` and **suppress** the finding
+          (start the clock).
+        * Subsequent appearances while elapsed < ``sustained_minutes``:
+          **suppress** (keep suppressing).
+        * After ``sustained_minutes`` have elapsed: **fire** the finding,
+          reset the clock to ``now`` (so re-fire requires another full
+          duration).
+
+        All other findings pass through unchanged.
+
+        Clock cleanup: after iterating findings, any entity_id that was in
+        ``_cyclical_deviation_above_since`` but did **not** appear in any
+        finding this run is removed (the entity dropped back below threshold).
+        Cleanup runs after gate processing so an entity that rises and falls
+        within a single run is tracked from first rise and cleared at end of
+        that same run.
+
+        Note on semantics: "sustained" means the entity was present in
+        findings on consecutive engine runs, not that it was continuously
+        above threshold for N wall-clock minutes.  At the default 5-minute
+        run cadence the approximation is close enough; document this rather
+        than adding wall-clock gap tracking.
+
+        Note on static rules: this gate is applied only to ``dynamic_findings``
+        from ``evaluate_dynamic_rules()``.  If static baseline rules are ever
+        added, apply the gate to their output as well.
+
+        Note on HA restart: ``_cyclical_deviation_above_since`` is in-memory
+        only and is cleared on restart.  The first compressor-on cycle after
+        restart waits the full ``sustained_minutes`` before notifying.
+        """
+        if sustained_minutes <= 0:
+            return findings
+
+        passed: list[AnomalyFinding] = []
+        # Track which entity_ids appeared in this run's cyclical findings so we
+        # can clear stale entries at the end.
+        seen_cyclical: set[str] = set()
+
+        for finding in findings:
+            template_id = finding.evidence.get("template_id", "")
+            if template_id not in self._GATED_TEMPLATE_IDS:
+                passed.append(finding)
+                continue
+
+            # Determine the entity_id for gate tracking.  Use the first entry
+            # in triggering_entities (baseline rules always produce a single-
+            # entity finding).
+            entity_id = (
+                finding.triggering_entities[0]
+                if finding.triggering_entities
+                else finding.anomaly_id
+            )
+            friendly_name = finding.evidence.get("friendly_name", "")
+
+            if not _is_cyclical(entity_id, str(friendly_name)):
+                passed.append(finding)
+                continue
+
+            seen_cyclical.add(entity_id)
+
+            first_seen = self._cyclical_deviation_above_since.get(entity_id)
+            if first_seen is None:
+                # First time above threshold — start the clock, suppress.
+                self._cyclical_deviation_above_since[entity_id] = now
+                LOGGER.debug(
+                    "Cyclical gate started for %s (sustained_minutes=%d).",
+                    entity_id,
+                    sustained_minutes,
+                )
+                continue
+
+            elapsed = (now - first_seen).total_seconds() / 60.0
+            if elapsed < sustained_minutes:
+                # Still within the gate window — suppress.
+                LOGGER.debug(
+                    "Cyclical gate suppressing %s (%.1f / %d min elapsed).",
+                    entity_id,
+                    elapsed,
+                    sustained_minutes,
+                )
+                continue
+
+            # Gate exceeded — fire and reset clock.
+            LOGGER.info(
+                "Cyclical gate exceeded for %s (%.1f min); firing finding.",
+                entity_id,
+                elapsed,
+            )
+            self._cyclical_deviation_above_since[entity_id] = now
+            passed.append(finding)
+
+        # Remove entries for entities that dropped below threshold this run.
+        # (Not in seen_cyclical means no cyclical finding appeared for them.)
+        stale = set(self._cyclical_deviation_above_since) - seen_cyclical
+        for entity_id in stale:
+            LOGGER.debug(
+                "Cyclical gate cleared for %s (no finding this run).", entity_id
+            )
+            del self._cyclical_deviation_above_since[entity_id]
+
+        return passed
 
     # ---------------------------------------------------------------------- #
     # Presence grace window maintenance

--- a/custom_components/home_generative_agent/strings.json
+++ b/custom_components/home_generative_agent/strings.json
@@ -165,6 +165,8 @@
             "sentinel_baseline_freshness_threshold_seconds": "Baseline freshness threshold (seconds)",
             "sentinel_baseline_weekly_patterns": "Enable day-of-week baselines (reduces weekend false positives)",
             "sentinel_baseline_dow_min_samples": "DOW baseline minimum samples (weeks of data per slot)",
+            "sentinel_baseline_min_samples": "Baseline minimum samples before deviation alerts fire",
+            "sentinel_baseline_sustained_minutes": "Cyclical load gate: minutes above threshold before alerting (0 = disabled)",
             "explain_enabled": "Enable LLM explanations for sentinel findings",
             "sentinel_require_pin_for_level_increase": "Require PIN for autonomy level increases",
             "sentinel_daily_digest_enabled": "Enable daily digest notification",

--- a/custom_components/home_generative_agent/translations/en.json
+++ b/custom_components/home_generative_agent/translations/en.json
@@ -162,6 +162,8 @@
             "sentinel_baseline_freshness_threshold_seconds": "Baseline freshness threshold (seconds)",
             "sentinel_baseline_weekly_patterns": "Enable day-of-week baselines (reduces weekend false positives)",
             "sentinel_baseline_dow_min_samples": "DOW baseline minimum samples (weeks of data per slot)",
+            "sentinel_baseline_min_samples": "Baseline minimum samples before deviation alerts fire",
+            "sentinel_baseline_sustained_minutes": "Cyclical load gate: minutes above threshold before alerting (0 = disabled)",
             "explain_enabled": "Enable LLM explanations for sentinel findings",
             "sentinel_require_pin_for_level_increase": "Require PIN for autonomy level increases",
             "sentinel_daily_digest_enabled": "Enable daily digest notification",

--- a/tests/custom_components/home_generative_agent/test_sentinel_baseline.py
+++ b/tests/custom_components/home_generative_agent/test_sentinel_baseline.py
@@ -2155,3 +2155,86 @@ def test_gate_friendly_name_match() -> None:
     result = SentinelEngine._apply_sustained_gate(engine, [finding], now, 20)
     assert result == [], "friendly_name match should trigger the gate"
     assert "sensor.smart_plug_1_power" in engine._cyclical_deviation_above_since
+
+
+def test_gate_empty_triggering_entities_passes_through() -> None:
+    """Findings with no triggering_entities bypass the gate unchanged."""
+    engine = _make_gate_engine()
+    # Construct a finding whose triggering_entities is empty.  The gate should
+    # not attempt to tokenise anomaly_id and should pass the finding through.
+    finding = AnomalyFinding(
+        anomaly_id="baseline_deviation_refrigerator_energy",
+        type="high_energy_consumption",
+        severity="medium",
+        confidence=0.9,
+        triggering_entities=[],  # empty — gate must skip
+        evidence={"template_id": "baseline_deviation", "friendly_name": ""},
+        suggested_actions=[],
+        is_sensitive=False,
+    )
+    now = _gate_now()
+
+    result = SentinelEngine._apply_sustained_gate(engine, [finding], now, 20)
+    assert result == [finding], "empty triggering_entities must pass through"
+    assert engine._cyclical_deviation_above_since == {}
+
+
+def test_gate_two_cyclical_stale_cleanup() -> None:
+    """When one of two tracked cyclical entities drops, only that clock is cleared."""
+    engine = _make_gate_engine()
+    now = _gate_now()
+    fridge = _make_deviation_finding("sensor.fridge_power", "")
+    freezer = _make_deviation_finding("sensor.freezer_power", "")
+
+    # Run 1: both entities appear; gate starts both clocks.
+    SentinelEngine._apply_sustained_gate(engine, [fridge, freezer], now, 20)
+    assert "sensor.fridge_power" in engine._cyclical_deviation_above_since
+    assert "sensor.freezer_power" in engine._cyclical_deviation_above_since
+
+    # Run 2: only fridge appears; freezer clock must be cleared.
+    later = datetime(2026, 4, 14, 12, 10, 0, tzinfo=UTC)
+    SentinelEngine._apply_sustained_gate(engine, [fridge], later, 20)
+    assert "sensor.fridge_power" in engine._cyclical_deviation_above_since
+    assert "sensor.freezer_power" not in engine._cyclical_deviation_above_since
+
+
+def test_cyclical_entities_gated_count_tracks_state() -> None:
+    """cyclical_entities_gated_count reflects dict size across suppression/cleanup."""
+    engine = _make_gate_engine()
+    assert engine.cyclical_entities_gated_count == 0
+
+    now = _gate_now()
+    finding = _make_deviation_finding("sensor.fridge_power", "")
+
+    # After first gate entry, count should be 1.
+    SentinelEngine._apply_sustained_gate(engine, [finding], now, 20)
+    assert engine.cyclical_entities_gated_count == 1
+
+    # After stale cleanup (no finding this run), count should be 0.
+    later = datetime(2026, 4, 14, 12, 10, 0, tzinfo=UTC)
+    SentinelEngine._apply_sustained_gate(engine, [], later, 20)
+    assert engine.cyclical_entities_gated_count == 0
+
+
+def test_gate_boundary_exactly_at_duration() -> None:
+    """At exactly sustained_minutes elapsed, finding is still suppressed (strict <)."""
+    engine = _make_gate_engine()
+    now = _gate_now()
+    finding = _make_deviation_finding("sensor.fridge_power", "")
+
+    # Seed the clock so that elapsed is exactly sustained_minutes.
+    engine._cyclical_deviation_above_since["sensor.fridge_power"] = datetime(
+        2026,
+        4,
+        14,
+        11,
+        40,
+        0,
+        tzinfo=UTC,  # 20 minutes before _gate_now()
+    )
+
+    result = SentinelEngine._apply_sustained_gate(engine, [finding], now, 20)
+    # elapsed == 20.0, sustained_minutes == 20 → elapsed < 20 is False → fires.
+    # This documents the contract: the gate uses strict-less-than, so exactly
+    # at the threshold the finding IS fired (not suppressed).
+    assert result == [finding], "finding at exactly threshold should fire"

--- a/tests/custom_components/home_generative_agent/test_sentinel_baseline.py
+++ b/tests/custom_components/home_generative_agent/test_sentinel_baseline.py
@@ -2238,3 +2238,26 @@ def test_gate_boundary_exactly_at_duration() -> None:
     # This documents the contract: the gate uses strict-less-than, so exactly
     # at the threshold the finding IS fired (not suppressed).
     assert result == [finding], "finding at exactly threshold should fire"
+
+
+def test_gate_clock_skew_resets_clock() -> None:
+    """Negative elapsed (clock went backward) resets the gate clock; finding suppressed."""
+    engine = _make_gate_engine()
+    now = _gate_now()
+    finding = _make_deviation_finding("sensor.fridge_power", "")
+
+    # Seed the clock AFTER now (clock went backward since last run).
+    engine._cyclical_deviation_above_since["sensor.fridge_power"] = datetime(
+        2026,
+        4,
+        14,
+        13,
+        0,
+        0,
+        tzinfo=UTC,  # 1 hour in the future relative to now
+    )
+
+    result = SentinelEngine._apply_sustained_gate(engine, [finding], now, 20)
+    assert result == [], "clock skew must suppress (not fire) and reset the clock"
+    # Clock should be reset to now, not left at the future timestamp.
+    assert engine._cyclical_deviation_above_since["sensor.fridge_power"] == now

--- a/tests/custom_components/home_generative_agent/test_sentinel_baseline.py
+++ b/tests/custom_components/home_generative_agent/test_sentinel_baseline.py
@@ -2123,3 +2123,35 @@ def test_gate_dot_split_entity_id() -> None:
 
     result = SentinelEngine._apply_sustained_gate(engine, [finding], now, 20)
     assert result == [], "sensor.refrigerator_power should be gated (dot-split match)"
+
+
+def test_gate_non_gated_template_passes_through() -> None:
+    """Findings with unrecognised template_id are not gated, even for cyclical entities."""
+    engine = _make_gate_engine()
+    # Use a cyclical entity but a template that is NOT in _GATED_TEMPLATE_IDS.
+    finding = _make_deviation_finding(
+        "sensor.fridge_power",
+        "Fridge",
+        template_id="appliance_power_duration",
+    )
+    now = _gate_now()
+
+    result = SentinelEngine._apply_sustained_gate(engine, [finding], now, 20)
+    assert len(result) == 1, (
+        "Non-gated template_id must pass through even for cyclical entity"
+    )
+    assert result[0] is finding
+    assert engine._cyclical_deviation_above_since == {}
+
+
+def test_gate_friendly_name_match() -> None:
+    """Gate activates when entity_id has no hint token but friendly_name does."""
+    engine = _make_gate_engine()
+    # entity_id is a generic plug — no cyclical hint.
+    # friendly_name contains "fridge" — should match.
+    finding = _make_deviation_finding("sensor.smart_plug_1_power", "Fridge Power")
+    now = _gate_now()
+
+    result = SentinelEngine._apply_sustained_gate(engine, [finding], now, 20)
+    assert result == [], "friendly_name match should trigger the gate"
+    assert "sensor.smart_plug_1_power" in engine._cyclical_deviation_above_since

--- a/tests/custom_components/home_generative_agent/test_sentinel_baseline.py
+++ b/tests/custom_components/home_generative_agent/test_sentinel_baseline.py
@@ -30,6 +30,7 @@ from custom_components.home_generative_agent.sentinel.baseline import (
     evaluate_baseline_deviation,
     evaluate_time_of_day_anomaly,
 )
+from custom_components.home_generative_agent.sentinel.engine import SentinelEngine
 from custom_components.home_generative_agent.sentinel.models import AnomalyFinding
 
 if TYPE_CHECKING:
@@ -1975,3 +1976,150 @@ async def test_async_initialize_reconstructs_dow_state_from_db() -> None:
     # m2 = stddev**2 * (count - 1) = 10**2 * 4 = 400.
     expected_m2 = 10.0**2 * (5 - 1)
     assert reconstructed_m2 == pytest.approx(expected_m2)
+
+
+# ---------------------------------------------------------------------------
+# Cyclical load sustained deviation gate tests
+# ---------------------------------------------------------------------------
+# These tests exercise SentinelEngine._apply_sustained_gate() directly.
+# To avoid instantiating the full engine (which requires hass, suppression,
+# notifier, etc.) we create a minimal uninitialized instance and seed only
+# the attributes the method accesses.
+
+
+def _make_gate_engine() -> SentinelEngine:
+    """Return a minimal SentinelEngine with only gate-relevant state populated."""
+    engine = object.__new__(SentinelEngine)
+    engine._cyclical_deviation_above_since = {}
+    return engine
+
+
+def _make_deviation_finding(
+    entity_id: str,
+    friendly_name: str = "",
+    template_id: str = "baseline_deviation",
+) -> AnomalyFinding:
+    """Construct a minimal AnomalyFinding for gate testing."""
+    return AnomalyFinding(
+        anomaly_id=f"test_{entity_id}",
+        type="high_energy_consumption",
+        severity="medium",
+        confidence=0.9,
+        triggering_entities=[entity_id],
+        evidence={
+            "template_id": template_id,
+            "friendly_name": friendly_name,
+        },
+        suggested_actions=[],
+        is_sensitive=False,
+    )
+
+
+def _gate_now() -> datetime:
+    return datetime(2026, 4, 14, 12, 0, 0, tzinfo=UTC)
+
+
+def test_gate_suppresses_below_duration() -> None:
+    """Entity above threshold for < sustained_minutes → finding suppressed."""
+    engine = _make_gate_engine()
+    finding = _make_deviation_finding("sensor.fridge_power", "Fridge")
+    now = _gate_now()
+
+    # First call: clock starts, finding suppressed.
+    result = SentinelEngine._apply_sustained_gate(engine, [finding], now, 20)
+    assert result == [], "First appearance should be suppressed (clock started)"
+
+    # Advance 10 minutes — still below 20-minute gate.
+    later = now + timedelta(minutes=10)
+    result = SentinelEngine._apply_sustained_gate(engine, [finding], later, 20)
+    assert result == [], "10 min elapsed < 20 min gate — still suppressed"
+
+
+def test_gate_fires_after_duration() -> None:
+    """Entity above threshold for >= sustained_minutes → finding fires."""
+    engine = _make_gate_engine()
+    finding = _make_deviation_finding("sensor.refrigerator_power", "Refrigerator")
+    now = _gate_now()
+
+    # Seed the clock as if it started 21 minutes ago.
+    entity_id = finding.triggering_entities[0]
+    engine._cyclical_deviation_above_since[entity_id] = now - timedelta(minutes=21)
+
+    result = SentinelEngine._apply_sustained_gate(engine, [finding], now, 20)
+    assert len(result) == 1, "Gate exceeded — finding should fire"
+    assert result[0] is finding
+
+    # Clock should have been reset to now.
+    assert engine._cyclical_deviation_above_since[entity_id] == now
+
+
+def test_gate_clears_when_entity_absent() -> None:
+    """Entity drops below threshold → clock cleared; next cycle waits full duration."""
+    engine = _make_gate_engine()
+    finding = _make_deviation_finding("sensor.freezer_power", "Freezer")
+    now = _gate_now()
+
+    # Seed the clock.
+    entity_id = finding.triggering_entities[0]
+    engine._cyclical_deviation_above_since[entity_id] = now - timedelta(minutes=5)
+
+    # Run with an empty findings list — entity has dropped below threshold.
+    result = SentinelEngine._apply_sustained_gate(engine, [], now, 20)
+    assert result == []
+    assert entity_id not in engine._cyclical_deviation_above_since
+
+    # Next appearance restarts clock — should be suppressed again.
+    result = SentinelEngine._apply_sustained_gate(engine, [finding], now, 20)
+    assert result == [], "Clock reset — should be suppressed from scratch"
+
+
+def test_gate_applies_to_time_of_day_anomaly() -> None:
+    """time_of_day_anomaly findings for cyclical entities are gated."""
+    engine = _make_gate_engine()
+    finding = _make_deviation_finding(
+        "sensor.fridge_energy",
+        "Fridge",
+        template_id="time_of_day_anomaly",
+    )
+    now = _gate_now()
+
+    result = SentinelEngine._apply_sustained_gate(engine, [finding], now, 20)
+    assert result == [], "time_of_day_anomaly for cyclical entity should be gated"
+    assert "sensor.fridge_energy" in engine._cyclical_deviation_above_since
+
+
+def test_gate_passes_non_cyclical_entity() -> None:
+    """Non-cyclical entity findings pass through the gate unchanged."""
+    engine = _make_gate_engine()
+    finding = _make_deviation_finding("sensor.living_room_tv_power", "TV")
+    now = _gate_now()
+
+    result = SentinelEngine._apply_sustained_gate(engine, [finding], now, 20)
+    assert len(result) == 1, "Non-cyclical entity should pass through unchanged"
+    assert result[0] is finding
+    assert engine._cyclical_deviation_above_since == {}
+
+
+def test_gate_disabled_when_zero() -> None:
+    """sustained_minutes = 0 → gate disabled; all findings pass through unchanged."""
+    engine = _make_gate_engine()
+    fridge_finding = _make_deviation_finding("sensor.fridge_power", "Fridge")
+    tv_finding = _make_deviation_finding("sensor.tv_power", "TV")
+    now = _gate_now()
+
+    result = SentinelEngine._apply_sustained_gate(
+        engine, [fridge_finding, tv_finding], now, 0
+    )
+    assert len(result) == 2, "sustained_minutes=0 — all findings should pass through"
+    assert engine._cyclical_deviation_above_since == {}
+
+
+def test_gate_dot_split_entity_id() -> None:
+    """Entity IDs with dots (sensor.refrigerator_power) match CYCLICAL_LOAD_HINTS."""
+    engine = _make_gate_engine()
+    # 'refrigerator' should match after splitting on the dot.
+    finding = _make_deviation_finding("sensor.refrigerator_power", "")
+    now = _gate_now()
+
+    result = SentinelEngine._apply_sustained_gate(engine, [finding], now, 20)
+    assert result == [], "sensor.refrigerator_power should be gated (dot-split match)"


### PR DESCRIPTION
## Summary

- **Stops fridge/compressor notification spam** — a new sustained deviation gate suppresses `baseline_deviation` and `time_of_day_anomaly` findings for refrigerators, freezers, and compressors until the entity has been continuously above the deviation threshold for a configurable duration (default 20 minutes). Normal compressor cycling (~944 W on/off every 30 min) no longer fires repeated "High energy consumption away" alerts.
- **Baseline minimum samples now configurable in the UI** — the "Baseline minimum samples" setting is exposed in the Sentinel config flow (range 1–500, default 20). Previously required editing config entries directly.
- **Health sensor reports gated entity count** — `cyclical_entities_gated` attribute on the Sentinel health sensor shows how many cyclical entities are currently held by the gate.

## Changes

| File | Change |
|------|--------|
| `sentinel/engine.py` | `_apply_sustained_gate()`, `_is_cyclical()`, `cyclical_entities_gated_count` property; clock-skew guard |
| `sentinel/baseline.py` | `CYCLICAL_LOAD_HINTS` frozenset (`fridge`, `refrigerator`, `freezer`, `compressor`) |
| `const.py` | `CONF_SENTINEL_BASELINE_SUSTAINED_MINUTES`, `RECOMMENDED_SENTINEL_BASELINE_SUSTAINED_MINUTES` |
| `flows/sentinel_subentry_flow.py` | Two new `NumberSelector` fields: `baseline_min_samples` and `sustained_minutes` |
| `core/sentinel_health_sensor.py` | `cyclical_entities_gated` health sensor attribute |
| `strings.json` / `translations/en.json` | UI labels for new fields |
| `tests/test_sentinel_baseline.py` | 13 gate tests: suppression, firing, stale cleanup, boundary, clock skew, friendly-name match, empty triggering_entities |
| `CHANGELOG.md` / `manifest.json` | v3.11.0 |

## Design notes

- **v1 scope is intentionally narrow** — HVAC/heat/AC/water-heater hints are deferred because an HVAC running at 3am in away mode IS a genuine anomaly worth surfacing. Only unambiguous cyclers (fridge/freezer/compressor) are gated.
- **Run-presence semantics** — "sustained" means the entity appeared in findings on N consecutive engine runs spanning ≥ `sustained_minutes` wall-clock minutes, not that it was continuously sampled. At the default 5-min cadence the approximation is accurate enough.
- **Clock-skew resilient** — negative elapsed (NTP correction, VM migration) resets the gate clock and logs a warning rather than causing permanent suppression.
- **Static rules exempt** — the gate applies only to `dynamic_findings` from `evaluate_dynamic_rules()`. The docstring notes where to apply it if static baseline rules are added.

## Test plan

- [x] `make lint` — clean
- [x] `make typecheck` — 0 errors
- [x] `make test` — 739 passed
- [x] 13 gate-specific unit tests covering: suppress below duration, fire after duration, stale clock cleanup, TOD anomaly, non-cyclical passthrough, disabled (0 minutes), dot-split entity ID, non-gated template passthrough, friendly-name match, empty triggering_entities, two-entity stale cleanup, gated count property, exact boundary, clock skew reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)