### PR TITLE
feat: populate HA 2026.4.0 chatlog for Show Details transparency (#369)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.11.1] - 2026-04-16
+
+### Added
+
+- **HA 2026.4.0 chatlog transparency (Show Details)** — HGA now populates the
+  HA conversation chatlog after each agent turn, enabling HA's "Show Details"
+  panel to display the full tool call / result chain. Each intermediate tool
+  call (with arguments) and its result are visible as typed chatlog entries.
+  Requires HA 2026.4.0 or later. Closes #369.
+
 ## [3.11.0] - 2026-04-14
 
 ### Added

--- a/custom_components/home_generative_agent/conversation.py
+++ b/custom_components/home_generative_agent/conversation.py
@@ -163,7 +163,7 @@ def _populate_chat_log_from_response(
                     llm.ToolInput(
                         tool_name=tc["name"],
                         tool_args=tc["args"],
-                        id=tc["id"],
+                        id=tc["id"] or ulid.ulid_now(),
                         external=True,
                     )
                     for tc in msg.tool_calls

--- a/custom_components/home_generative_agent/conversation.py
+++ b/custom_components/home_generative_agent/conversation.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.util import ulid
 from langchain_core.caches import InMemoryCache
 from langchain_core.globals import set_debug, set_llm_cache, set_verbose
-from langchain_core.messages import AIMessage, AnyMessage, HumanMessage
+from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, ToolMessage
 from pydantic import PydanticInvalidForJsonSchema
 
 from .agent.graph import workflow
@@ -67,6 +67,7 @@ if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
+    from homeassistant.util.json import JsonObjectType
     from langchain_core.runnables import RunnableConfig
 
     from .agent.graph import State
@@ -89,13 +90,107 @@ else:
 def _convert_content(
     content: conversation.UserContent | conversation.AssistantContent,
 ) -> HumanMessage | AIMessage:
-    """Convert HA native chat messages to LangChain messages."""
-    if content.content is None:
-        _LOGGER.warning("Content is None, returning empty message")
-        return HumanMessage(content="")
+    """
+    Convert HA native chat messages to LangChain messages.
+
+    Only called with UserContent or tool-call-free AssistantContent (filtered
+    upstream — see message_history comprehension in _async_handle_message).
+    """
     if isinstance(content, conversation.UserContent):
-        return HumanMessage(content=content.content)
-    return AIMessage(content=content.content)
+        return HumanMessage(content=content.content or "")
+    return AIMessage(content=content.content or "")
+
+
+def _normalize_ai_content(content: str | list) -> str | None:
+    """
+    Normalize AIMessage.content to str for HA AssistantContent.
+
+    AIMessage.content is str for most providers, or list[dict] (content blocks) for
+    providers that return structured output (e.g. Anthropic). Extracts text blocks
+    only; returns None if the result is empty.
+    """
+    if isinstance(content, str):
+        return content or None
+    parts = [
+        block.get("text", "")
+        for block in content
+        if isinstance(block, dict) and block.get("type") == "text"
+    ]
+    return "\n".join(parts) or None
+
+
+def _normalize_tool_result(content: str | list) -> JsonObjectType:
+    """
+    Normalize ToolMessage.content to JsonObjectType for HA ToolResultContent.
+
+    ToolMessage.content is str for plain string results, or list[dict] (content blocks)
+    from some providers. HA ToolResultContent.tool_result requires JsonObjectType.
+    """
+    if isinstance(content, str):
+        return {"result": content}
+    parts = [
+        block.get("text", "") if isinstance(block, dict) else str(block)
+        for block in content
+    ]
+    return {"result": "\n".join(parts)}
+
+
+def _populate_chat_log_from_response(
+    chat_log: conversation.ChatLog,
+    agent_id: str,
+    new_messages: list[AnyMessage],
+) -> None:
+    """
+    Backfill chat_log with LangGraph response messages for HA Show Details.
+
+    Walks new_messages (messages produced this turn, sliced from
+    response["messages"][len(app_input["messages"]):]) and appends AssistantContent
+    and ToolResultContent entries so HA's "Show Details" panel renders the full tool
+    call / result chain.
+
+    All ToolInput entries use external=True because LangGraph, not HA, executed the
+    tools. async_add_assistant_content_without_tools() raises ValueError if any
+    ToolInput has external=False.
+
+    chat_log state is not persisted across HA restarts. The LangGraph PostgreSQL
+    checkpointer holds the full conversation history; chat_log is repopulated each
+    turn from the ainvoke() response slice.
+    """
+    for msg in new_messages:
+        if isinstance(msg, AIMessage):
+            if msg.tool_calls:
+                tool_inputs = [
+                    llm.ToolInput(
+                        tool_name=tc["name"],
+                        tool_args=tc["args"],
+                        id=tc["id"],
+                        external=True,
+                    )
+                    for tc in msg.tool_calls
+                ]
+                chat_log.async_add_assistant_content_without_tools(
+                    conversation.AssistantContent(
+                        agent_id=agent_id,
+                        content=_normalize_ai_content(msg.content),
+                        tool_calls=tool_inputs,
+                    )
+                )
+            else:
+                chat_log.async_add_assistant_content_without_tools(
+                    conversation.AssistantContent(
+                        agent_id=agent_id,
+                        content=_normalize_ai_content(msg.content),
+                    )
+                )
+        elif isinstance(msg, ToolMessage):
+            chat_log.async_add_assistant_content_without_tools(
+                conversation.ToolResultContent(
+                    agent_id=agent_id,
+                    tool_call_id=msg.tool_call_id,
+                    tool_name=msg.name or "",
+                    tool_result=_normalize_tool_result(msg.content),
+                )
+            )
 
 
 class MultiLLMAPI:
@@ -235,7 +330,7 @@ class HGAConversationEntity(conversation.ConversationEntity, AbstractConversatio
         """Return a list of supported languages."""
         return MATCH_ALL
 
-    async def _async_handle_message(  # noqa: PLR0912, PLR0915
+    async def _async_handle_message(  # noqa: PLR0911, PLR0912, PLR0915
         self,
         user_input: conversation.ConversationInput,
         chat_log: conversation.ChatLog,
@@ -256,10 +351,14 @@ class HGAConversationEntity(conversation.ConversationEntity, AbstractConversatio
         )
 
         # Include only HA User/Assistant messages not already seen by this entity.
+        # Exclude AssistantContent with tool_calls: those are intermediate LangGraph
+        # turns already persisted in the PostgreSQL checkpointer. Including them would
+        # duplicate messages that LangGraph already manages internally.
         message_history = [
             _convert_content(m)
             for m in chat_log.content
-            if isinstance(m, conversation.UserContent | conversation.AssistantContent)
+            if isinstance(m, conversation.UserContent)
+            or (isinstance(m, conversation.AssistantContent) and m.tool_calls is None)
         ]
         # The last chat log entry will be the current user request—add it later.
         message_history = message_history[:-1]
@@ -499,7 +598,7 @@ class HGAConversationEntity(conversation.ConversationEntity, AbstractConversatio
 
         _LOGGER.debug("====== End of run ======")
 
-        intent_response = intent.IntentResponse(language=user_input.language)
+        # Post-process the final LLM text (entity ID resolution, YAML conversion).
         final_content = response["messages"][-1].content
         if isinstance(final_content, str):
             if options.get(CONF_SCHEMA_FIRST_YAML, False):
@@ -510,10 +609,44 @@ class HGAConversationEntity(conversation.ConversationEntity, AbstractConversatio
                 final_content, options.get(CONF_SCHEMA_FIRST_YAML, False)
             )
             _LOGGER.debug("Final response content: %s", final_content)
-        intent_response.async_set_speech(final_content)
-        return conversation.ConversationResult(
-            response=intent_response, conversation_id=conversation_id
-        )
+
+        # Backfill chat_log with the messages produced this turn so HA's
+        # "Show Details" panel renders the full tool call / result chain.
+        # Slice off history + current HumanMessage — only net-new messages.
+        new_messages = response["messages"][len(app_input["messages"]) :]
+
+        # Guard: async_get_result_from_chat_log requires last entry is AssistantContent,
+        # which means the last new message must be an AIMessage.
+        if not new_messages or not isinstance(new_messages[-1], AIMessage):
+            _LOGGER.error(
+                "LangGraph response did not end with AIMessage (got %s). "
+                "Falling back to manual ConversationResult.",
+                type(new_messages[-1]) if new_messages else "empty",
+            )
+            intent_response = intent.IntentResponse(language=user_input.language)
+            intent_response.async_set_speech(
+                final_content if isinstance(final_content, str) else ""
+            )
+            return conversation.ConversationResult(
+                response=intent_response, conversation_id=conversation_id
+            )
+
+        # Replace the final AIMessage content with the post-processed text so
+        # Show Details reflects the same text the user hears.
+        if isinstance(final_content, str):
+            processed_messages: list[AnyMessage] = [
+                *new_messages[:-1],
+                AIMessage(
+                    content=final_content,
+                    tool_calls=new_messages[-1].tool_calls,
+                ),
+            ]
+        else:
+            processed_messages = list(new_messages)
+
+        _populate_chat_log_from_response(chat_log, self.entity_id, processed_messages)
+
+        return conversation.async_get_result_from_chat_log(user_input, chat_log)
 
     async def _async_discover_provider_tools(
         self,

--- a/custom_components/home_generative_agent/manifest.json
+++ b/custom_components/home_generative_agent/manifest.json
@@ -33,5 +33,5 @@
     "transformers==4.57.1",
     "langchain-google-genai==3.1.0"
   ],
-  "version": "3.11.0"
+  "version": "3.11.1"
 }


### PR DESCRIPTION
## Summary

Populates HA 2026.4.0 `ChatLog` after each `ainvoke()` turn so the HA conversation chat log preserves the full agent reasoning chain.

**New functions in `conversation.py`:**
- `_normalize_ai_content()` — normalizes `AIMessage.content` (`str | list`) to `str | None` for `AssistantContent`
- `_normalize_tool_result()` — wraps `ToolMessage.content` in `JsonObjectType` for `ToolResultContent`
- `_populate_chat_log_from_response()` — walks net-new LangGraph messages and appends `AssistantContent` (with `external=True` ToolInputs) and `ToolResultContent` via `async_add_assistant_content_without_tools()`

**Changed:**
- Message history filter now excludes `AssistantContent` with `tool_calls` — prevents ghost messages in LangGraph input on subsequent turns (PostgreSQL checkpointer already holds intermediate turns)
- Return path switched from manual `intent_response.async_set_speech()` to `conversation.async_get_result_from_chat_log()` — correct HA 2026.4.0 protocol
- `ToolInput.id` guards against `None` from LangChain tool_call dict (pyright fix)

Closes #369. Part 1 of #368. Part 2 (native streaming) tracked as #370.

## Test Coverage

Verified manually via HA debug-level logs — `Adding assistant content:` entries appear for each tool call and result after every agent turn. 739 existing tests pass.

New unit tests for the helper functions (`_normalize_ai_content`, `_normalize_tool_result`, `_populate_chat_log_from_response`) deferred to follow-up — they are pure functions with no external dependencies, straightforward to add.

## Pre-Landing Review

No critical issues. Two informational notes:
- `_normalize_tool_result` list path joins all block types (not just text) — acceptable, display-only
- `response["messages"][-1]` accessed before empty guard — unreachable in practice (LangGraph always appends ≥1 message)

## Plan Completion

CEO plan: `~/.gstack/projects/goruck-home-generative-agent/ceo-plans/2026-04-15-chatlog-show-details.md`

All accepted scope items implemented:
- ✅ Walk `new_messages` after `ainvoke()`, populate chatlog
- ✅ Fix `_convert_content` filter to exclude tool-call `AssistantContent`
- ✅ Return via `conversation.async_get_result_from_chat_log()`

## Test plan
- [x] 739 existing tests pass
- [x] Manual integration test: HA debug logs confirm `Adding assistant content:` fires per tool call/result
- [x] Multi-tool turn verified (time lookup + light control + camera check in one request)

🤖 Generated with [Claude Code](https://claude.com/claude-code)