### PR TITLE
feat: native LLM streaming via astream_events + HA ChatLog delta (v3.12.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.12.0] - 2026-04-21
+
+### Added
+
+- **Native LLM streaming** — HGA now streams assistant tokens to the HA frontend
+  in real time via `astream_events` + HA ChatLog delta API. Responses appear
+  word-by-word instead of waiting for the full LLM response. Closes #370.
+  Requires HA 2026.4.0 or later.
+
+- **Parallel tool execution** — multiple tool calls within a single model turn
+  now run concurrently via `asyncio.gather`, reducing multi-tool turn latency
+  (e.g. `get_current_time` + `get_and_analyze_camera_image` in parallel).
+
+- **LangChain tool timeout** — each tool call is bounded by a 30-second timeout
+  via `asyncio.wait_for`. Stuck tool calls now produce a descriptive error
+  instead of hanging the conversation indefinitely.
+
+### Changed
+
+- **Protected-action PIN flow hardened** — wrong-PIN entries no longer mark the
+  pending action as resolved. Routing errors on `confirm_sensitive_action` are
+  also treated as unresolved, preventing a bypass when the confirm tool is
+  unavailable. Type annotations for PIN helper functions updated to
+  `Sequence[AnyMessage]` for broader compatibility.
+
+- **Streaming robustness** — LangGraph stream delta synchronization hardened:
+  tool call IDs are correlated across `on_chat_model_end` and `on_chain_end`
+  events; orphaned tool calls are flushed as synthetic rejections on generator
+  exit; partial content is committed and recoverable on stream failure;
+  CONTENT_ADDED is re-fired for the final AssistantContent so the HA frontend
+  streaming UI shows the complete response. Empty chat logs on mid-stream error
+  now produce a safe fallback instead of crashing the turn.
+
+### Fixed
+
+- HA intent-tool results containing `response_type` dict structures no longer
+  produce an empty chat bubble in multi-tool turns.
+
+- JSON tool results are correctly parsed; streaming failures fall back to graph
+  state recovery to avoid empty responses.
+
 ## [3.11.1] - 2026-04-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ These are some of the features currently supported:
 - Short- and long-term memory using semantic search.
 - Automatic summarization of home state to manage LLM context length.
 - Semantic tool retrieval (RAG): tools are embedded at startup and retrieved per-turn by cosine similarity, keeping prompts lean and tool selection accurate.
+- Native LLM streaming: assistant tokens appear in the HA frontend word-by-word via `astream_events` + HA ChatLog delta API (requires HA 2026.4.0 or later).
 
 This integration will set up the `conversation` platform, allowing users to converse directly with the Home Generative Assistant, and the `image` and `sensor` platforms which create entities to display the latest camera image, the AI-generated summary, and recognized people in HA's UI or they can be used to create automations.
 
@@ -969,6 +970,8 @@ Below is a high-level view of the architecture.
 
 The general integration architecture follows the best practices as described in [Home Assistant Core](https://developers.home-assistant.io/docs/development_index/) and is compliant with [Home Assistant Community Store](https://www.hacs.xyz/) (HACS) publishing requirements.
 
+For a deep-dive on the streaming implementation, see [docs/streaming-design.md](docs/streaming-design.md).
+
 The agent is built using LangGraph and uses the HA `conversation` component to interact with the user. The agent uses the Home Assistant LLM API to fetch the state of the home and understand the HA native tools it has at its disposal. I implemented all other tools available to the agent using LangChain. The agent employs several LLMs, a large and very accurate primary model for high-level reasoning, smaller specialized helper models for camera image analysis, primary model context summarization, and embedding generation for long-term semantic search. The models can be either cloud (best accuracy, highest cost) or edge-based (good accuracy, lowest cost). Edge models run under the [Ollama](https://ollama.com/) framework or any OpenAI-compatible server (vLLM, llama.cpp, LiteLLM, etc.) on a computer located in the home. Recommended defaults and supported models are configurable in the integration UI, with defaults defined in `const.py`.
 
 Category | Provider | Default model | Purpose
@@ -997,7 +1000,7 @@ LangGraph powers the conversation agent, enabling you to create stateful, multi-
 
 The agent workflow has four nodes, each Python module modifying the agent's state, a shared data structure. The edges between the nodes represent the allowed transitions between them, with solid lines unconditional and dashed lines conditional. Nodes do the work, and edges tell what to do next.
 
-The ```__start__``` and ```__end__``` nodes inform the graph where to start and stop. The ```retrieve_tools``` node runs first: it queries the vector index to select the tools most relevant to the current message (see [Tool Retrieval](#tool-retrieval-rag) above). The ```agent``` node then runs the primary LLM with only those tools bound to its context, and if it decides to use a tool, the ```action``` node runs the tool and returns control to ```agent```. When the agent does not call a tool, control passes to ```summarize_and_remove_messages```, which summarizes only when trimming is required to manage the LLM context.
+The ```__start__``` and ```__end__``` nodes inform the graph where to start and stop. The ```retrieve_tools``` node runs first: it queries the vector index to select the tools most relevant to the current message (see [Tool Retrieval](#tool-retrieval-rag) above). The ```agent``` node then runs the primary LLM with only those tools bound to its context, and if it decides to use a tool, the ```action``` node runs the tool and returns control to ```agent```. Multiple tool calls within a single model turn execute concurrently via `asyncio.gather`, with a 30-second per-tool timeout to prevent hung calls from blocking the conversation. When the agent does not call a tool, control passes to ```summarize_and_remove_messages```, which summarizes only when trimming is required to manage the LLM context.
 
 ### LLM Context Management
 You need to carefully manage the context length of LLMs to balance cost, accuracy, and latency and avoid triggering rate limits such as OpenAI's Tokens per Minute restriction. The system controls the context length of the primary model by trimming the messages in the context if they exceed a max parameter which can be expressed in either tokens or messages, and the trimmed messages are replaced by a shorter summary inserted into the system message. These parameters are configurable in the UI, with defaults defined in `const.py`; their description is below.
@@ -1011,11 +1014,13 @@ Parameter | Description | Default
 ### Latency
 The latency between user requests or the agent taking timely action on the user's behalf is critical for you to consider in the design. I used several techniques to reduce latency, including using specialized, smaller helper LLMs running on the edge and facilitating primary model prompt caching by structuring the prompts to put static content, such as instructions and examples, upfront and variable content, such as user-specific information at the end. These techniques also reduce primary model usage costs considerably.
 
+Native LLM streaming (v3.12.0+) means the first tokens appear in the HA conversation UI within milliseconds of the model starting its response — total response time is unchanged, but perceived latency drops significantly. Multi-tool turns also benefit from parallel tool execution: tools in the same model turn run concurrently rather than serially.
+
 You can see the typical latency performance in the table below.
 
 Action | Latency (s) | Remark
 -- | -- | -- |
-HA intents | < 1 | e.g., turn on a light
+HA intents | < 1 | e.g., turn on a light; first token streams immediately
 Analyze camera image | < 3 | initial request
 Add automation | < 1 |
 Memory operations | < 1 |

--- a/TODOS.md
+++ b/TODOS.md
@@ -16,6 +16,34 @@
 
 ---
 
+### Rename sync methods with `_async_` prefix in conversation.py
+
+**What:** Three synchronous methods in `HGAConversationEntity` have the `_async_` prefix, which conventionally means "coroutine" in HA code: `_async_get_message_history` (line 629), `_async_get_all_tools` (line 685), `_async_render_system_prompt` (line 718). None use `await`.
+
+**Why:** Misleading naming. Future maintainers may incorrectly assume these are coroutines.
+
+**How to apply:** Rename each to drop `_async_` prefix and update all callers within `conversation.py`.
+
+**Effort:** S
+**Priority:** P3
+**Depends on:** feat/streaming-chatlog
+
+---
+
+### Integration tests for streaming conversation path (HA fixture level)
+
+**What:** Add four HA-fixture-level integration tests using a real (mocked) LangGraph + HA conversation entity: (1) single-turn text-only streaming, (2) multi-turn with tool calls, (3) PIN flow multi-turn with confirmation, (4) `schema_first_yaml=True` fallback fires `ainvoke` path correctly.
+
+**Why:** Current test coverage (58%) is dominated by pure-function unit tests. The `HGAConversationEntity` integration methods (`_async_run_astream`, `_async_handle_message`, `_async_render_system_prompt`, `_async_init_llm_apis`) have zero unit test coverage. These tests were listed as required in the streaming design plan but deferred at ship time. Accepted risk per user override.
+
+**How to apply:** Use the existing `test_conversation.py` integration test harness as a model. Create `tests/custom_components/home_generative_agent/test_conversation_stream_integration.py`. Mock `app.astream_events` to return a controlled sequence of events, verify delta sequence delivered to HA ChatLog.
+
+**Effort:** M
+**Priority:** P2
+**Depends on:** feat/streaming-chatlog
+
+---
+
 ### Integration smoke test: on_tool_end propagation during action node
 
 **What:** After feat/streaming-chatlog lands, run a real multi-tool conversation (`get_current_time` + `get_and_analyze_camera_image`) and verify that `on_tool_end` for `get_current_time` fires BEFORE the camera tool completes.

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,5 +1,35 @@
 # TODOS
 
+## Agent
+
+### asyncio.gather concurrency policy for state-mutating tools
+
+**What:** Add per-tool annotation or global policy for whether a tool is safe to run concurrently. State-mutating HA tools (`turn_on`, `turn_off`, lock, unlock, `alarm_control`) called in the same model batch could interleave under `asyncio.gather`.
+
+**Why:** With `asyncio.gather` (introduced in feat/streaming-chatlog), a model turn that includes both `turn_on` and `get_state` may now run concurrently. `get_state` might return stale state if it completes before `turn_on` finishes. Previously sequential. Flagged during eng review Codex outside voice.
+
+**How to apply:** In `graph.py`, add a `_SEQUENTIAL_TOOLS` set or per-tool `safe_to_parallelize` annotation. In `_call_tools`, run sequential tools before the gather batch, or use `asyncio.gather` only for tools not in the set. Alternatively, add a note in the integration docs that sequential ordering of state-changing + read-back calls requires separate model turns.
+
+**Effort:** M
+**Priority:** P3
+**Depends on:** feat/streaming-chatlog
+
+---
+
+### Integration smoke test: on_tool_end propagation during action node
+
+**What:** After feat/streaming-chatlog lands, run a real multi-tool conversation (`get_current_time` + `get_and_analyze_camera_image`) and verify that `on_tool_end` for `get_current_time` fires BEFORE the camera tool completes.
+
+**Why:** The streaming win depends on LangGraph propagating child `on_tool_end` events from `lc_tool.ainvoke()` to the outer `astream_events` DURING node execution. Verified against LangGraph 1.1.2 source during planning, but not confirmed via integration test. If LangGraph buffers nested events until node completion, the streaming gain disappears.
+
+**How to verify:** Add a timing log in the `on_tool_end` handler (DEBUG level). Time delta between `on_tool_end` for the time tool and the camera tool should be ~3980ms apart, not ~0ms.
+
+**Effort:** S
+**Priority:** P2 (post-ship validation)
+**Depends on:** feat/streaming-chatlog
+
+---
+
 ## Explain / Prompts
 
 ### Sanitize area/entity strings before injecting into LLM prompts

--- a/custom_components/home_generative_agent/agent/graph.py
+++ b/custom_components/home_generative_agent/agent/graph.py
@@ -903,6 +903,10 @@ def _has_pending_pin_confirmation(messages: Sequence[AnyMessage]) -> bool:
                 if "Incorrect PIN" in content:
                     # Wrong PIN entered — action is still pending, keep scanning.
                     continue
+                if getattr(msg, "status", None) == "error":
+                    # Routing or tool error on confirm_sensitive_action itself —
+                    # the PIN was never checked. Keep the action pending.
+                    continue
                 return False
         return True
 

--- a/custom_components/home_generative_agent/agent/graph.py
+++ b/custom_components/home_generative_agent/agent/graph.py
@@ -899,6 +899,10 @@ def _has_pending_pin_confirmation(messages: list[AnyMessage]) -> bool:
     if pin_idx is not None:
         for msg in recent[pin_idx + 1 :]:
             if isinstance(msg, ToolMessage) and msg.name == "confirm_sensitive_action":
+                content = msg.content if isinstance(msg.content, str) else ""
+                if "Incorrect PIN" in content:
+                    # Wrong PIN entered — action is still pending, keep scanning.
+                    continue
                 return False
         return True
 

--- a/custom_components/home_generative_agent/agent/graph.py
+++ b/custom_components/home_generative_agent/agent/graph.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import copy
 import json
 import logging
@@ -83,6 +84,15 @@ if TYPE_CHECKING:
     from langgraph.store.base import BaseStore
 
 LOGGER = logging.getLogger(__name__)
+
+# Maximum seconds to wait for a single LangChain tool (e.g. camera VLM).
+# With asyncio.gather a hung tool blocks all parallel tools in the batch,
+# so this converts an infinite hang into a bounded error. Keep below the
+# outer HA conversation timeout.
+_LC_TOOL_TIMEOUT_S: float = 30.0
+
+_PIN_LOOKBACK = 20  # messages to scan for an unresolved requires_pin
+_ROUTING_REJECTION_MARKER = "is not available for this request"
 
 
 class State(MessagesState):
@@ -231,7 +241,9 @@ async def _run_langchain_tool(
             return str(val)
 
     try:
-        lc_result = await lc_tool.ainvoke(tool_call_copy)
+        lc_result = await asyncio.wait_for(
+            lc_tool.ainvoke(tool_call_copy), timeout=_LC_TOOL_TIMEOUT_S
+        )
         if isinstance(lc_result, ToolMessage):
             status = lc_result.status
             result_str = _stringify(lc_result.content)
@@ -266,6 +278,12 @@ async def _run_langchain_tool(
             name=tool_name,
             tool_call_id=tool_call.get("id") or "",
             status=status,
+        )
+    except TimeoutError:
+        return _make_tool_error(
+            f"Tool timed out after {_LC_TOOL_TIMEOUT_S}s.",
+            tool_name,
+            tool_call.get("id") or "",
         )
     except (HomeAssistantError, ValidationError) as err:
         status_msg = (
@@ -828,6 +846,113 @@ def _format_and_dedupe_tools(
 # ----- Graph nodes and edges -----
 
 
+def _last_requires_pin_idx(recent: list[AnyMessage]) -> int | None:
+    """Return the index of the most recent unresolved requires_pin ToolMessage."""
+    idx: int | None = None
+    for i, msg in enumerate(recent):
+        if not isinstance(msg, ToolMessage):
+            continue
+        content = msg.content
+        if not isinstance(content, str):
+            continue
+        try:
+            data = json.loads(content)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if isinstance(data, dict) and data.get("status") == "requires_pin":
+            idx = i
+    return idx
+
+
+def _last_routing_rejection_idx(recent: list[AnyMessage]) -> int | None:
+    """Return index of the last unresolved routing-rejected actuation ToolMessage."""
+    idx: int | None = None
+    for i, msg in enumerate(recent):
+        if not isinstance(msg, ToolMessage):
+            continue
+        if not is_actuation_tool(msg.name or ""):
+            continue
+        content = msg.content if isinstance(msg.content, str) else ""
+        if msg.status == "error" and _ROUTING_REJECTION_MARKER in content:
+            idx = i
+        else:
+            idx = None  # tool ran (success or other error) — rejection resolved
+    return idx
+
+
+def _has_pending_pin_confirmation(messages: list[AnyMessage]) -> bool:
+    """
+    Return True if a PIN confirmation is pending in recent message history.
+
+    Detects two cases:
+
+    Case 1 (normal flow): A ``requires_pin`` ToolMessage exists without a
+    subsequent ``confirm_sensitive_action`` call.
+
+    Case 2 (degraded flow): An actuation tool was routing-rejected and the model
+    subsequently asked for a PIN in an AI message.  Injecting
+    ``confirm_sensitive_action`` lets the model recover on the next turn.
+    """
+    recent = messages[-_PIN_LOOKBACK:] if len(messages) > _PIN_LOOKBACK else messages
+
+    pin_idx = _last_requires_pin_idx(recent)
+    if pin_idx is not None:
+        for msg in recent[pin_idx + 1 :]:
+            if isinstance(msg, ToolMessage) and msg.name == "confirm_sensitive_action":
+                return False
+        return True
+
+    rejection_idx = _last_routing_rejection_idx(recent)
+    if rejection_idx is None:
+        return False
+
+    # AI asked for PIN after routing rejection but before a successful actuation call.
+    for msg in recent[rejection_idx + 1 :]:
+        if isinstance(msg, AIMessage) and not msg.tool_calls:
+            content = msg.content if isinstance(msg.content, str) else ""
+            if "pin" in content.lower():
+                return True
+
+    return False
+
+
+async def _get_pending_pin_tools(
+    messages: list[AnyMessage],
+    store: BaseStore | None,
+) -> list[RawTool]:
+    """Return [confirm_sensitive_action] when a PIN confirmation is pending."""
+    if not _has_pending_pin_confirmation(messages):
+        return []
+
+    if store is None:
+        return []
+
+    try:
+        item = await store.aget(
+            ("system", "tools"), key="hga_local::confirm_sensitive_action"
+        )
+    except Exception:  # noqa: BLE001
+        LOGGER.debug(
+            "Could not fetch confirm_sensitive_action from store for PIN injection"
+        )
+        return []
+
+    if item is None:
+        return []
+
+    val = item.value
+    LOGGER.debug("PIN flow active: force-injecting confirm_sensitive_action")
+    return [
+        RawTool(
+            name=val["name"],
+            api_id=val["api_id"],
+            description=val["description"],
+            parameters=val["parameters"],
+            is_actuation=val.get("is_actuation", False),
+        )
+    ]
+
+
 async def _retrieve_tools(
     state: State,
     config: RunnableConfig,
@@ -847,9 +972,10 @@ async def _retrieve_tools(
     limit = int(opts.get(CONF_TOOL_RETRIEVAL_LIMIT, 5))
 
     # 1. Gather candidates
-    rag_tools = await _get_rag_retrieved_tools(store, config, query, allowed_api_ids)
-    safety_tools = await _get_actuation_safety_tools(
-        store, config, query, allowed_api_ids
+    rag_tools, safety_tools, pin_tools = await asyncio.gather(
+        _get_rag_retrieved_tools(store, config, query, allowed_api_ids),
+        _get_actuation_safety_tools(store, config, query, allowed_api_ids),
+        _get_pending_pin_tools(state["messages"], store),
     )
 
     # 2. Merge: safety tools take priority; RAG fills remaining slots.
@@ -862,12 +988,20 @@ async def _retrieve_tools(
     # effective_limit expands just enough to fit all rag_only tools that survived
     # the per-sub-query RAG budget, but is capped at safety_cap + limit to avoid
     # unbounded growth.
+    #
+    # pin_tools are force-injected outside the limit — they must always be present
+    # when a PIN confirmation is pending, regardless of RAG scores.
+    pin_names = {t["name"] for t in pin_tools}
     safety_cap = min(len(safety_tools), max(1, limit * 3 // 4))
-    safety_capped = safety_tools[:safety_cap]
+    safety_capped = [t for t in safety_tools[:safety_cap] if t["name"] not in pin_names]
     safety_names = {t["name"] for t in safety_capped}
-    rag_only = [t for t in rag_tools if t["name"] not in safety_names]
+    rag_only = [
+        t
+        for t in rag_tools
+        if t["name"] not in safety_names and t["name"] not in pin_names
+    ]
     effective_limit = min(safety_cap + len(rag_only), safety_cap + limit)
-    all_candidates = (safety_capped + rag_only)[:effective_limit]
+    all_candidates = pin_tools + (safety_capped + rag_only)[:effective_limit]
 
     # 3. Fallback: vector store unavailable or index not yet ready.
     # Still apply the limit so the user-configured cap is always respected.
@@ -891,12 +1025,13 @@ async def _retrieve_tools(
     selected_tools, routing_map = _format_and_dedupe_tools(all_candidates)
 
     LOGGER.debug(
-        "Tool retrieval: limit=%d eff=%d rag=%d safety=%d/%d merged=%d tools=%s",
+        "Tool retrieval: limit=%d eff=%d rag=%d safety=%d/%d pin=%d merged=%d tools=%s",
         limit,
         effective_limit,
         len(rag_tools),
         safety_cap,
         len(safety_tools),
+        len(pin_tools),
         len(all_candidates),
         [t["function"]["name"] for t in selected_tools],
     )
@@ -1249,15 +1384,18 @@ async def _call_tools(
 
     tool_routing_map: dict[str, str] = state.get("tool_routing_map", {})
 
-    for tool_call in tool_calls:
+    # Execute all tool calls concurrently.
+    # asyncio.gather preserves submission order: results[i] matches tool_calls[i].
+    # Concurrent HA tool calls may interleave (e.g. turn_on + get_state in same
+    # batch). If strict sequencing is needed, issue separate model turns.
+    async def _invoke_one(tool_call: dict[str, Any]) -> ToolMessage:
+        """Execute a single tool call and return its ToolMessage."""
         tool_name = tool_call.get("name", "")
         tool_args = tool_call.get("args", {}) or {}
         LOGGER.debug("Tool call: %s(%s)", tool_name, tool_args)
 
         # Enforce the retrieved tool set: reject calls for tools that were not
-        # selected by _retrieve_tools this turn. This prevents the model from
-        # executing tools it learned from conversation history but that were not
-        # retrieved for the current query (e.g. when retrieval limit is low).
+        # selected by _retrieve_tools this turn.
         if tool_routing_map and tool_name not in tool_routing_map:
             LOGGER.warning(
                 "Model called tool '%s' which was not retrieved for this turn "
@@ -1265,15 +1403,12 @@ async def _call_tools(
                 tool_name,
                 list(tool_routing_map),
             )
-            tool_responses.append(
-                _make_tool_error(
-                    f"Tool '{tool_name}' is not available for this request. "
-                    "Only use the tools listed in your schema.",
-                    tool_name,
-                    tool_call.get("id") or "",
-                )
+            return _make_tool_error(
+                f"Tool '{tool_name}' is not available for this request. "
+                "Only use the tools listed in your schema.",
+                tool_name,
+                tool_call.get("id") or "",
             )
-            continue
 
         ctx = ToolExecutionContext(
             hass=hass,
@@ -1292,8 +1427,7 @@ async def _call_tools(
             tool_name=tool_name, tool_args=tool_args, ctx=ctx, tool_call=tool_call
         )
         if precheck:
-            tool_responses.append(precheck)
-            continue
+            return precheck
 
         lc_key = tool_name.lower()
         if lc_key in langchain_tools:
@@ -1308,7 +1442,28 @@ async def _call_tools(
                 tool_call=tool_call,
             )
         LOGGER.debug("Tool response: %s", tool_response)
-        tool_responses.append(tool_response)
+        return tool_response
+
+    results = await asyncio.gather(
+        *[_invoke_one(tc) for tc in tool_calls],
+        return_exceptions=True,
+    )
+    tool_responses: list[ToolMessage] = []
+    for i, result in enumerate(results):
+        if isinstance(result, Exception):
+            # Log the full exception; surface a sanitized message to avoid
+            # leaking tokens, URLs, or internal details to the model.
+            tc = tool_calls[i]
+            LOGGER.error("Tool %s raised during gather: %r", tc.get("name", ""), result)
+            tool_responses.append(
+                _make_tool_error(
+                    f"Tool execution failed: {type(result).__name__}",
+                    tc.get("name", ""),
+                    tc.get("id") or "",
+                )
+            )
+        else:
+            tool_responses.append(result)  # type: ignore[arg-type]
 
     return {"messages": tool_responses}
 

--- a/custom_components/home_generative_agent/agent/graph.py
+++ b/custom_components/home_generative_agent/agent/graph.py
@@ -77,7 +77,7 @@ from .helpers import (
 from .token_counter import count_tokens_cross_provider
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Sequence
 
     from homeassistant.core import HomeAssistant
     from langchain_core.runnables import RunnableConfig
@@ -846,7 +846,7 @@ def _format_and_dedupe_tools(
 # ----- Graph nodes and edges -----
 
 
-def _last_requires_pin_idx(recent: list[AnyMessage]) -> int | None:
+def _last_requires_pin_idx(recent: Sequence[AnyMessage]) -> int | None:
     """Return the index of the most recent unresolved requires_pin ToolMessage."""
     idx: int | None = None
     for i, msg in enumerate(recent):
@@ -864,7 +864,7 @@ def _last_requires_pin_idx(recent: list[AnyMessage]) -> int | None:
     return idx
 
 
-def _last_routing_rejection_idx(recent: list[AnyMessage]) -> int | None:
+def _last_routing_rejection_idx(recent: Sequence[AnyMessage]) -> int | None:
     """Return index of the last unresolved routing-rejected actuation ToolMessage."""
     idx: int | None = None
     for i, msg in enumerate(recent):
@@ -880,7 +880,7 @@ def _last_routing_rejection_idx(recent: list[AnyMessage]) -> int | None:
     return idx
 
 
-def _has_pending_pin_confirmation(messages: list[AnyMessage]) -> bool:
+def _has_pending_pin_confirmation(messages: Sequence[AnyMessage]) -> bool:
     """
     Return True if a PIN confirmation is pending in recent message history.
 

--- a/custom_components/home_generative_agent/const.py
+++ b/custom_components/home_generative_agent/const.py
@@ -624,15 +624,17 @@ Error: {error}
 Call the tool again with your mistake corrected.
 """
 CRITICAL_ACTION_PROMPT = """
-Critical actions (door/lock/garage/open) require user confirmation.
-- If a tool response has status "requires_pin", ask the user for the PIN they set and
-  then call the "confirm_sensitive_action" tool with the provided action_id and PIN.
-- Never guess or invent a PIN. Do not proceed without a PIN. If the user refuses or
-  fails, inform them and do not re-attempt the action.
+For critical actions (door/lock/garage/open), call the tool directly—do NOT ask
+for verbal confirmation first. The tool itself enforces security.
+- If a tool response has status "requires_pin", ask the user for the security PIN
+  they configured, then call "confirm_sensitive_action" with the action_id from
+  the tool response and the PIN.
+- Never guess or invent a PIN. Do not proceed without a PIN. If the user refuses
+  or fails, inform them and do not re-attempt the action.
 - Do not expose or repeat the PIN in responses beyond acknowledging success/failure.
-- Alarm control uses the alarm system code, not the critical-action PIN. When arming or
-  disarming an alarm, ask for the alarm code and include it in the tool call. Do NOT
-  call "confirm_sensitive_action" for alarm control.
+- Alarm control uses the alarm system code, not the critical-action PIN. When
+  arming or disarming an alarm, ask for the alarm code and include it in the tool
+  call. Do NOT call "confirm_sensitive_action" for alarm control.
 """
 SCHEMA_FIRST_YAML_PROMPT = """
 When the user requests YAML, automations, or Lovelace dashboards, output ONLY valid JSON

--- a/custom_components/home_generative_agent/conversation.py
+++ b/custom_components/home_generative_agent/conversation.py
@@ -729,6 +729,21 @@ class HGAConversationEntity(conversation.ConversationEntity, AbstractConversatio
         # Fire trace after stream completes using final graph state.
         # astream_events handles exhaustion only after graph termination.
         _LOGGER.debug("====== End of run (streaming) ======")
+
+        # Re-fire CONTENT_ADDED for the final AssistantContent so the HA
+        # frontend's streaming UI shows it in the main chat area.
+        # async_add_delta_content_stream flushes via async_add_assistant_content,
+        # which does NOT fire CONTENT_ADDED for AssistantContent. Re-committing
+        # via async_add_assistant_content_without_tools does fire it.
+        if (
+            chat_log.content
+            and isinstance(chat_log.content[-1], conversation.AssistantContent)
+            and not chat_log.content[-1].tool_calls
+            and chat_log.content[-1].content
+        ):
+            final_content = chat_log.content.pop()
+            chat_log.async_add_assistant_content_without_tools(final_content)
+
         try:
             final_state = await app.aget_state(config)
             trace.async_conversation_trace_append(

--- a/custom_components/home_generative_agent/conversation.py
+++ b/custom_components/home_generative_agent/conversation.py
@@ -275,7 +275,13 @@ async def _stream_langgraph_to_ha(
 
             # 4. Tool results from the action node.
             elif node == "action" and event_type == "on_chain_end":
-                output = cast("Mapping[str, Any]", data.get("output", {}))
+                output = data.get("output")
+                # LangGraph emits two on_chain_end events tagged langgraph_node="action":
+                # (a) the node function's own event: output = {"messages": [ToolMessage, ...]}
+                # (b) a graph-level state event: output = the full updated messages list
+                # We only want (a). Skip anything that is not a dict.
+                if not isinstance(output, dict):
+                    continue
                 messages = cast("list[Any]", output.get("messages", []))
                 tool_messages = [m for m in messages if isinstance(m, ToolMessage)]
 

--- a/custom_components/home_generative_agent/conversation.py
+++ b/custom_components/home_generative_agent/conversation.py
@@ -2,26 +2,40 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import hashlib
 import json
 import logging
 import string
-from typing import TYPE_CHECKING, Any, Literal
+from collections.abc import AsyncGenerator, AsyncIterable
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import homeassistant.util.dt as dt_util
 import voluptuous as vol
 from homeassistant.components import conversation
-from homeassistant.components.conversation import trace
+from homeassistant.components.conversation import (
+    AssistantContentDeltaDict,
+    ToolResultContentDeltaDict,
+    trace,
+)
 from homeassistant.components.conversation.models import AbstractConversationAgent
 from homeassistant.const import CONF_LLM_HASS_API, MATCH_ALL
-from homeassistant.exceptions import HomeAssistantError, TemplateError
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import intent, llm, template
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.util import ulid
 from langchain_core.caches import InMemoryCache
 from langchain_core.globals import set_debug, set_llm_cache, set_verbose
-from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, ToolMessage
+from langchain_core.messages import (
+    AIMessage,
+    AIMessageChunk,
+    AnyMessage,
+    HumanMessage,
+    ToolCall,
+    ToolMessage,
+)
 from pydantic import PydanticInvalidForJsonSchema
 
 from .agent.graph import workflow
@@ -62,7 +76,7 @@ from .core.conversation_helpers import (
 from .core.utils import gather_store_puts_in_chunks
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import AsyncGenerator, AsyncIterable, Callable, Mapping
 
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
@@ -119,20 +133,22 @@ def _normalize_ai_content(content: str | list) -> str | None:
     return "\n".join(parts) or None
 
 
-def _normalize_tool_result(content: str | list) -> JsonObjectType:
+def _normalize_tool_result(content: Any) -> JsonObjectType:
     """
     Normalize ToolMessage.content to JsonObjectType for HA ToolResultContent.
 
     ToolMessage.content is str for plain string results, or list[dict] (content blocks)
-    from some providers. HA ToolResultContent.tool_result requires JsonObjectType.
+    from some providers (e.g. Anthropic).
     """
     if isinstance(content, str):
         return {"result": content}
-    parts = [
-        block.get("text", "") if isinstance(block, dict) else str(block)
-        for block in content
-    ]
-    return {"result": "\n".join(parts)}
+    if isinstance(content, list):
+        parts = [
+            block.get("text", "") if isinstance(block, dict) else str(block)
+            for block in content
+        ]
+        return {"result": "\n".join(parts)}
+    return {"result": str(content)}
 
 
 def _populate_chat_log_from_response(
@@ -191,6 +207,110 @@ def _populate_chat_log_from_response(
                     tool_result=_normalize_tool_result(msg.content),
                 )
             )
+
+
+# ruff: noqa: PLR0912
+async def _stream_langgraph_to_ha(
+    event_stream: AsyncIterable[Mapping[str, Any]],
+    _agent_id: str,
+) -> AsyncGenerator[AssistantContentDeltaDict | ToolResultContentDeltaDict]:
+    """
+    Transform LangGraph astream_events into HA ChatLog deltas.
+
+    Filters for events from the 'agent' node for tokens/tool-calls and the
+    'action' node for tool results.
+    """
+    pending_tool_map: dict[str, ToolCall] = {}
+
+    try:
+        async for event in event_stream:
+            ev = cast("dict[str, Any]", event)
+            metadata = cast("dict[str, Any]", ev.get("metadata", {}))
+            node = metadata.get("langgraph_node")
+            event_type = ev.get("event")
+            data = cast("dict[str, Any]", ev.get("data", {}))
+
+            # 1. Start of a model turn: open an AssistantContent block.
+            # HA flushes any previous AssistantContent when it receives a
+            # role="assistant" delta. We yield this at every agent start to ensure
+            # HA state sync in recursive loops (Agent -> Action -> Agent).
+            if node == "agent" and event_type == "on_chat_model_start":
+                yield AssistantContentDeltaDict(role="assistant")
+
+            # 2. Incremental text tokens.
+            elif node == "agent" and event_type == "on_chat_model_stream":
+                chunk = data.get("chunk")
+                if not isinstance(chunk, AIMessageChunk) or chunk.tool_call_chunks:
+                    continue
+
+                chunk_text = _normalize_ai_content(chunk.content)
+                if chunk_text:
+                    yield AssistantContentDeltaDict(content=chunk_text)
+
+            # 3. End of a model turn: record pending tool calls.
+            elif node == "agent" and event_type == "on_chat_model_end":
+                msg = data.get("output")
+                if not isinstance(msg, AIMessage):
+                    continue
+
+                if msg.tool_calls:
+                    # Update mapping for result correlation.
+                    call_id_map = []
+                    for tc in msg.tool_calls:
+                        call_id = tc.get("id") or ulid.ulid_now()
+                        pending_tool_map[call_id] = tc
+                        call_id_map.append(call_id)
+
+                    yield AssistantContentDeltaDict(
+                        tool_calls=[
+                            llm.ToolInput(
+                                tool_name=str(tc["name"]),
+                                tool_args=cast("dict[str, Any]", tc["args"]),
+                                id=call_id_map[i],
+                                external=True,
+                            )
+                            for i, tc in enumerate(msg.tool_calls)
+                        ]
+                    )
+
+            # 4. Tool results from the action node.
+            elif node == "action" and event_type == "on_chain_end":
+                output = cast("Mapping[str, Any]", data.get("output", {}))
+                messages = cast("list[Any]", output.get("messages", []))
+                tool_messages = [m for m in messages if isinstance(m, ToolMessage)]
+
+                # 1. Yield successful results and remove from pending map.
+                for msg in tool_messages:
+                    pending_tool_map.pop(msg.tool_call_id, None)
+
+                    yield ToolResultContentDeltaDict(
+                        role="tool_result",
+                        tool_call_id=str(msg.tool_call_id),
+                        tool_name=str(msg.name or ""),
+                        tool_result=_normalize_tool_result(msg.content),
+                    )
+
+                # 2. Yield synthetic rejections for any calls that didn't return a
+                # result. This ensures HA doesn't hang if a tool fails silently or
+                # is rejected.
+                for call_id, tc in pending_tool_map.items():
+                    yield ToolResultContentDeltaDict(
+                        role="tool_result",
+                        tool_call_id=call_id,
+                        tool_name=tc.get("name") or "tool",
+                        tool_result={
+                            "error": "Tool execution rejected by routing policy."
+                        },
+                    )
+                pending_tool_map.clear()
+    except (GeneratorExit, asyncio.CancelledError):
+        # Stop iteration on cancellation or closure.
+        raise
+    except Exception:
+        _LOGGER.exception("Error in LangGraph streaming transformation generator.")
+        raise
+    finally:
+        pending_tool_map.clear()
 
 
 class MultiLLMAPI:
@@ -280,6 +400,7 @@ class HGAConversationEntity(conversation.ConversationEntity, AbstractConversatio
 
     _attr_has_entity_name = True
     _attr_name = None
+    _attr_supports_streaming = True
 
     def __init__(self, entry: ConfigEntry) -> None:
         """Initialize the agent."""
@@ -330,26 +451,10 @@ class HGAConversationEntity(conversation.ConversationEntity, AbstractConversatio
         """Return a list of supported languages."""
         return MATCH_ALL
 
-    async def _async_handle_message(  # noqa: PLR0911, PLR0912, PLR0915
-        self,
-        user_input: conversation.ConversationInput,
-        chat_log: conversation.ChatLog,
-    ) -> conversation.ConversationResult:
-        """Process the user input."""
-        hass = self.hass
-        options = self.entry.runtime_data.options
-        runtime_data = self.entry.runtime_data
-        intent_response = intent.IntentResponse(language=user_input.language)
-        tools: list[dict[str, Any]] | None = None
-        user_name: str | None = None
-        llm_context = llm.LLMContext(
-            platform=DOMAIN,
-            context=user_input.context,
-            language=user_input.language,
-            assistant=conversation.DOMAIN,
-            device_id=user_input.device_id,
-        )
-
+    def _async_get_message_history(
+        self, chat_log: conversation.ChatLog
+    ) -> list[HumanMessage | AIMessage]:
+        """Extract and slice the relevant chat log history."""
         # Include only HA User/Assistant messages not already seen by this entity.
         # Exclude AssistantContent with tool_calls: those are intermediate LangGraph
         # turns already persisted in the PostgreSQL checkpointer. Including them would
@@ -363,21 +468,21 @@ class HGAConversationEntity(conversation.ConversationEntity, AbstractConversatio
         # The last chat log entry will be the current user request—add it later.
         message_history = message_history[:-1]
 
-        if (mhlen := len(message_history)) <= self.message_history_len:
+        mhlen = len(message_history)
+        if mhlen <= self.message_history_len:
             message_history = []
         else:
             diff = mhlen - self.message_history_len
             message_history = message_history[-diff:]
             self.message_history_len = mhlen
 
-        conversation_id = (
-            ulid.ulid_now()
-            if chat_log.conversation_id is None
-            else chat_log.conversation_id
-        )
+        return message_history
 
-        # HA tools & schema
-        # Gather ALL selected APIs
+    async def _async_init_llm_apis(self, llm_context: llm.LLMContext) -> MultiLLMAPI:
+        """Load and validate configured LLM APIs, returning a MultiLLMAPI instance."""
+        hass = self.hass
+        options = self.entry.runtime_data.options
+
         active_api_ids = options.get(CONF_LLM_HASS_API, [llm.LLM_API_ASSIST])
         if isinstance(active_api_ids, str):
             active_api_ids = [active_api_ids]
@@ -393,32 +498,20 @@ class HGAConversationEntity(conversation.ConversationEntity, AbstractConversatio
                 failed_apis.append(api_id)
 
         if not active_apis:
-            intent_response.async_set_error(
-                intent.IntentResponseErrorCode.UNKNOWN,
+            msg = (
                 "No LLM APIs could be loaded. "
                 f"Failed: {', '.join(failed_apis)}. "
-                f"Configured: {', '.join(active_api_ids)}",
+                f"Configured: {', '.join(active_api_ids)}"
             )
-            return conversation.ConversationResult(
-                response=intent_response, conversation_id=conversation_id
-            )
+            raise HomeAssistantError(msg)
 
-        # Multi-API initialization
-        llm_api = MultiLLMAPI(active_apis, {})
+        return MultiLLMAPI(active_apis, {})
 
-        # --- Global Tool Indexing (Background) ---
-        await self._async_index_tools(llm_context, runtime_data)
-
-        if not options.get(CONF_SCHEMA_FIRST_YAML, False) and _is_dashboard_request(
-            user_input.text
-        ):
-            intent_response.async_set_speech(
-                """Please enable 'Schema-first JSON for YAML requests' in
-                HGA's configuration and try again"""
-            )
-            return conversation.ConversationResult(
-                response=intent_response, conversation_id=conversation_id
-            )
+    def _async_get_all_tools(
+        self, active_apis: dict[str, llm.APIInstance]
+    ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+        """Aggregate HA tools and LangChain-native tools."""
+        options = self.entry.runtime_data.options
 
         tools = (
             [
@@ -445,10 +538,248 @@ class HGAConversationEntity(conversation.ConversationEntity, AbstractConversatio
             langchain_tools["add_automation"] = add_automation
         tools.extend(langchain_tools.values())
 
-        # Conversation ID
-        _LOGGER.debug("Conversation ID: %s", conversation_id)
+        return tools, langchain_tools
+
+    def _async_render_system_prompt(
+        self,
+        llm_context: llm.LLMContext,
+        user_name: str | None,
+        llm_api: MultiLLMAPI,
+        *,
+        has_tools: bool,
+    ) -> str:
+        """Render the full system instructions."""
+        options = self.entry.runtime_data.options
+
+        pin_enabled = options.get(CONF_CRITICAL_ACTION_PIN_ENABLED, False)
+        critical_prompt = CRITICAL_ACTION_PROMPT if pin_enabled else ""
+        schema_prompt = (
+            SCHEMA_FIRST_YAML_PROMPT
+            if options.get(CONF_SCHEMA_FIRST_YAML, False)
+            else ""
+        )
+        prompt_parts = [
+            template.Template(
+                (
+                    llm.DATE_TIME_PROMPT
+                    + options.get(CONF_PROMPT, llm.DEFAULT_INSTRUCTIONS_PROMPT)
+                    + f"\nYou are in the {self.tz} timezone."
+                    + critical_prompt
+                    + schema_prompt
+                    + TOOL_CALL_ERROR_SYSTEM_MESSAGE
+                    if has_tools
+                    else ""
+                ),
+                self.hass,
+            ).async_render(
+                {
+                    "ha_name": self.hass.config.location_name,
+                    "user_name": user_name,
+                    "llm_context": llm_context,
+                },
+                parse_result=False,
+            )
+        ]
+
+        if llm_api:
+            prompt_parts.append(llm_api.api_prompt)
+
+        return "\n".join(prompt_parts)
+
+    async def _async_run_ainvoke(
+        self,
+        app: Any,
+        input_data: State,
+        config: RunnableConfig,
+        chat_log: conversation.ChatLog,
+        tools: list[dict[str, Any]] | None,
+    ) -> None:
+        """Handle the non-streaming ainvoke path."""
+        options = self.entry.runtime_data.options
+        hass = self.hass
+
+        try:
+            response = await app.ainvoke(input=input_data, config=config)
+        except HomeAssistantError as err:
+            _LOGGER.exception("LangGraph error during conversation processing.")
+            msg = f"Something went wrong: {err}"
+            raise HomeAssistantError(msg) from err
+
+        trace.async_conversation_trace_append(
+            trace.ConversationTraceEventType.AGENT_DETAIL,
+            {"messages": response["messages"], "tools": tools or None},
+        )
+
+        _LOGGER.debug("====== End of run (ainvoke) ======")
+
+        # Post-process the final LLM text (entity ID resolution, YAML conversion).
+        final_content = response["messages"][-1].content
+        if isinstance(final_content, str):
+            if options.get(CONF_SCHEMA_FIRST_YAML, False):
+                final_content = _maybe_fix_dashboard_entities(final_content, hass)
+                final_content = _convert_schema_json_to_yaml(
+                    final_content, enabled=True
+                )
+            else:
+                final_content = _fix_entity_ids_in_text(final_content, hass)
+            _LOGGER.debug("Final response content: %s", final_content)
+
+        # Backfill chat_log with the messages produced this turn so HA's
+        # "Show Details" panel renders the full tool call / result chain.
+        # Slice off history + current HumanMessage — only net-new messages.
+        new_messages = response["messages"][len(input_data["messages"]) :]
+
+        # Guard: async_get_result_from_chat_log requires last entry to be
+        # AssistantContent, which means the last new message must be an
+        # AIMessage.
+        if not new_messages or not isinstance(new_messages[-1], AIMessage):
+            _LOGGER.error(
+                "LangGraph response did not end with AIMessage (got %s). "
+                "Falling back to manual ConversationResult.",
+                type(new_messages[-1]) if new_messages else "empty",
+            )
+            chat_log.async_add_assistant_content_without_tools(
+                conversation.AssistantContent(
+                    agent_id=self.entity_id,
+                    content=final_content if isinstance(final_content, str) else "",
+                )
+            )
+            return
+
+        # Replace the final AIMessage content with the post-processed text so
+        # Show Details reflects the same text the user hears.
+        if isinstance(final_content, str):
+            processed_messages: list[AnyMessage] = [
+                *new_messages[:-1],
+                AIMessage(
+                    content=final_content,
+                    tool_calls=new_messages[-1].tool_calls,
+                ),
+            ]
+        else:
+            processed_messages = list(new_messages)
+
+        _populate_chat_log_from_response(chat_log, self.entity_id, processed_messages)
+
+    async def _async_run_astream(
+        self,
+        app: Any,
+        input_data: State,
+        config: RunnableConfig,
+        chat_log: conversation.ChatLog,
+        tools: list[dict[str, Any]] | None,
+    ) -> None:
+        """Handle the streaming astream_events path."""
+        hass = self.hass
+
+        async def _run_streaming_task() -> None:
+            """Coroutine to drive the delta stream and ensure cancellation."""
+            event_stream = app.astream_events(
+                input=input_data, config=config, version="v2"
+            )
+            async for _ in chat_log.async_add_delta_content_stream(
+                self.entity_id,
+                _stream_langgraph_to_ha(event_stream, self.entity_id),
+            ):
+                pass
+
+        # Create a task for the streaming process to enable explicit cancellation
+        # if the client disconnects or the conversation turn is aborted.
+        stream_task = hass.async_create_task(_run_streaming_task())
+        try:
+            await stream_task
+        except HomeAssistantError:
+            # Partial content already committed — cannot roll back.
+            # Log and return whatever was committed.
+            _LOGGER.exception(
+                "HomeAssistantError mid-stream; partial content committed."
+            )
+        except asyncio.CancelledError:
+            # Hard kill: cancel the background graph run if the consumer has left.
+            stream_task.cancel()
+            raise
+        finally:
+            if not stream_task.done():
+                stream_task.cancel()
+                # Non-blocking wait to allow generators to close.
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await stream_task
+
+        # Fire trace after stream completes using final graph state.
+        # astream_events handles exhaustion only after graph termination.
+        _LOGGER.debug("====== End of run (streaming) ======")
+        try:
+            final_state = await app.aget_state(config)
+            trace.async_conversation_trace_append(
+                trace.ConversationTraceEventType.AGENT_DETAIL,
+                {
+                    "messages": final_state.values.get("messages", []),
+                    "tools": tools or None,
+                },
+            )
+        except ValueError:
+            # Expected when no checkpointer is configured (e.g. tests)
+            _LOGGER.debug("aget_state unavailable; skipping trace for streaming turn.")
+        except Exception:
+            _LOGGER.exception("Failed to retrieve final state for tracing.")
+
+    async def _async_handle_message(
+        self,
+        user_input: conversation.ConversationInput,
+        chat_log: conversation.ChatLog,
+    ) -> conversation.ConversationResult:
+        """Process the user input."""
+        hass = self.hass
+        options = self.entry.runtime_data.options
+        runtime_data = self.entry.runtime_data
+        intent_response = intent.IntentResponse(language=user_input.language)
+
+        llm_context = llm.LLMContext(
+            platform=DOMAIN,
+            context=user_input.context,
+            language=user_input.language,
+            assistant=conversation.DOMAIN,
+            device_id=user_input.device_id,
+        )
+
+        message_history = self._async_get_message_history(chat_log)
+
+        conversation_id = (
+            ulid.ulid_now()
+            if chat_log.conversation_id is None
+            else chat_log.conversation_id
+        )
+
+        # Multi-API initialization
+        try:
+            llm_api = await self._async_init_llm_apis(llm_context)
+        except HomeAssistantError as err:
+            intent_response.async_set_error(
+                intent.IntentResponseErrorCode.UNKNOWN,
+                str(err),
+            )
+            return conversation.ConversationResult(
+                response=intent_response, conversation_id=conversation_id
+            )
+
+        # --- Global Tool Indexing (Background) ---
+        await self._async_index_tools(llm_context, runtime_data)
+
+        if not options.get(CONF_SCHEMA_FIRST_YAML, False) and _is_dashboard_request(
+            user_input.text
+        ):
+            intent_response.async_set_speech(
+                "Please enable 'Schema-first JSON for YAML requests' in "
+                "HGA's configuration and try again"
+            )
+            return conversation.ConversationResult(
+                response=intent_response, conversation_id=conversation_id
+            )
+
+        tools, langchain_tools = self._async_get_all_tools(llm_api.apis)
 
         # Resolve user name (None means automation)
+        user_name = None
         if (
             user_input.context
             and user_input.context.user_id
@@ -456,55 +787,11 @@ class HGAConversationEntity(conversation.ConversationEntity, AbstractConversatio
         ):
             user_name = user.name
 
-        # Build system prompt
-        try:
-            pin_enabled = options.get(CONF_CRITICAL_ACTION_PIN_ENABLED, False)
-            critical_prompt = CRITICAL_ACTION_PROMPT if pin_enabled else ""
-            schema_prompt = (
-                SCHEMA_FIRST_YAML_PROMPT
-                if options.get(CONF_SCHEMA_FIRST_YAML, False)
-                else ""
-            )
-            prompt_parts = [
-                template.Template(
-                    (
-                        llm.DATE_TIME_PROMPT
-                        + options.get(CONF_PROMPT, llm.DEFAULT_INSTRUCTIONS_PROMPT)
-                        + f"\nYou are in the {self.tz} timezone."
-                        + critical_prompt
-                        + schema_prompt
-                        + TOOL_CALL_ERROR_SYSTEM_MESSAGE
-                        if tools
-                        else ""
-                    ),
-                    self.hass,
-                ).async_render(
-                    {
-                        "ha_name": self.hass.config.location_name,
-                        "user_name": user_name,
-                        "llm_context": llm_context,
-                    },
-                    parse_result=False,
-                )
-            ]
-        except TemplateError as err:
-            _LOGGER.exception("Error rendering prompt.")
-            intent_response = intent.IntentResponse(language=user_input.language)
-            intent_response.async_set_error(
-                intent.IntentResponseErrorCode.UNKNOWN,
-                f"Sorry, I had a problem with my template: {err}",
-            )
-            return conversation.ConversationResult(
-                response=intent_response, conversation_id=conversation_id
-            )
-
-        if llm_api:
-            prompt_parts.append(llm_api.api_prompt)
-
-        prompt = "\n".join(prompt_parts)
+        prompt = self._async_render_system_prompt(
+            llm_context, user_name, llm_api, has_tools=bool(tools)
+        )
 
         # Use the already-configured chat model from __init__.py.
-        # Tool binding happens dynamically per-turn inside _call_model via RAG.
         base_llm = runtime_data.chat_model
         if not hasattr(base_llm, "bind_tools"):
             _LOGGER.exception("Error during conversation processing.")
@@ -533,15 +820,16 @@ class HGAConversationEntity(conversation.ConversationEntity, AbstractConversatio
             )
 
         # A user name of None indicates an automation is being run.
-        user_name = "robot" if user_name is None else user_name
+        clean_user_name = "robot" if user_name is None else user_name
         # Remove special characters since memory namespace labels cannot contain them.
-        user_name = user_name.translate(str.maketrans("", "", string.punctuation))
-        _LOGGER.debug("User name: %s", user_name)
+        clean_user_name = clean_user_name.translate(
+            str.maketrans("", "", string.punctuation)
+        )
 
         app_config: RunnableConfig = {
             "configurable": {
                 "thread_id": conversation_id,
-                "user_id": user_name,
+                "user_id": clean_user_name,
                 "chat_model": base_llm,
                 "chat_model_options": runtime_data.chat_model_options,
                 "prompt": prompt,
@@ -565,9 +853,7 @@ class HGAConversationEntity(conversation.ConversationEntity, AbstractConversatio
         )
 
         # Agent input: message history + current user request.
-        messages: list[AnyMessage] = []
-        messages.extend(message_history)
-        messages.append(HumanMessage(content=user_input.text))
+        messages = [*message_history, HumanMessage(content=user_input.text)]
         app_input: State = {
             "messages": messages,
             "summary": "",
@@ -578,73 +864,21 @@ class HGAConversationEntity(conversation.ConversationEntity, AbstractConversatio
         }
 
         # Interact with agent app.
-        try:
-            response = await app.ainvoke(input=app_input, config=app_config)
-        except HomeAssistantError as err:
-            _LOGGER.exception("LangGraph error during conversation processing.")
-            intent_response = intent.IntentResponse(language=user_input.language)
-            intent_response.async_set_error(
-                intent.IntentResponseErrorCode.UNKNOWN,
-                f"Something went wrong: {err}",
-            )
-            return conversation.ConversationResult(
-                response=intent_response, conversation_id=conversation_id
-            )
-
-        trace.async_conversation_trace_append(
-            trace.ConversationTraceEventType.AGENT_DETAIL,
-            {"messages": response["messages"], "tools": tools or None},
-        )
-
-        _LOGGER.debug("====== End of run ======")
-
-        # Post-process the final LLM text (entity ID resolution, YAML conversion).
-        final_content = response["messages"][-1].content
-        if isinstance(final_content, str):
-            if options.get(CONF_SCHEMA_FIRST_YAML, False):
-                final_content = _maybe_fix_dashboard_entities(final_content, hass)
-            else:
-                final_content = _fix_entity_ids_in_text(final_content, hass)
-            final_content = _convert_schema_json_to_yaml(
-                final_content, options.get(CONF_SCHEMA_FIRST_YAML, False)
-            )
-            _LOGGER.debug("Final response content: %s", final_content)
-
-        # Backfill chat_log with the messages produced this turn so HA's
-        # "Show Details" panel renders the full tool call / result chain.
-        # Slice off history + current HumanMessage — only net-new messages.
-        new_messages = response["messages"][len(app_input["messages"]) :]
-
-        # Guard: async_get_result_from_chat_log requires last entry is AssistantContent,
-        # which means the last new message must be an AIMessage.
-        if not new_messages or not isinstance(new_messages[-1], AIMessage):
-            _LOGGER.error(
-                "LangGraph response did not end with AIMessage (got %s). "
-                "Falling back to manual ConversationResult.",
-                type(new_messages[-1]) if new_messages else "empty",
-            )
-            intent_response = intent.IntentResponse(language=user_input.language)
-            intent_response.async_set_speech(
-                final_content if isinstance(final_content, str) else ""
-            )
-            return conversation.ConversationResult(
-                response=intent_response, conversation_id=conversation_id
-            )
-
-        # Replace the final AIMessage content with the post-processed text so
-        # Show Details reflects the same text the user hears.
-        if isinstance(final_content, str):
-            processed_messages: list[AnyMessage] = [
-                *new_messages[:-1],
-                AIMessage(
-                    content=final_content,
-                    tool_calls=new_messages[-1].tool_calls,
-                ),
-            ]
+        if options.get(CONF_SCHEMA_FIRST_YAML, False):
+            try:
+                await self._async_run_ainvoke(
+                    app, app_input, app_config, chat_log, tools
+                )
+            except HomeAssistantError as err:
+                intent_response.async_set_error(
+                    intent.IntentResponseErrorCode.UNKNOWN,
+                    str(err),
+                )
+                return conversation.ConversationResult(
+                    response=intent_response, conversation_id=conversation_id
+                )
         else:
-            processed_messages = list(new_messages)
-
-        _populate_chat_log_from_response(chat_log, self.entity_id, processed_messages)
+            await self._async_run_astream(app, app_input, app_config, chat_log, tools)
 
         return conversation.async_get_result_from_chat_log(user_input, chat_log)
 

--- a/custom_components/home_generative_agent/conversation.py
+++ b/custom_components/home_generative_agent/conversation.py
@@ -140,6 +140,12 @@ def _normalize_tool_result(content: Any) -> JsonObjectType:
     ToolMessage.content is str for plain string results (HA tools serialize their
     response via json.dumps, so the content is a JSON-encoded string), or list[dict]
     (content blocks) from some providers (e.g. Anthropic).
+
+    HA intent tools (e.g. HassTurnOn) return a JSON string whose decoded form
+    contains a ``response_type`` key (e.g. ``"action_done"``).  If the raw dict
+    is stored in ToolResultContent the HA frontend mistakes it for the final
+    conversation response and renders an empty speech bubble.  We detect that
+    shape and re-encode it so only the meaningful payload is kept.
     """
     if isinstance(content, str):
         # HA tools produce json.dumps(response) as content, so try to deserialize
@@ -147,7 +153,7 @@ def _normalize_tool_result(content: Any) -> JsonObjectType:
         try:
             parsed = json.loads(content)
             if isinstance(parsed, dict):
-                return parsed
+                return _sanitize_tool_result_dict(parsed)
         except (json.JSONDecodeError, ValueError):
             pass
         return {"result": content}
@@ -158,6 +164,38 @@ def _normalize_tool_result(content: Any) -> JsonObjectType:
         ]
         return {"result": "\n".join(parts)}
     return {"result": str(content)}
+
+
+def _sanitize_tool_result_dict(d: dict[str, Any]) -> JsonObjectType:
+    """
+    Reformat HA intent-response dicts to avoid frontend misinterpretation.
+
+    HA intent tools (e.g. HassTurnOn) return a dict with ``response_type`` and
+    ``speech`` keys that mirror the top-level ConversationResult shape.  When
+    stored verbatim in ToolResultContent the HA frontend mistakes it for the
+    final conversation response and renders an empty speech bubble.  We flatten
+    the meaningful payload instead.
+    """
+    if "response_type" not in d:
+        return d
+
+    out: dict[str, Any] = {"result": d["response_type"]}
+
+    # Lift the plain-speech text when present (non-empty string).
+    speech = d.get("speech")
+    if isinstance(speech, dict):
+        plain = speech.get("plain")
+        if isinstance(plain, dict):
+            text = plain.get("speech")
+            if text:
+                out["result"] = text
+
+    # Preserve the data payload (success/failed entity lists, etc.).
+    data = d.get("data")
+    if isinstance(data, dict):
+        out.update(data)
+
+    return out
 
 
 def _populate_chat_log_from_response(

--- a/custom_components/home_generative_agent/conversation.py
+++ b/custom_components/home_generative_agent/conversation.py
@@ -137,10 +137,19 @@ def _normalize_tool_result(content: Any) -> JsonObjectType:
     """
     Normalize ToolMessage.content to JsonObjectType for HA ToolResultContent.
 
-    ToolMessage.content is str for plain string results, or list[dict] (content blocks)
-    from some providers (e.g. Anthropic).
+    ToolMessage.content is str for plain string results (HA tools serialize their
+    response via json.dumps, so the content is a JSON-encoded string), or list[dict]
+    (content blocks) from some providers (e.g. Anthropic).
     """
     if isinstance(content, str):
+        # HA tools produce json.dumps(response) as content, so try to deserialize
+        # back to a dict to avoid double-escaping in Show Details.
+        try:
+            parsed = json.loads(content)
+            if isinstance(parsed, dict):
+                return parsed
+        except (json.JSONDecodeError, ValueError):
+            pass
         return {"result": content}
     if isinstance(content, list):
         parts = [
@@ -276,9 +285,9 @@ async def _stream_langgraph_to_ha(
             # 4. Tool results from the action node.
             elif node == "action" and event_type == "on_chain_end":
                 output = data.get("output")
-                # LangGraph emits two on_chain_end events tagged langgraph_node="action":
-                # (a) the node function's own event: output = {"messages": [ToolMessage, ...]}
-                # (b) a graph-level state event: output = the full updated messages list
+                # LangGraph emits two on_chain_end events for "action":
+                # (a) node function event: output = {"messages": [ToolMessage, ...]}
+                # (b) graph-level state event: output = full updated messages list
                 # We only want (a). Skip anything that is not a dict.
                 if not isinstance(output, dict):
                     continue
@@ -704,6 +713,12 @@ class HGAConversationEntity(conversation.ConversationEntity, AbstractConversatio
             # Hard kill: cancel the background graph run if the consumer has left.
             stream_task.cancel()
             raise
+        except Exception:
+            # Any other exception (e.g. GraphRecursionError, tool failure) leaves
+            # the chat_log in a partial state. Log and fall through to recovery.
+            _LOGGER.exception(
+                "Unexpected error in streaming task; attempting state recovery."
+            )
         finally:
             if not stream_task.done():
                 stream_task.cancel()
@@ -723,6 +738,27 @@ class HGAConversationEntity(conversation.ConversationEntity, AbstractConversatio
                     "tools": tools or None,
                 },
             )
+
+            # If streaming ended without committing a final AssistantContent
+            # (e.g. the generator raised before the last LLM turn), recover the
+            # final AIMessage from the graph state so the caller can return it.
+            if not isinstance(
+                chat_log.content[-1] if chat_log.content else None,
+                conversation.AssistantContent,
+            ):
+                messages = final_state.values.get("messages", [])
+                if messages and isinstance(messages[-1], AIMessage):
+                    final_msg = messages[-1]
+                    chat_log.async_add_assistant_content_without_tools(
+                        conversation.AssistantContent(
+                            agent_id=self.entity_id,
+                            content=_normalize_ai_content(final_msg.content),
+                        )
+                    )
+                    _LOGGER.debug(
+                        "Recovered final AssistantContent from graph state after "
+                        "streaming failure."
+                    )
         except ValueError:
             # Expected when no checkpointer is configured (e.g. tests)
             _LOGGER.debug("aget_state unavailable; skipping trace for streaming turn.")

--- a/custom_components/home_generative_agent/conversation.py
+++ b/custom_components/home_generative_agent/conversation.py
@@ -8,8 +8,12 @@ import hashlib
 import json
 import logging
 import string
-from collections.abc import AsyncGenerator, AsyncIterable
+from collections import deque
+from collections.abc import AsyncIterable, AsyncIterator
 from typing import TYPE_CHECKING, Any, Literal, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 import homeassistant.util.dt as dt_util
 import voluptuous as vol
@@ -21,7 +25,7 @@ from homeassistant.components.conversation import (
 )
 from homeassistant.components.conversation.models import AbstractConversationAgent
 from homeassistant.const import CONF_LLM_HASS_API, MATCH_ALL
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, TemplateError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import intent, llm, template
 from homeassistant.helpers.dispatcher import async_dispatcher_send
@@ -76,7 +80,12 @@ from .core.conversation_helpers import (
 from .core.utils import gather_store_puts_in_chunks
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, AsyncIterable, Callable, Mapping
+    from collections.abc import (
+        AsyncIterable,
+        AsyncIterator,
+        Callable,
+        Mapping,
+    )
 
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
@@ -256,114 +265,218 @@ def _populate_chat_log_from_response(
             )
 
 
-# ruff: noqa: PLR0912
+def _handle_on_chat_model_end(
+    data: dict[str, Any],
+    pending_tool_map: dict[str, ToolCall],
+    unidentified_call_ids: deque[str],
+) -> AssistantContentDeltaDict | None:
+    """
+    Process on_chat_model_end events to record tool calls.
+
+    Updates pending_tool_map with new tool calls and handles ULID generation
+    for calls without native IDs, tracking them in unidentified_call_ids for
+    later correlation.
+    """
+    msg = data.get("output")
+    if not isinstance(msg, AIMessage) or not msg.tool_calls:
+        return None
+
+    call_id_map = []
+    for tc in msg.tool_calls:
+        orig_id = tc.get("id")
+        call_id = orig_id or ulid.ulid_now()
+        if not orig_id:
+            unidentified_call_ids.append(call_id)
+        pending_tool_map[call_id] = tc
+        call_id_map.append(call_id)
+
+    return AssistantContentDeltaDict(
+        tool_calls=[
+            llm.ToolInput(
+                tool_name=str(tc["name"]),
+                tool_args=cast("dict[str, Any]", tc["args"]),
+                id=call_id_map[i],
+                external=True,
+            )
+            for i, tc in enumerate(msg.tool_calls)
+        ]
+    )
+
+
+def _handle_on_chain_end(
+    data: dict[str, Any],
+    pending_tool_map: dict[str, ToolCall],
+    unidentified_call_ids: deque[str],
+) -> list[ToolResultContentDeltaDict]:
+    """
+    Process on_chain_end events for the action node to yield tool results.
+
+    Correlates results back to pending tool calls (handling ID-less correlation
+    via unidentified_call_ids) and yields ToolResultContentDeltaDicts. Any
+    tools that did not return a result are yielded as synthetic rejections.
+    """
+    output = data.get("output")
+    # LangGraph emits two on_chain_end events for "action":
+    # (a) node function event: output = {"messages": [ToolMessage, ...]}
+    # (b) graph-level state event: output = full updated messages list
+    # We only want (a). Skip anything that is not a dict (e.g. the list in (b)).
+    if not isinstance(output, dict):
+        return []
+
+    messages = cast("list[Any]", output.get("messages", []))
+    tool_messages = [m for m in messages if isinstance(m, ToolMessage)]
+
+    deltas: list[ToolResultContentDeltaDict] = []
+
+    # 1. Yield successful results and remove from pending map.
+    for msg in tool_messages:
+        tool_call_id = msg.tool_call_id
+        # Fallback correlation for models without tool IDs.
+        if (not tool_call_id or tool_call_id == "None") and unidentified_call_ids:
+            tool_call_id = unidentified_call_ids.popleft()
+
+        pending_tool_map.pop(tool_call_id, None)
+
+        deltas.append(
+            ToolResultContentDeltaDict(
+                role="tool_result",
+                tool_call_id=str(tool_call_id or ""),
+                tool_name=str(msg.name or ""),
+                tool_result=_normalize_tool_result(msg.content),
+            )
+        )
+
+    # 2. Yield synthetic rejections for any calls that didn't return a result.
+    deltas.extend(
+        _get_synthetic_rejections(
+            pending_tool_map, "Tool execution rejected by routing policy."
+        )
+    )
+    pending_tool_map.clear()
+    unidentified_call_ids.clear()
+    return deltas
+
+
+def _get_synthetic_rejections(
+    pending_tool_map: dict[str, ToolCall], error_msg: str
+) -> list[ToolResultContentDeltaDict]:
+    """
+    Generate synthetic tool result rejections for pending calls.
+
+    Used when a tool execution is rejected by policy or fails mid-stream,
+    ensuring Home Assistant receives a final state for all initiated calls.
+    """
+    return [
+        ToolResultContentDeltaDict(
+            role="tool_result",
+            tool_call_id=call_id,
+            tool_name=tc.get("name") or "tool",
+            tool_result={"error": error_msg},
+        )
+        for call_id, tc in pending_tool_map.items()
+    ]
+
+
+def _handle_on_chat_model_stream(
+    data: dict[str, Any],
+) -> AssistantContentDeltaDict | None:
+    """
+    Process on_chat_model_stream events to yield text tokens.
+
+    Filters out tool-call chunks and empty content, yielding only valid
+    AssistantContentDeltaDict tokens.
+    """
+    chunk = data.get("chunk")
+    if not isinstance(chunk, AIMessageChunk) or chunk.tool_call_chunks:
+        return None
+
+    if chunk_text := _normalize_ai_content(chunk.content):
+        return AssistantContentDeltaDict(content=chunk_text)
+    return None
+
+
+def _process_stream_event(
+    event: Mapping[str, Any],
+    pending_tool_map: dict[str, ToolCall],
+    unidentified_call_ids: deque[str],
+) -> Iterator[AssistantContentDeltaDict | ToolResultContentDeltaDict]:
+    """
+    Process a single LangGraph event and yield HA ChatLog deltas.
+
+    Dispatches LangGraph astream_events (start, stream, end) to the appropriate
+    handler based on the node and event type. Manages the orchestration of
+    token streaming and tool call/result lifecycle.
+    """
+    metadata = cast("dict[str, Any]", event.get("metadata", {}))
+    node = metadata.get("langgraph_node")
+    event_type = event.get("event")
+    data = cast("dict[str, Any]", event.get("data", {}))
+
+    if node == "agent":
+        if event_type == "on_chat_model_start":
+            yield AssistantContentDeltaDict(role="assistant")
+        elif (
+            event_type == "on_chat_model_stream"
+            and (delta := _handle_on_chat_model_stream(data))
+        ) or (
+            event_type == "on_chat_model_end"
+            and (
+                delta := _handle_on_chat_model_end(
+                    data, pending_tool_map, unidentified_call_ids
+                )
+            )
+        ):
+            yield delta
+    elif node == "action" and event_type == "on_chain_end":
+        for delta in _handle_on_chain_end(
+            data, pending_tool_map, unidentified_call_ids
+        ):
+            yield delta
+
+
 async def _stream_langgraph_to_ha(
     event_stream: AsyncIterable[Mapping[str, Any]],
     _agent_id: str,
-) -> AsyncGenerator[AssistantContentDeltaDict | ToolResultContentDeltaDict]:
+) -> AsyncIterator[AssistantContentDeltaDict | ToolResultContentDeltaDict]:
     """
     Transform LangGraph astream_events into HA ChatLog deltas.
 
     Filters for events from the 'agent' node for tokens/tool-calls and the
     'action' node for tool results.
     """
+    # pending_tool_map survives across multiple model turns (iterations) within
+    # this generator to handle partial-result cases where some tools return results
+    # and others don't. It is cleared only after synthetic rejections are yielded
+    # at the end of an 'action' node chain.
     pending_tool_map: dict[str, ToolCall] = {}
+
+    # unidentified_call_ids tracks ULIDs generated for tool calls that lacked
+    # native IDs. This ensures we can correlate ToolMessages from the 'action'
+    # node back to the correct HA ToolInput entry even when the LLM provider
+    # (e.g. local models) drops the ID.
+    unidentified_call_ids: deque[str] = deque()
 
     try:
         async for event in event_stream:
-            ev = cast("dict[str, Any]", event)
-            metadata = cast("dict[str, Any]", ev.get("metadata", {}))
-            node = metadata.get("langgraph_node")
-            event_type = ev.get("event")
-            data = cast("dict[str, Any]", ev.get("data", {}))
-
-            # 1. Start of a model turn: open an AssistantContent block.
-            # HA flushes any previous AssistantContent when it receives a
-            # role="assistant" delta. We yield this at every agent start to ensure
-            # HA state sync in recursive loops (Agent -> Action -> Agent).
-            if node == "agent" and event_type == "on_chat_model_start":
-                yield AssistantContentDeltaDict(role="assistant")
-
-            # 2. Incremental text tokens.
-            elif node == "agent" and event_type == "on_chat_model_stream":
-                chunk = data.get("chunk")
-                if not isinstance(chunk, AIMessageChunk) or chunk.tool_call_chunks:
-                    continue
-
-                chunk_text = _normalize_ai_content(chunk.content)
-                if chunk_text:
-                    yield AssistantContentDeltaDict(content=chunk_text)
-
-            # 3. End of a model turn: record pending tool calls.
-            elif node == "agent" and event_type == "on_chat_model_end":
-                msg = data.get("output")
-                if not isinstance(msg, AIMessage):
-                    continue
-
-                if msg.tool_calls:
-                    # Update mapping for result correlation.
-                    call_id_map = []
-                    for tc in msg.tool_calls:
-                        call_id = tc.get("id") or ulid.ulid_now()
-                        pending_tool_map[call_id] = tc
-                        call_id_map.append(call_id)
-
-                    yield AssistantContentDeltaDict(
-                        tool_calls=[
-                            llm.ToolInput(
-                                tool_name=str(tc["name"]),
-                                tool_args=cast("dict[str, Any]", tc["args"]),
-                                id=call_id_map[i],
-                                external=True,
-                            )
-                            for i, tc in enumerate(msg.tool_calls)
-                        ]
-                    )
-
-            # 4. Tool results from the action node.
-            elif node == "action" and event_type == "on_chain_end":
-                output = data.get("output")
-                # LangGraph emits two on_chain_end events for "action":
-                # (a) node function event: output = {"messages": [ToolMessage, ...]}
-                # (b) graph-level state event: output = full updated messages list
-                # We only want (a). Skip anything that is not a dict.
-                if not isinstance(output, dict):
-                    continue
-                messages = cast("list[Any]", output.get("messages", []))
-                tool_messages = [m for m in messages if isinstance(m, ToolMessage)]
-
-                # 1. Yield successful results and remove from pending map.
-                for msg in tool_messages:
-                    pending_tool_map.pop(msg.tool_call_id, None)
-
-                    yield ToolResultContentDeltaDict(
-                        role="tool_result",
-                        tool_call_id=str(msg.tool_call_id),
-                        tool_name=str(msg.name or ""),
-                        tool_result=_normalize_tool_result(msg.content),
-                    )
-
-                # 2. Yield synthetic rejections for any calls that didn't return a
-                # result. This ensures HA doesn't hang if a tool fails silently or
-                # is rejected.
-                for call_id, tc in pending_tool_map.items():
-                    yield ToolResultContentDeltaDict(
-                        role="tool_result",
-                        tool_call_id=call_id,
-                        tool_name=tc.get("name") or "tool",
-                        tool_result={
-                            "error": "Tool execution rejected by routing policy."
-                        },
-                    )
-                pending_tool_map.clear()
+            for delta in _process_stream_event(
+                event, pending_tool_map, unidentified_call_ids
+            ):
+                yield delta
     except (GeneratorExit, asyncio.CancelledError):
         # Stop iteration on cancellation or closure.
         raise
     except Exception:
         _LOGGER.exception("Error in LangGraph streaming transformation generator.")
+        # Persistence guard: flush pending tools as synthetic rejections so HA
+        # doesn't hang waiting for results that will never arrive due to the error.
+        for delta in _get_synthetic_rejections(
+            pending_tool_map, "Tool execution failed mid-stream."
+        ):
+            yield delta
         raise
     finally:
         pending_tool_map.clear()
+        unidentified_call_ids.clear()
 
 
 class MultiLLMAPI:
@@ -611,28 +724,33 @@ class HGAConversationEntity(conversation.ConversationEntity, AbstractConversatio
             if options.get(CONF_SCHEMA_FIRST_YAML, False)
             else ""
         )
-        prompt_parts = [
-            template.Template(
-                (
-                    llm.DATE_TIME_PROMPT
-                    + options.get(CONF_PROMPT, llm.DEFAULT_INSTRUCTIONS_PROMPT)
-                    + f"\nYou are in the {self.tz} timezone."
-                    + critical_prompt
-                    + schema_prompt
-                    + TOOL_CALL_ERROR_SYSTEM_MESSAGE
-                    if has_tools
-                    else ""
-                ),
-                self.hass,
-            ).async_render(
-                {
-                    "ha_name": self.hass.config.location_name,
-                    "user_name": user_name,
-                    "llm_context": llm_context,
-                },
-                parse_result=False,
-            )
-        ]
+        try:
+            prompt_parts = [
+                template.Template(
+                    (
+                        llm.DATE_TIME_PROMPT
+                        + options.get(CONF_PROMPT, llm.DEFAULT_INSTRUCTIONS_PROMPT)
+                        + f"\nYou are in the {self.tz} timezone."
+                        + critical_prompt
+                        + schema_prompt
+                        + TOOL_CALL_ERROR_SYSTEM_MESSAGE
+                        if has_tools
+                        else ""
+                    ),
+                    self.hass,
+                ).async_render(
+                    {
+                        "ha_name": self.hass.config.location_name,
+                        "user_name": user_name,
+                        "llm_context": llm_context,
+                    },
+                    parse_result=False,
+                )
+            ]
+        except TemplateError as err:
+            _LOGGER.exception("Error rendering prompt")
+            msg = f"Error rendering prompt: {err}"
+            raise HomeAssistantError(msg) from err
 
         if llm_api:
             prompt_parts.append(llm_api.api_prompt)

--- a/custom_components/home_generative_agent/conversation.py
+++ b/custom_components/home_generative_agent/conversation.py
@@ -9,7 +9,6 @@ import json
 import logging
 import string
 from collections import deque
-from collections.abc import AsyncIterable, AsyncIterator
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 if TYPE_CHECKING:
@@ -891,24 +890,23 @@ class HGAConversationEntity(conversation.ConversationEntity, AbstractConversatio
                 # Non-blocking wait to allow generators to close.
                 with contextlib.suppress(asyncio.CancelledError, Exception):
                     await stream_task
-
-        # Fire trace after stream completes using final graph state.
-        # astream_events handles exhaustion only after graph termination.
-        _LOGGER.debug("====== End of run (streaming) ======")
-
-        # Re-fire CONTENT_ADDED for the final AssistantContent so the HA
-        # frontend's streaming UI shows it in the main chat area.
-        # async_add_delta_content_stream flushes via async_add_assistant_content,
-        # which does NOT fire CONTENT_ADDED for AssistantContent. Re-committing
-        # via async_add_assistant_content_without_tools does fire it.
-        if (
-            chat_log.content
-            and isinstance(chat_log.content[-1], conversation.AssistantContent)
-            and not chat_log.content[-1].tool_calls
-            and chat_log.content[-1].content
-        ):
-            final_content = cast(conversation.AssistantContent, chat_log.content.pop())
-            chat_log.async_add_assistant_content_without_tools(final_content)
+            # Re-fire CONTENT_ADDED for the final AssistantContent so the HA
+            # frontend's streaming UI shows it in the main chat area.
+            # async_add_delta_content_stream flushes via async_add_assistant_content,
+            # which does NOT fire CONTENT_ADDED for AssistantContent. Re-committing
+            # via async_add_assistant_content_without_tools does fire it.
+            # Runs even on cancellation so the UI is consistent if HA reads
+            # partial chat_log state after a cancelled turn.
+            if (
+                chat_log.content
+                and isinstance(chat_log.content[-1], conversation.AssistantContent)
+                and not chat_log.content[-1].tool_calls
+                and chat_log.content[-1].content
+            ):
+                _final_content = cast(
+                    "conversation.AssistantContent", chat_log.content.pop()
+                )
+                chat_log.async_add_assistant_content_without_tools(_final_content)
 
         try:
             final_state = await app.aget_state(config)
@@ -1102,6 +1100,19 @@ class HGAConversationEntity(conversation.ConversationEntity, AbstractConversatio
                 )
         else:
             await self._async_run_astream(app, app_input, app_config, chat_log, tools)
+
+        # Guard against an empty chat log (e.g. HomeAssistantError swallowed mid-stream
+        # before any AssistantContent was committed).
+        # async_get_result_from_chat_log raises if no AssistantContent is present.
+        if not any(
+            isinstance(msg, conversation.AssistantContent) for msg in chat_log.content
+        ):
+            chat_log.async_add_assistant_content_without_tools(
+                conversation.AssistantContent(
+                    agent_id=self.entity_id,
+                    content="",
+                )
+            )
 
         return conversation.async_get_result_from_chat_log(user_input, chat_log)
 

--- a/custom_components/home_generative_agent/conversation.py
+++ b/custom_components/home_generative_agent/conversation.py
@@ -333,18 +333,20 @@ def _handle_on_chain_end(
         tool_call_id = msg.tool_call_id
         # Fallback correlation for models without tool IDs.
         if (not tool_call_id or tool_call_id == "None") and unidentified_call_ids:
-            tool_call_id = unidentified_call_ids.popleft()
+            # Peek first; only pop if it matches a pending call
+            if unidentified_call_ids[0] in pending_tool_map:
+                tool_call_id = unidentified_call_ids.popleft()
 
-        pending_tool_map.pop(tool_call_id, None)
-
-        deltas.append(
-            ToolResultContentDeltaDict(
-                role="tool_result",
-                tool_call_id=str(tool_call_id or ""),
-                tool_name=str(msg.name or ""),
-                tool_result=_normalize_tool_result(msg.content),
+        if tool_call_id in pending_tool_map:
+            pending_tool_map.pop(tool_call_id)
+            deltas.append(
+                ToolResultContentDeltaDict(
+                    role="tool_result",
+                    tool_call_id=str(tool_call_id),
+                    tool_name=str(msg.name or ""),
+                    tool_result=_normalize_tool_result(msg.content),
+                )
             )
-        )
 
     # 2. Yield synthetic rejections for any calls that didn't return a result.
     deltas.extend(
@@ -383,11 +385,11 @@ def _handle_on_chat_model_stream(
     """
     Process on_chat_model_stream events to yield text tokens.
 
-    Filters out tool-call chunks and empty content, yielding only valid
-    AssistantContentDeltaDict tokens.
+    Yields text content even if the chunk also contains tool call chunks,
+    ensuring that mid-message tool calls do not swallow preceding text.
     """
     chunk = data.get("chunk")
-    if not isinstance(chunk, AIMessageChunk) or chunk.tool_call_chunks:
+    if not isinstance(chunk, AIMessageChunk):
         return None
 
     if chunk_text := _normalize_ai_content(chunk.content):
@@ -408,7 +410,7 @@ def _process_stream_event(
     token streaming and tool call/result lifecycle.
     """
     metadata = cast("dict[str, Any]", event.get("metadata", {}))
-    node = metadata.get("langgraph_node")
+    node = metadata.get("langgraph_node") or event.get("name")
     event_type = event.get("event")
     data = cast("dict[str, Any]", event.get("data", {}))
 
@@ -428,10 +430,10 @@ def _process_stream_event(
         ):
             yield delta
     elif node == "action" and event_type == "on_chain_end":
-        for delta in _handle_on_chain_end(
+        for res_delta in _handle_on_chain_end(
             data, pending_tool_map, unidentified_call_ids
         ):
-            yield delta
+            yield res_delta
 
 
 async def _stream_langgraph_to_ha(
@@ -456,11 +458,20 @@ async def _stream_langgraph_to_ha(
     # (e.g. local models) drops the ID.
     unidentified_call_ids: deque[str] = deque()
 
+    # track the current role to avoid yielding redundant 'role' deltas that
+    # might cause the HA frontend to reset the message content during loops.
+    active_role: str | None = None
+
     try:
         async for event in event_stream:
             for delta in _process_stream_event(
                 event, pending_tool_map, unidentified_call_ids
             ):
+                new_role = delta.get("role")
+                if new_role == "assistant" and active_role == "assistant":
+                    continue
+                if new_role:
+                    active_role = new_role
                 yield delta
     except (GeneratorExit, asyncio.CancelledError):
         # Stop iteration on cancellation or closure.

--- a/custom_components/home_generative_agent/conversation.py
+++ b/custom_components/home_generative_agent/conversation.py
@@ -332,10 +332,12 @@ def _handle_on_chain_end(
     for msg in tool_messages:
         tool_call_id = msg.tool_call_id
         # Fallback correlation for models without tool IDs.
-        if (not tool_call_id or tool_call_id == "None") and unidentified_call_ids:
-            # Peek first; only pop if it matches a pending call
-            if unidentified_call_ids[0] in pending_tool_map:
-                tool_call_id = unidentified_call_ids.popleft()
+        if (
+            (not tool_call_id or tool_call_id == "None")
+            and unidentified_call_ids
+            and unidentified_call_ids[0] in pending_tool_map
+        ):
+            tool_call_id = unidentified_call_ids.popleft()
 
         if tool_call_id in pending_tool_map:
             pending_tool_map.pop(tool_call_id)
@@ -430,10 +432,7 @@ def _process_stream_event(
         ):
             yield delta
     elif node == "action" and event_type == "on_chain_end":
-        for res_delta in _handle_on_chain_end(
-            data, pending_tool_map, unidentified_call_ids
-        ):
-            yield res_delta
+        yield from _handle_on_chain_end(data, pending_tool_map, unidentified_call_ids)
 
 
 async def _stream_langgraph_to_ha(
@@ -908,7 +907,7 @@ class HGAConversationEntity(conversation.ConversationEntity, AbstractConversatio
             and not chat_log.content[-1].tool_calls
             and chat_log.content[-1].content
         ):
-            final_content = chat_log.content.pop()
+            final_content = cast(conversation.AssistantContent, chat_log.content.pop())
             chat_log.async_add_assistant_content_without_tools(final_content)
 
         try:

--- a/custom_components/home_generative_agent/manifest.json
+++ b/custom_components/home_generative_agent/manifest.json
@@ -33,5 +33,5 @@
     "transformers==4.57.1",
     "langchain-google-genai==3.1.0"
   ],
-  "version": "3.11.1"
+  "version": "3.12.0"
 }

--- a/docs/streaming-design.md
+++ b/docs/streaming-design.md
@@ -1,0 +1,436 @@
+# Design: Native LLM Streaming via astream_events + HA ChatLog Delta (Issue #370)
+
+Branch: `feat/streaming-chatlog` | Status: APPROVED (v5, 2026-04-17)
+
+## Problem Statement
+
+HGA blocks on `app.ainvoke()` until the full LangGraph response is complete before
+returning any text or audio. For voice pipelines this creates audible silence gaps.
+For text chat, users see no feedback until the full response arrives. HA 2026.4.0
+introduced `async_add_delta_content_stream()` and a delta streaming protocol to fix
+this. HGA does not yet use it.
+
+## What Makes This Cool
+
+First token reaches the HA voice pipeline while LangGraph is still running tool calls.
+Silence gaps disappear. The "Show Details" panel streams in real time. This is the
+architecture HA designed for — HGA has been the odd one out since 2026.4.0.
+
+## Constraints
+
+- Part 1 (#369, PR #371) shipped `async_add_assistant_content_without_tools()`.
+  That commit logic must be **replaced**, not layered on top — the two approaches
+  are mutually exclusive for the same turn (1Jamie, #368).
+- `schema_first_yaml=True` mode does full-response JSON→YAML conversion that cannot
+  be done per-token. That mode falls back to the existing `ainvoke` path.
+- All ToolInputs must use `external=True` — LangGraph executes tools, not HA.
+- Post-processing (`_fix_entity_ids_in_text`) cannot be applied to a committed stream.
+  Dropped for streaming path in this PR; relocate to graph as a follow-up.
+
+## Premises
+
+1. `schema_first_yaml=True` is rare enough that an `ainvoke` fallback for that mode
+   is acceptable for MVP — no streaming TTFT for dashboard generation.
+2. `_fix_entity_ids_in_text` fires rarely in practice and is display-only (not
+   safety-critical). Dropping it from the streaming path is a safe MVP trade-off;
+   it should move into the graph as a post-processing node later.
+3. Filtering on `event["metadata"]["langgraph_node"] == "agent"` is sufficient to
+   exclude summarization node tokens from the stream.
+4. Tool call argument tokens (`on_chat_model_stream` during tool-call generation)
+   should be suppressed — JSON fragments, not user-readable text. Only text content
+   tokens stream to HA.
+5. The transformation function lives in `conversation.py` as a private async generator.
+   No new module. Minimal diff.
+6. `_attr_supports_streaming = True` is set unconditionally. Setting this flag enables
+   the `async_add_delta_content_stream()` API on ChatLog — it does NOT prohibit calling
+   `async_add_assistant_content_without_tools()` (which the schema_first_yaml fallback
+   path continues to use via `_populate_chat_log_from_response`). The two are compatible.
+
+## Approaches Considered
+
+### Approach A: Minimal — transformation function, schema_first_yaml fallback (CHOSEN)
+- Replace `ainvoke()` with `astream_events()` in `conversation.py`
+- Add `_stream_langgraph_to_ha()` async generator (transformation function)
+- `schema_first_yaml=True` branches to existing `ainvoke` + `_populate_chat_log_from_response` path
+- Remove `_populate_chat_log_from_response` from non-schema_first_yaml path
+- Effort: M | Risk: Low | Files: primarily `conversation.py`
+
+### Approach B: Ideal — graph-level post-processing node
+- Move `_fix_entity_ids_in_text` into a post-processing LangGraph node after `_call_model`
+- Single streaming code path, no ainvoke fallback
+- Effort: L | Risk: Medium | Files: `conversation.py` + `agent/graph.py`
+
+## Recommended Approach: A
+
+Minimal diff, single new abstraction, well-understood fallback. Entity ID fixing moves
+into the graph as a follow-up — that's the right separation of concerns anyway.
+
+## Implementation Plan
+
+### 1. Set `_attr_supports_streaming = True`
+
+On `HGAConversationEntity`. HA will now expect the streaming path to be available.
+This enables `async_add_delta_content_stream()` on ChatLog objects. The schema_first_yaml
+fallback continues to call `async_add_assistant_content_without_tools()` — that method
+remains available regardless of this flag. No conflict.
+
+### 2. Add `_stream_langgraph_to_ha()` transformation function
+
+Private async generator in `conversation.py`. Signature:
+
+```python
+async def _stream_langgraph_to_ha(
+    event_stream: AsyncIterable[dict],
+    agent_id: str,
+) -> AsyncGenerator[AssistantContentDeltaDict | ToolResultContentDeltaDict, None]:
+```
+
+**Event mapping logic:**
+
+The HA `async_add_delta_content_stream` state machine rules:
+- Delta with `role="assistant"`: flush any accumulated block → open new AssistantContent block
+- Delta without `role`: append content/tool_calls/thinking_content to current block
+- Delta with `role="tool_result"`: flush accumulated AssistantContent → commit ToolResultContent
+- Generator exhaustion: auto-flush any remaining accumulated block
+
+Therefore `role="assistant"` must be sent at **block open** (`on_chat_model_start`),
+not at block close. Sending it at `on_chat_model_end` with `content=accumulated_text`
+causes HA to flush the accumulated text, then seed a NEW block with that same text,
+resulting in double-committed content. This matches HA reference implementations
+(OpenAI entity, Google AI entity) which send `role="assistant"` at message open.
+
+No `accumulated_text` state variable is needed — HA accumulates internally.
+The generator holds one piece of cross-event state: `_pending_tool_calls` — the list
+of tool_call dicts from the most recent `on_chat_model_end`, used to synthesize error
+results if `on_chain_end` for "action" returns an empty message list.
+
+```
+# Generator-level state (initialised once, persists across events):
+_pending_tool_calls: list[dict] = []
+
+on_chat_model_start
+  event.get("metadata", {}).get("langgraph_node") == "agent"
+  → yield AssistantContentDeltaDict(role="assistant")  # opens new block, no content
+  (retrieve_tools uses an embedding model → fires on_embeddings_* events, NOT
+  on_chat_model_start — the "agent" node filter is therefore sufficient.)
+
+on_chat_model_stream
+  event.get("metadata", {}).get("langgraph_node") == "agent"
+  → extract chunk_text from AIMessageChunk.content:
+      if isinstance(chunk.content, str): chunk_text = chunk.content
+      elif isinstance(chunk.content, list):
+          chunk_text = "".join(
+              b.get("text", "") for b in chunk.content
+              if isinstance(b, dict) and b.get("type") == "text"
+          )
+      else: chunk_text = ""
+  → skip if chunk_text is empty OR chunk.tool_call_chunks is non-empty
+  → yield AssistantContentDeltaDict(content=chunk_text)  # no role = incremental
+
+on_chat_model_end
+  event.get("metadata", {}).get("langgraph_node") == "agent"
+  AIMessage has tool_calls
+  → _pending_tool_calls = list(tool_calls)  # track for synthetic fallback
+  → yield AssistantContentDeltaDict(
+        tool_calls=[llm.ToolInput(external=True, id=tc["id"], tool_name=tc["name"],
+                              tool_args=tc["args"]) for tc in tool_calls]
+    )  # no role — appends tool_calls to current block; role="tool_result" will flush
+
+  AIMessage has no tool_calls (final response)
+  → _pending_tool_calls = []
+  → no yield — generator exhaustion auto-flushes the accumulated block
+
+on_chain_end
+  event.get("metadata", {}).get("langgraph_node") == "action"
+  tool_messages = [
+      msg for msg in event["data"]["output"].get("messages", [])
+      if isinstance(msg, ToolMessage)
+  ]
+
+  if tool_messages:
+      → for each msg in tool_messages:
+            yield ToolResultContentDeltaDict(
+                role="tool_result",
+                tool_call_id=msg.tool_call_id,
+                tool_name=msg.name or "",
+                tool_result=_normalize_tool_result(msg.content),
+            )
+      → _pending_tool_calls = []
+      (first role="tool_result" flushes the accumulated AssistantContent with its
+      tool_calls; each subsequent one commits an additional ToolResultContent block)
+
+  else:
+      # No tool messages — routing guard or precheck rejected all calls before
+      # they produced results. Without a role="tool_result", the open AssistantContent
+      # block (with its tool_calls) would hang until the next role="assistant" flushes
+      # it, leaving the LLM with tool calls in its context window but no results.
+      # That ambiguity causes hallucinated results or retry loops.
+      # Inject a synthetic rejection result for every pending tool_call so the
+      # LLM receives an explicit policy-rejection signal.
+      for tc in _pending_tool_calls:
+          yield ToolResultContentDeltaDict(
+              role="tool_result",
+              tool_call_id=tc.get("id") or "",
+              tool_name=tc.get("name") or "",
+              tool_result={"error": "tool execution rejected by routing policy"},
+          )
+      _pending_tool_calls = []
+
+all other events → skip
+```
+
+**Content normalization:** `AIMessageChunk.content` is a `str` for OpenAI/Gemini/local
+models and a `list[dict]` (content blocks) for Anthropic Claude (same structure as
+`AIMessage.content`). The extraction logic above mirrors `_normalize_ai_content()` at
+`conversation.py:104`. Apply it consistently to every `on_chat_model_stream` chunk.
+
+**`tool_args=` not `tool_input=`:** `llm.ToolInput` dataclass field is `tool_args`
+(verified from existing call sites at `conversation.py:165`). Using `tool_input=` raises
+`TypeError` at runtime.
+
+**Why `on_chain_end` for "action" node, not `on_tool_end`:**
+
+`_call_tools` dispatches to either `_run_langchain_tool` (calls `lc_tool.ainvoke()`,
+which IS a LangChain Runnable and emits `on_tool_end`) or `_run_ha_tool` (calls
+`llm_api.async_call_tool()`, which is NOT a LangChain Runnable and does NOT emit
+`on_tool_end`). Using `on_tool_end` would silently miss all HA tool results. The
+action node's `on_chain_end` fires after ALL tools complete and contains the full
+`{"messages": [ToolMessage, ...]}` in `event["data"]["output"]`. This is the correct
+and complete source for tool results.
+
+**`_normalize_tool_result` note:**
+This function is already defined at `conversation.py:122`. It converts `ToolMessage.content`
+(str or list) to `JsonObjectType` for HA's `ToolResultContent`. Reuse as-is.
+
+**Anthropic thinking_content:**
+`AIMessageChunk` may contain thinking blocks for Claude models. In langchain-anthropic,
+thinking blocks arrive in `chunk.content` as list items — same list-of-blocks format as
+text, but with `"type": "thinking"` and `"thinking": "..."` keys. They do NOT appear in
+`additional_kwargs`. To extract:
+```python
+chunk_thinking = "".join(
+    b.get("thinking", "") for b in chunk.content
+    if isinstance(b, dict) and b.get("type") == "thinking"
+)
+```
+When non-empty, include in the same delta as content:
+`AssistantContentDeltaDict(content=chunk_text or None, thinking_content=chunk_thinking or None)`.
+The `test_stream_anthropic_thinking` mock must use `chunk.content = [{"type": "thinking", "thinking": "..."}]`,
+NOT `chunk.additional_kwargs = {"thinking": "..."}`. Low effort, makes Show Details
+richer for Claude users. Deferred — silently no-ops if not implemented.
+
+### 3. Replace the invoke block in `_async_handle_message`
+
+```python
+if options.get(CONF_SCHEMA_FIRST_YAML, False):
+    # schema_first_yaml requires full-response JSON→YAML conversion.
+    # Stream not supported for this mode — use existing ainvoke path.
+    try:
+        response = await app.ainvoke(input=app_input, config=app_config)
+    except HomeAssistantError as err:
+        _LOGGER.exception("LangGraph error during conversation processing.")
+        intent_response = intent.IntentResponse(language=user_input.language)
+        intent_response.async_set_error(
+            intent.IntentResponseErrorCode.UNKNOWN,
+            f"Something went wrong: {err}",
+        )
+        return conversation.ConversationResult(
+            response=intent_response, conversation_id=conversation_id
+        )
+    trace.async_conversation_trace_append(
+        trace.ConversationTraceEventType.AGENT_DETAIL,
+        {"messages": response["messages"], "tools": tools or None},
+    )
+    # ... existing post-processing and _populate_chat_log_from_response ...
+else:
+    # Streaming path — tokens reach HA as they arrive.
+    event_stream = app.astream_events(
+        input=app_input, config=app_config, version="v2"
+    )
+    try:
+        async for _ in chat_log.async_add_delta_content_stream(
+            self.entity_id,
+            _stream_langgraph_to_ha(event_stream, self.entity_id),
+        ):
+            pass  # HA commits each content block; we consume the generator
+    except HomeAssistantError:
+        # Partial content already committed — cannot roll back.
+        # Log and return whatever was committed rather than failing silently.
+        _LOGGER.exception(
+            "HomeAssistantError mid-stream; partial content committed to chat_log."
+        )
+
+    # Fire trace after stream completes using final graph state.
+    # LangGraph writes checkpoint at node completion, BEFORE emitting on_chain_end.
+    # By the time astream_events() is exhausted, the final checkpoint is committed.
+    # aget_state() therefore returns current-turn state, not a stale prior checkpoint.
+    # If no checkpointer is configured (test mode), aget_state() raises — catch and skip.
+    try:
+        final_state = await app.aget_state(app_config)
+        trace.async_conversation_trace_append(
+            trace.ConversationTraceEventType.AGENT_DETAIL,
+            {"messages": final_state.values.get("messages", []), "tools": tools or None},
+        )
+    except Exception:  # noqa: BLE001
+        _LOGGER.debug("aget_state unavailable; skipping trace for streaming turn.")
+
+    return conversation.async_get_result_from_chat_log(user_input, chat_log)
+```
+
+### 4. Error handling mid-stream
+
+If `astream_events()` raises `HomeAssistantError` mid-stream, partial content is
+already committed to chat_log — cannot be rolled back. Behavior change from current
+ainvoke path (which replaces with error message): partial response is committed as-is.
+This is better than silent failure. Document in changelog.
+
+`HomeAssistantError` mid-stream is caught at the `async for` level (around the
+`async_add_delta_content_stream` call). The trace append and result construction
+still run — `async_get_result_from_chat_log` returns whatever is in chat_log.
+
+Note: HA's `async_add_delta_content_stream` auto-flushes any accumulated incremental
+content when the generator is exhausted (or raises). This means even if the generator
+exits without a `role="assistant"` final flush, HA will commit the partial text.
+The streaming path therefore has no dangling-accumulator problem on early exit.
+
+TODO (follow-up, not MVP): before raising/returning on a mid-stream error, consider
+yielding a final `AssistantContentDeltaDict(content=" [response truncated]")` so
+the user and the LLM both receive an explicit truncation signal rather than an
+abruptly-ended response. Logging the error is always required regardless.
+
+### 5. Remove `_populate_chat_log_from_response` from non-schema_first_yaml path
+
+Dead code once streaming path is in place. Keep it for the `schema_first_yaml` fallback.
+Keep the function itself — it is the fallback path.
+
+## Data Flow Diagram
+
+```
+astream_events(version="v2")
+        │
+        ▼
+_stream_langgraph_to_ha()           [transformation function]
+        │
+        ├── on_chat_model_start (agent node)
+        │   └── AssistantContentDeltaDict(role="assistant")     [open new block]
+        │
+        ├── on_chat_model_stream (agent node, text only, no tool_call_chunks)
+        │   └── AssistantContentDeltaDict(content=token)        [no role = incremental]
+        │
+        ├── on_chat_model_end (agent node, with tool_calls)
+        │   └── AssistantContentDeltaDict(                      [append tool_calls]
+        │           tool_calls=[llm.ToolInput(external=True, tool_args=...)])
+        │
+        ├── on_chain_end (action node)                          [ALL tool results]
+        │   └── for each ToolMessage in output["messages"]:
+        │       ToolResultContentDeltaDict(role="tool_result",  [flush+commit]
+        │           tool_call_id=..., tool_result=...)
+        │   OR if output["messages"] is empty:
+        │       synthetic ToolResultContentDeltaDict per _pending_tool_calls
+        │           tool_result={"error": "tool execution rejected by routing policy"}
+        │
+        ├── on_chat_model_start (agent node, next iteration)
+        │   └── AssistantContentDeltaDict(role="assistant")     [open next block]
+        │   ...repeat...
+        │
+        └── [generator exhausted after final on_chat_model_end with no tool_calls]
+            └── HA auto-flushes accumulated block               [final commit]
+                        │
+                        ▼
+        async_add_delta_content_stream()    [HA ChatLog API]
+                        │
+                        ├── delta_listener → TTS pipeline       [TTFT]
+                        └── chat_log.content                    [Show Details]
+```
+
+## Test Plan
+
+**Unit tests** (mock event stream, no HA):
+- `test_stream_text_only`: emit `on_chat_model_start` + 3 `on_chat_model_stream` events +
+  `on_chat_model_end` (no tool_calls). Assert: 4 total deltas — first is
+  `AssistantContentDeltaDict(role="assistant")`, next 3 are `content=token` with no role,
+  and `on_chat_model_end` emits nothing. Generator exhaustion provides final flush.
+- `test_stream_suppresses_tool_call_tokens`: emit `on_chat_model_stream` events where
+  `tool_call_chunks` is non-empty. Assert: no content deltas yielded.
+- `test_stream_with_tools`: emit on_chat_model_start → stream → on_chat_model_end (with
+  tool_calls) → on_chain_end (action) → on_chat_model_start → stream → on_chat_model_end
+  (no tool_calls). Assert: role="assistant" open, content tokens, tool_calls delta (no role),
+  ToolResultContentDeltaDict(role="tool_result"), role="assistant" open, content tokens.
+  No role="assistant" at on_chat_model_end; no content in tool_calls delta.
+- `test_stream_filters_summarization_node`: emit `on_chat_model_stream` events with
+  `langgraph_node="summarize_and_remove_messages"`. Assert: none yielded.
+- `test_stream_synthetic_tool_rejection`: emit on_chat_model_start → stream →
+  on_chat_model_end (with tool_calls) → on_chain_end (action, empty messages list).
+  Assert: synthetic `ToolResultContentDeltaDict` yielded for each pending tool_call,
+  with `tool_result={"error": "tool execution rejected by routing policy"}`.
+  Assert: `_pending_tool_calls` cleared after injection.
+- `test_stream_anthropic_thinking`: emit chunk with `chunk.content = [{"type": "thinking", "thinking": "..."}]`.
+  Assert: `thinking_content` field present in delta. Do NOT use `additional_kwargs["thinking"]` —
+  thinking blocks arrive in `chunk.content`, not `additional_kwargs`.
+- `test_normalize_tool_result_passthrough`: verify `_normalize_tool_result` handles
+  string and list content from ToolMessage correctly.
+
+**Integration tests** (real HA + LangGraph):
+- Single-turn, no tools: assert chat_log has one AssistantContent block.
+- Multi-turn with tool calls: assert tool_call sequence + tool_result sequence
+  reaches chat_log in order.
+- PIN flow (Turn N ends with `requires_pin`, Turn N+1 provides PIN): assert both
+  turns complete correctly, no dangling accumulator state.
+- `schema_first_yaml=True`: assert fallback to ainvoke fires, YAML output correct.
+
+**Provider matrix** (risk downgraded — LangGraph abstracts provider wire formats):
+The transformation function reads LangGraph events, not provider-specific payloads.
+The only provider-specific concern is the shape of `AIMessageChunk.content` (str vs list),
+which the extraction logic already handles. Provider testing validates LangChain's adapter
+layer, not HGA's logic.
+- Anthropic (Claude): list-type content + thinking blocks
+- OpenAI: string content
+- Gemini: verify chunk.content shape
+- Local (Ollama): verify chunk.content shape
+
+## Open Questions
+
+1. **`app.aget_state` checkpoint ordering (RESOLVED)**: LangGraph writes checkpoint
+   state at node completion, BEFORE emitting the `on_chain_end` event for that node.
+   The outermost graph's `on_chain_end` fires last — after all checkpoints are written.
+   By the time `astream_events()` is exhausted, the final state is committed. `aget_state`
+   returns current-turn state. Implementation wraps in `try/except` for test-mode safety
+   (no checkpointer → raises, caught silently).
+
+2. **Multi-tool parallelism (RESOLVED for current code)**: `_call_tools` runs tool calls
+   sequentially. `on_chain_end` for "action" fires after all tools finish, so ordering
+   matches LangGraph message insertion order. If parallelism is added later, `on_chain_end`
+   remains correct (all results available at chain_end regardless).
+
+3. **Anthropic thinking chunk format (DEFERRED, additive feature)**: The thinking_content
+   field is additive — if the implementation is wrong, the feature silently no-ops (no
+   regression). The integration test against Claude is the real gate. Acceptable for MVP.
+
+## Success Criteria
+
+- [ ] Text appears token-by-token in the HA conversation panel
+- [ ] Voice pipeline TTFT reduced vs `ainvoke()` baseline (verify with HA developer
+      tools timing; expect ≥500ms improvement on tool-less queries at p50)
+- [ ] All model providers (Anthropic, OpenAI, Gemini, local) produce correct output
+      with no dropped tokens or malformed tool call sequences
+- [ ] PIN verification flow not broken: multi-turn test passes (Turn N → requires_pin,
+      Turn N+1 → action confirmed)
+- [ ] `_attr_supports_streaming = True` set on the entity
+- [ ] Part 1's `async_add_assistant_content_without_tools()` block removed from streaming path
+- [ ] Tool call/result events reach HA chat_log in correct sequence (verified by
+      inspecting chat_log.content in integration test)
+- [ ] Routing-guard rejection emits synthetic `ToolResultContentDeltaDict` (no orphaned tool_calls)
+- [ ] `schema_first_yaml=True` falls back to `ainvoke` correctly, YAML output unchanged
+- [ ] Trace append fires after stream completes with full message list from `aget_state`
+- [ ] Unit tests pass: all test cases in Test Plan section
+- [ ] `make lint`, `make typecheck`, `make test` green
+
+## Next Steps
+
+1. `_attr_supports_streaming = True` on entity — one-liner, do first, confirms HA wiring
+2. Write `_stream_langgraph_to_ha()` with unit tests (mock event stream, assert delta sequence)
+3. Replace `ainvoke` block with streaming path + `schema_first_yaml` branch
+4. Add `aget_state` trace call after stream loop
+5. Integration test: single-turn no tools, multi-turn with tools, PIN flow
+6. Test each model provider
+7. Follow-up TODO: move `_fix_entity_ids_in_text` into graph post-processing node

--- a/tests/custom_components/home_generative_agent/test_conversation_stream.py
+++ b/tests/custom_components/home_generative_agent/test_conversation_stream.py
@@ -1,0 +1,367 @@
+# ruff: noqa: S101, E402
+"""Unit tests for _stream_langgraph_to_ha generator in conversation.py."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+from langchain_core.messages import AIMessage, AIMessageChunk, ToolMessage
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+
+def _stub_ha_conversation() -> None:
+    """Stub HA conversation module for testing."""
+    if "homeassistant.components.conversation" in sys.modules:
+        return
+
+    # Build real (empty) base classes.
+    class _AbstractConversationAgent:
+        pass
+
+    class _ConversationEntity:
+        pass
+
+    conv_mod: Any = types.ModuleType("homeassistant.components.conversation")
+    conv_mod.AssistantContentDeltaDict = dict
+    conv_mod.ToolResultContentDeltaDict = dict
+    conv_mod.trace = MagicMock()
+    conv_mod.ConversationEntity = _ConversationEntity
+
+    # conversation.models submodule
+    models_mod: Any = types.ModuleType("homeassistant.components.conversation.models")
+    models_mod.AbstractConversationAgent = _AbstractConversationAgent
+    conv_mod.models = models_mod
+
+    sys.modules["homeassistant.components.conversation"] = conv_mod
+    sys.modules["homeassistant.components.conversation.models"] = models_mod
+    sys.modules["home_assistant_intents"] = types.ModuleType("home_assistant_intents")
+    sys.modules["hassil"] = types.ModuleType("hassil")
+    sys.modules["hassil.recognize"] = types.ModuleType("hassil.recognize")
+
+
+_stub_ha_conversation()
+
+from custom_components.home_generative_agent.conversation import (
+    _stream_langgraph_to_ha,
+)
+
+
+@pytest.mark.asyncio
+async def test_stream_text_only() -> None:
+    """Test streaming plain text tokens."""
+
+    async def event_stream() -> AsyncGenerator[dict[str, Any]]:
+        yield {
+            "event": "on_chat_model_start",
+            "metadata": {"langgraph_node": "agent"},
+        }
+        yield {
+            "event": "on_chat_model_stream",
+            "metadata": {"langgraph_node": "agent"},
+            "data": {"chunk": AIMessageChunk(content="Hello")},
+        }
+        yield {
+            "event": "on_chat_model_stream",
+            "metadata": {"langgraph_node": "agent"},
+            "data": {"chunk": AIMessageChunk(content=" world")},
+        }
+        yield {
+            "event": "on_chat_model_end",
+            "metadata": {"langgraph_node": "agent"},
+            "data": {"output": AIMessage(content="Hello world")},
+        }
+
+    deltas = [d async for d in _stream_langgraph_to_ha(event_stream(), "agent_1")]
+
+    assert len(deltas) == 3
+    assert deltas[0] == {"role": "assistant"}
+    assert deltas[1] == {"content": "Hello"}
+    assert deltas[2] == {"content": " world"}
+
+
+@pytest.mark.asyncio
+async def test_stream_filters_thinking() -> None:
+    """Test that Claude 'thinking' blocks are filtered out."""
+
+    async def event_stream() -> AsyncGenerator[dict[str, Any]]:
+        yield {
+            "event": "on_chat_model_start",
+            "metadata": {"langgraph_node": "agent"},
+        }
+        yield {
+            "event": "on_chat_model_stream",
+            "metadata": {"langgraph_node": "agent"},
+            "data": {
+                "chunk": AIMessageChunk(
+                    content=[
+                        {"type": "thinking", "thinking": "Let me think..."},
+                        {"type": "text", "text": "The answer is 42."},
+                    ]
+                )
+            },
+        }
+        yield {
+            "event": "on_chat_model_end",
+            "metadata": {"langgraph_node": "agent"},
+            "data": {"output": AIMessage(content="The answer is 42.")},
+        }
+
+    deltas = [d async for d in _stream_langgraph_to_ha(event_stream(), "agent_1")]
+
+    assert len(deltas) == 2
+    assert deltas[0] == {"role": "assistant"}
+    assert deltas[1] == {"content": "The answer is 42."}
+
+
+@pytest.mark.asyncio
+async def test_stream_recursive_loops() -> None:
+    """Test that role='assistant' is yielded at every agent start to support loops."""
+
+    async def event_stream() -> AsyncGenerator[dict[str, Any]]:
+        yield {"event": "on_chat_model_start", "metadata": {"langgraph_node": "agent"}}
+        yield {
+            "event": "on_chat_model_stream",
+            "metadata": {"langgraph_node": "agent"},
+            "data": {"chunk": AIMessageChunk(content="Thinking...")},
+        }
+        # Simulate Action node finishing
+        yield {
+            "event": "on_chain_end",
+            "metadata": {"langgraph_node": "action"},
+            "data": {
+                "output": {
+                    "messages": [
+                        ToolMessage(
+                            content="Result", tool_call_id="call_1", name="tool"
+                        )
+                    ]
+                }
+            },
+        }
+        # Loop back to Agent
+        yield {"event": "on_chat_model_start", "metadata": {"langgraph_node": "agent"}}
+        yield {
+            "event": "on_chat_model_stream",
+            "metadata": {"langgraph_node": "agent"},
+            "data": {"chunk": AIMessageChunk(content="Done.")},
+        }
+
+    deltas = [d async for d in _stream_langgraph_to_ha(event_stream(), "agent_1")]
+
+    # Should have TWO {"role": "assistant"} blocks
+    roles = [d for d in deltas if d.get("role") == "assistant"]
+    assert len(roles) == 2
+    assert deltas[0] == {"role": "assistant"}
+    assert deltas[3] == {"role": "assistant"}
+
+
+@pytest.mark.asyncio
+async def test_stream_malformed_chunks() -> None:
+    """Test that malformed chunks are skipped gracefully."""
+
+    async def event_stream() -> AsyncGenerator[dict[str, Any]]:
+        yield {"event": "on_chat_model_start", "metadata": {"langgraph_node": "agent"}}
+        # Correct
+        yield {
+            "event": "on_chat_model_stream",
+            "metadata": {"langgraph_node": "agent"},
+            "data": {"chunk": AIMessageChunk(content="Hello")},
+        }
+        # Missing data/chunk
+        yield {
+            "event": "on_chat_model_stream",
+            "metadata": {"langgraph_node": "agent"},
+            "data": {},
+        }
+        # Content is list but blocks are missing text
+        yield {
+            "event": "on_chat_model_stream",
+            "metadata": {"langgraph_node": "agent"},
+            "data": {"chunk": AIMessageChunk(content=[{"type": "text"}])},
+        }
+        # Not a chunk object at all (should be skipped by isinstance check)
+        yield {
+            "event": "on_chat_model_stream",
+            "metadata": {"langgraph_node": "agent"},
+            "data": {"chunk": {"completely": "wrong"}},
+        }
+
+    deltas = [d async for d in _stream_langgraph_to_ha(event_stream(), "agent_1")]
+
+    # 1. role="assistant"
+    # 2. content="Hello"
+    assert len(deltas) == 2
+    assert deltas[1] == {"content": "Hello"}
+
+
+@pytest.mark.asyncio
+async def test_stream_partial_results() -> None:
+    """Test that missing tool results trigger synthetic failures."""
+
+    async def event_stream() -> AsyncGenerator[dict[str, Any]]:
+        yield {"event": "on_chat_model_start", "metadata": {"langgraph_node": "agent"}}
+        yield {
+            "event": "on_chat_model_end",
+            "metadata": {"langgraph_node": "agent"},
+            "data": {
+                "output": AIMessage(
+                    content="",
+                    tool_calls=[
+                        {"name": "tool_1", "args": {}, "id": "call_1"},
+                        {"name": "tool_2", "args": {}, "id": "call_2"},
+                    ],
+                )
+            },
+        }
+        # Only one result arrives
+        yield {
+            "event": "on_chain_end",
+            "metadata": {"langgraph_node": "action"},
+            "data": {
+                "output": {
+                    "messages": [
+                        ToolMessage(
+                            content="Result 1", tool_call_id="call_1", name="tool_1"
+                        )
+                    ]
+                }
+            },
+        }
+
+    deltas = [d async for d in _stream_langgraph_to_ha(event_stream(), "agent_1")]
+
+    # 1. role="assistant"
+    # 2. tool_calls=[...]
+    # 3. role="tool_result" for call_1
+    # 4. role="tool_result" (synthetic) for call_2
+    assert len(deltas) == 4
+    assert cast("Any", deltas[2])["tool_call_id"] == "call_1"
+    assert cast("Any", deltas[3])["role"] == "tool_result"
+    assert cast("Any", deltas[3])["tool_call_id"] == "call_2"
+    tool_result = cast("Any", deltas[3])["tool_result"]
+    assert "rejected by routing policy" in tool_result["error"]
+
+
+@pytest.mark.asyncio
+async def test_stream_with_tool_calls() -> None:
+    """Test streaming with tool calls and results (successful mapping)."""
+
+    async def event_stream() -> AsyncGenerator[dict[str, Any]]:
+        yield {
+            "event": "on_chat_model_start",
+            "metadata": {"langgraph_node": "agent"},
+        }
+        yield {
+            "event": "on_chat_model_end",
+            "metadata": {"langgraph_node": "agent"},
+            "data": {
+                "output": AIMessage(
+                    content="Calling tool...",
+                    tool_calls=[
+                        {
+                            "name": "turn_on",
+                            "args": {"entity_id": "light.test"},
+                            "id": "call_1",
+                        }
+                    ],
+                )
+            },
+        }
+        yield {
+            "event": "on_chain_end",
+            "metadata": {"langgraph_node": "action"},
+            "data": {
+                "output": {
+                    "messages": [
+                        ToolMessage(
+                            content="Light turned on",
+                            tool_call_id="call_1",
+                            name="turn_on",
+                        )
+                    ]
+                }
+            },
+        }
+
+    deltas = [d async for d in _stream_langgraph_to_ha(event_stream(), "agent_1")]
+
+    assert len(deltas) == 3
+    assert deltas[0] == {"role": "assistant"}
+    assert "tool_calls" in deltas[1]
+    assert deltas[2] == {
+        "role": "tool_result",
+        "tool_call_id": "call_1",
+        "tool_name": "turn_on",
+        "tool_result": {"result": "Light turned on"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_stream_orphaned_tool_calls() -> None:
+    """Test synthetic rejection for tool calls that yield NO results at all."""
+
+    async def event_stream() -> AsyncGenerator[dict[str, Any]]:
+        yield {
+            "event": "on_chat_model_start",
+            "metadata": {"langgraph_node": "agent"},
+        }
+        yield {
+            "event": "on_chat_model_end",
+            "metadata": {"langgraph_node": "agent"},
+            "data": {
+                "output": AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": "turn_on",
+                            "args": {"entity_id": "light.test"},
+                            "id": "call_1",
+                        }
+                    ],
+                )
+            },
+        }
+        yield {
+            "event": "on_chain_end",
+            "metadata": {"langgraph_node": "action"},
+            "data": {"output": {"messages": []}},  # Rejected by guard
+        }
+
+    deltas = [d async for d in _stream_langgraph_to_ha(event_stream(), "agent_1")]
+
+    # Note: Synthetic rejection fires on ACTION node completion, not generator end
+    assert len(deltas) == 3
+    assert deltas[0] == {"role": "assistant"}
+    assert "tool_calls" in deltas[1]
+    assert deltas[2] == {
+        "role": "tool_result",
+        "tool_call_id": "call_1",
+        "tool_name": "turn_on",
+        "tool_result": {"error": "Tool execution rejected by routing policy."},
+    }
+
+
+@pytest.mark.asyncio
+async def test_stream_cancellation() -> None:
+    """Test that the generator handles asyncio.CancelledError gracefully."""
+
+    async def event_stream() -> AsyncGenerator[dict[str, Any]]:
+        yield {"event": "on_chat_model_start", "metadata": {"langgraph_node": "agent"}}
+        raise asyncio.CancelledError
+
+    gen = _stream_langgraph_to_ha(event_stream(), "agent_1")
+
+    # First item should arrive (the assistant role)
+    delta = await anext(gen)
+    assert delta == {"role": "assistant"}
+
+    # Next iteration should raise CancelledError
+    with pytest.raises(asyncio.CancelledError):
+        await anext(gen)

--- a/tests/custom_components/home_generative_agent/test_conversation_stream.py
+++ b/tests/custom_components/home_generative_agent/test_conversation_stream.py
@@ -49,6 +49,7 @@ def _stub_ha_conversation() -> None:
 _stub_ha_conversation()
 
 from custom_components.home_generative_agent.conversation import (
+    _normalize_tool_result,
     _stream_langgraph_to_ha,
 )
 
@@ -365,3 +366,98 @@ async def test_stream_cancellation() -> None:
     # Next iteration should raise CancelledError
     with pytest.raises(asyncio.CancelledError):
         await anext(gen)
+
+
+# ---------------------------------------------------------------------------
+# _normalize_tool_result unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_tool_result_plain_string() -> None:
+    """Plain (non-JSON) strings are wrapped under 'result'."""
+    result = _normalize_tool_result("light turned on")
+    assert result == {"result": "light turned on"}
+
+
+def test_normalize_tool_result_json_string_parsed_to_dict() -> None:
+    """JSON-encoded dicts (produced by _parse_tool_response's json.dumps) are
+    deserialized so Show Details shows clean key/value pairs, not escaped JSON."""
+    content = '{"timezone": "Europe/London", "datetime": "2026-04-17T12:00:00"}'
+    result = _normalize_tool_result(content)
+    assert result == {"timezone": "Europe/London", "datetime": "2026-04-17T12:00:00"}
+
+
+def test_normalize_tool_result_nested_content_blocks() -> None:
+    """HA tools that return Anthropic-style content blocks are also deserialized."""
+    content = '{"content": [{"type": "text", "text": "The time is noon."}]}'
+    result = _normalize_tool_result(content)
+    assert result == {"content": [{"type": "text", "text": "The time is noon."}]}
+
+
+def test_normalize_tool_result_list_of_blocks() -> None:
+    """List content (Anthropic content blocks) is joined into a single string."""
+    content = [
+        {"type": "text", "text": "Part one."},
+        {"type": "text", "text": "Part two."},
+    ]
+    result = _normalize_tool_result(content)
+    assert result == {"result": "Part one.\nPart two."}
+
+
+def test_normalize_tool_result_non_dict_json_stays_wrapped() -> None:
+    """JSON arrays and scalars are NOT returned as-is; they stay wrapped."""
+    result = _normalize_tool_result("[1, 2, 3]")
+    assert result == {"result": "[1, 2, 3]"}
+
+
+# ---------------------------------------------------------------------------
+# on_chain_end state-event guard test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stream_ignores_state_chain_end() -> None:
+    """LangGraph emits a second on_chain_end for 'action' whose output is the full
+    messages list (not a dict). The generator must skip it without error."""
+
+    async def event_stream() -> AsyncGenerator[dict[str, Any]]:
+        yield {"event": "on_chat_model_start", "metadata": {"langgraph_node": "agent"}}
+        yield {
+            "event": "on_chat_model_end",
+            "metadata": {"langgraph_node": "agent"},
+            "data": {
+                "output": AIMessage(
+                    content="",
+                    tool_calls=[{"name": "turn_on", "args": {}, "id": "call_1"}],
+                )
+            },
+        }
+        # (a) node function event — dict output
+        yield {
+            "event": "on_chain_end",
+            "metadata": {"langgraph_node": "action"},
+            "data": {
+                "output": {
+                    "messages": [
+                        ToolMessage(content="done", tool_call_id="call_1", name="turn_on")
+                    ]
+                }
+            },
+        }
+        # (b) graph-level state event — list output (must be ignored)
+        yield {
+            "event": "on_chain_end",
+            "metadata": {"langgraph_node": "action"},
+            "data": {
+                "output": [
+                    ToolMessage(content="done", tool_call_id="call_1", name="turn_on")
+                ]
+            },
+        }
+
+    deltas = [d async for d in _stream_langgraph_to_ha(event_stream(), "agent_1")]
+
+    # Exactly one tool result — the state event must not add a duplicate.
+    tool_results = [d for d in deltas if isinstance(d, dict) and d.get("role") == "tool_result"]
+    assert len(tool_results) == 1
+    assert tool_results[0]["tool_call_id"] == "call_1"

--- a/tests/custom_components/home_generative_agent/test_conversation_stream.py
+++ b/tests/custom_components/home_generative_agent/test_conversation_stream.py
@@ -380,8 +380,12 @@ def test_normalize_tool_result_plain_string() -> None:
 
 
 def test_normalize_tool_result_json_string_parsed_to_dict() -> None:
-    """JSON-encoded dicts (produced by _parse_tool_response's json.dumps) are
-    deserialized so Show Details shows clean key/value pairs, not escaped JSON."""
+    """
+    JSON-encoded dicts are deserialized.
+
+    _parse_tool_response produces json.dumps output; Show Details must show
+    clean key/value pairs, not escaped JSON.
+    """
     content = '{"timezone": "Europe/London", "datetime": "2026-04-17T12:00:00"}'
     result = _normalize_tool_result(content)
     assert result == {"timezone": "Europe/London", "datetime": "2026-04-17T12:00:00"}
@@ -417,8 +421,12 @@ def test_normalize_tool_result_non_dict_json_stays_wrapped() -> None:
 
 @pytest.mark.asyncio
 async def test_stream_ignores_state_chain_end() -> None:
-    """LangGraph emits a second on_chain_end for 'action' whose output is the full
-    messages list (not a dict). The generator must skip it without error."""
+    """
+    LangGraph emits a second on_chain_end for 'action' with a list output.
+
+    The output is the full messages list (not a dict). The generator must skip
+    it without error.
+    """
 
     async def event_stream() -> AsyncGenerator[dict[str, Any]]:
         yield {"event": "on_chat_model_start", "metadata": {"langgraph_node": "agent"}}
@@ -439,7 +447,9 @@ async def test_stream_ignores_state_chain_end() -> None:
             "data": {
                 "output": {
                     "messages": [
-                        ToolMessage(content="done", tool_call_id="call_1", name="turn_on")
+                        ToolMessage(
+                            content="done", tool_call_id="call_1", name="turn_on"
+                        )
                     ]
                 }
             },
@@ -458,6 +468,8 @@ async def test_stream_ignores_state_chain_end() -> None:
     deltas = [d async for d in _stream_langgraph_to_ha(event_stream(), "agent_1")]
 
     # Exactly one tool result — the state event must not add a duplicate.
-    tool_results = [d for d in deltas if isinstance(d, dict) and d.get("role") == "tool_result"]
+    tool_results = [
+        d for d in deltas if isinstance(d, dict) and d.get("role") == "tool_result"
+    ]
     assert len(tool_results) == 1
     assert tool_results[0]["tool_call_id"] == "call_1"

--- a/tests/custom_components/home_generative_agent/test_conversation_stream.py
+++ b/tests/custom_components/home_generative_agent/test_conversation_stream.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import sys
 import types
 from typing import TYPE_CHECKING, Any, cast
@@ -50,6 +51,7 @@ _stub_ha_conversation()
 
 from custom_components.home_generative_agent.conversation import (
     _normalize_tool_result,
+    _sanitize_tool_result_dict,
     _stream_langgraph_to_ha,
 )
 
@@ -473,3 +475,64 @@ async def test_stream_ignores_state_chain_end() -> None:
     ]
     assert len(tool_results) == 1
     assert tool_results[0]["tool_call_id"] == "call_1"
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_tool_result_dict unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_passthrough_plain_dict() -> None:
+    """Dicts without response_type are returned unchanged."""
+    d = {"timezone": "Europe/London", "datetime": "2026-04-17T12:00:00"}
+    assert _sanitize_tool_result_dict(d) == d
+
+
+def test_sanitize_ha_action_done_with_speech() -> None:
+    """HassTurnOn-style response is flattened; speech text becomes 'result'."""
+    d = {
+        "response_type": "action_done",
+        "speech": {"plain": {"speech": "Turned on Garage Light", "extra_data": None}},
+        "data": {
+            "success": [{"name": "Garage Light", "type": "domain"}],
+            "failed": [],
+        },
+    }
+    result = _sanitize_tool_result_dict(d)
+    assert result["result"] == "Turned on Garage Light"
+    assert result["success"] == [{"name": "Garage Light", "type": "domain"}]
+    assert result["failed"] == []
+    assert "response_type" not in result
+    assert "speech" not in result
+
+
+def test_sanitize_ha_action_done_empty_speech_falls_back_to_response_type() -> None:
+    """When speech text is absent the response_type string is used as result."""
+    d = {
+        "response_type": "action_done",
+        "speech": {},
+        "data": {"success": [], "failed": []},
+    }
+    result = _sanitize_tool_result_dict(d)
+    assert result["result"] == "action_done"
+    assert "response_type" not in result
+
+
+def test_normalize_tool_result_ha_intent_string() -> None:
+    """JSON-encoded HA intent responses are sanitized by _normalize_tool_result."""
+    content = json.dumps(
+        {
+            "response_type": "action_done",
+            "speech": {
+                "plain": {"speech": "Turned on Garage Light", "extra_data": None}
+            },
+            "data": {
+                "success": [{"name": "Garage Light", "type": "domain"}],
+                "failed": [],
+            },
+        }
+    )
+    result = _normalize_tool_result(content)
+    assert result["result"] == "Turned on Garage Light"
+    assert "response_type" not in result
+    assert "speech" not in result

--- a/tests/custom_components/home_generative_agent/test_conversation_stream.py
+++ b/tests/custom_components/home_generative_agent/test_conversation_stream.py
@@ -12,7 +12,12 @@ from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import MagicMock
 
 import pytest
-from langchain_core.messages import AIMessage, AIMessageChunk, ToolCallChunk, ToolMessage
+from langchain_core.messages import (
+    AIMessage,
+    AIMessageChunk,
+    ToolCallChunk,
+    ToolMessage,
+)
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
@@ -493,7 +498,7 @@ async def test_stream_ignores_state_chain_end() -> None:
         [d for d in deltas if isinstance(d, dict) and d.get("role") == "tool_result"],
     )
     assert len(tool_results) == 1
-    assert cast(Any, tool_results[0])["tool_call_id"] == "call_1"
+    assert cast("Any", tool_results[0])["tool_call_id"] == "call_1"
 
 
 @pytest.mark.asyncio
@@ -617,9 +622,7 @@ async def test_stream_mixed_text_and_tools() -> None:
                 "chunk": AIMessageChunk(
                     content="Thinking... ",
                     tool_call_chunks=[
-                        ToolCallChunk(
-                            name="tool", args="{}", id="call_1", index=0
-                        )
+                        ToolCallChunk(name="tool", args="{}", id="call_1", index=0)
                     ],
                 )
             },

--- a/tests/custom_components/home_generative_agent/test_conversation_stream.py
+++ b/tests/custom_components/home_generative_agent/test_conversation_stream.py
@@ -142,6 +142,16 @@ async def test_stream_recursive_loops() -> None:
             "metadata": {"langgraph_node": "agent"},
             "data": {"chunk": AIMessageChunk(content="Thinking...")},
         }
+        yield {
+            "event": "on_chat_model_end",
+            "metadata": {"langgraph_node": "agent"},
+            "data": {
+                "output": AIMessage(
+                    content="Thinking...",
+                    tool_calls=[{"name": "tool", "args": {}, "id": "call_1"}],
+                )
+            },
+        }
         # Simulate Action node finishing
         yield {
             "event": "on_chain_end",
@@ -170,7 +180,11 @@ async def test_stream_recursive_loops() -> None:
     roles = [d for d in deltas if d.get("role") == "assistant"]
     assert len(roles) == 2
     assert deltas[0] == {"role": "assistant"}
-    assert deltas[3] == {"role": "assistant"}
+    # deltas[1] is content="Thinking..."
+    # deltas[2] is tool_calls
+    # deltas[3] is role="tool_result"
+    # deltas[4] is role="assistant" (the second start)
+    assert deltas[4] == {"role": "assistant"}
 
 
 @pytest.mark.asyncio
@@ -569,8 +583,8 @@ async def test_stream_graph_error_persistence_guard() -> None:
 
 
 @pytest.mark.asyncio
-async def test_stream_tool_result_id_none_stringification() -> None:
-    """Test that tool_call_id=None becomes '' instead of 'None'."""
+async def test_stream_drops_orphaned_tool_results() -> None:
+    """Test that tool results without a preceding tool call are safely dropped."""
 
     async def event_stream() -> AsyncGenerator[dict[str, Any]]:
         yield {"event": "on_chat_model_start", "metadata": {"langgraph_node": "agent"}}
@@ -587,10 +601,58 @@ async def test_stream_tool_result_id_none_stringification() -> None:
         }
 
     deltas = [d async for d in _stream_langgraph_to_ha(event_stream(), "agent_1")]
-    # Result for an unknown ID-less call (since we didn't provide a tool_call event)
-    # tool_call_id should be "" (not "None")
-    result_delta = cast("ToolResultContentDeltaDict", deltas[1])
-    assert result_delta.get("tool_call_id") == ""
+    # Result for an unknown call should be dropped, leaving only the agent start.
+    assert len(deltas) == 1
+    assert deltas[0]["role"] == "assistant"
+
+
+@pytest.mark.asyncio
+async def test_stream_mixed_text_and_tools() -> None:
+    """Test that text is not swallowed when mixed with tool call chunks."""
+
+    async def event_stream() -> AsyncGenerator[dict[str, Any]]:
+        yield {"event": "on_chat_model_start", "metadata": {"langgraph_node": "agent"}}
+        yield {
+            "event": "on_chat_model_stream",
+            "metadata": {"langgraph_node": "agent"},
+            "data": {
+                # Mixed chunk: has both content and tool_call_chunks
+                "chunk": AIMessageChunk(
+                    content="Thinking... ",
+                    tool_call_chunks=[{"name": "tool", "args": "{}", "id": "call_1"}],
+                )
+            },
+        }
+
+    deltas = [d async for d in _stream_langgraph_to_ha(event_stream(), "agent_1")]
+
+    # Should have yielded the text despite the presence of tool_call_chunks
+    assert len(deltas) == 2
+    assert deltas[0] == {"role": "assistant"}
+    assert deltas[1] == {"content": "Thinking... "}
+
+
+@pytest.mark.asyncio
+async def test_stream_role_tracking() -> None:
+    """Test that redundant role deltas are suppressed."""
+
+    async def event_stream() -> AsyncGenerator[dict[str, Any]]:
+        yield {"event": "on_chat_model_start", "metadata": {"langgraph_node": "agent"}}
+        # Simulate a second start (e.g. from a loop without an intervening role change)
+        yield {"event": "on_chat_model_start", "metadata": {"langgraph_node": "agent"}}
+        yield {
+            "event": "on_chat_model_stream",
+            "metadata": {"langgraph_node": "agent"},
+            "data": {"chunk": AIMessageChunk(content="Hi")},
+        }
+
+    deltas = [d async for d in _stream_langgraph_to_ha(event_stream(), "agent_1")]
+
+    # Should only have ONE role="assistant" delta
+    roles = [d for d in deltas if d.get("role") == "assistant"]
+    assert len(roles) == 1
+    assert deltas[0] == {"role": "assistant"}
+    assert deltas[1] == {"content": "Hi"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/custom_components/home_generative_agent/test_conversation_stream.py
+++ b/tests/custom_components/home_generative_agent/test_conversation_stream.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import sys
 import types
@@ -15,6 +16,11 @@ from langchain_core.messages import AIMessage, AIMessageChunk, ToolMessage
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
+
+    from homeassistant.components.conversation import (
+        AssistantContentDeltaDict,
+        ToolResultContentDeltaDict,
+    )
 
 
 def _stub_ha_conversation() -> None:
@@ -118,6 +124,8 @@ async def test_stream_filters_thinking() -> None:
 
     deltas = [d async for d in _stream_langgraph_to_ha(event_stream(), "agent_1")]
 
+    # Thinking blocks are intentionally filtered in the MVP streaming path.
+    # Piping thinking_content through AssistantContentDeltaDict is a deferred feature.
     assert len(deltas) == 2
     assert deltas[0] == {"role": "assistant"}
     assert deltas[1] == {"content": "The answer is 42."}
@@ -475,6 +483,114 @@ async def test_stream_ignores_state_chain_end() -> None:
     ]
     assert len(tool_results) == 1
     assert tool_results[0]["tool_call_id"] == "call_1"
+
+
+@pytest.mark.asyncio
+async def test_stream_idless_tool_calls() -> None:
+    """Test correlation for models that emit tool calls without IDs (e.g. Ollama)."""
+
+    async def event_stream() -> AsyncGenerator[dict[str, Any]]:
+        yield {"event": "on_chat_model_start", "metadata": {"langgraph_node": "agent"}}
+        yield {
+            "event": "on_chat_model_end",
+            "metadata": {"langgraph_node": "agent"},
+            "data": {
+                "output": AIMessage(
+                    content="",
+                    tool_calls=[
+                        {"name": "test_tool", "args": {}, "id": None},  # ID is None
+                    ],
+                )
+            },
+        }
+        yield {
+            "event": "on_chain_end",
+            "metadata": {"langgraph_node": "action"},
+            "data": {
+                "output": {
+                    "messages": [
+                        ToolMessage(
+                            content="Success", tool_call_id="", name="test_tool"
+                        )
+                    ]
+                }
+            },
+        }
+
+    deltas = [d async for d in _stream_langgraph_to_ha(event_stream(), "agent_1")]
+
+    # 1. role="assistant"
+    # 2. AssistantContentDeltaDict with generated ULID
+    # 3. ToolResultContentDeltaDict with matching ULID
+    assert len(deltas) == 3
+    assistant_delta = cast("AssistantContentDeltaDict", deltas[1])
+    tool_calls = assistant_delta.get("tool_calls")
+    assert tool_calls is not None
+    generated_id = tool_calls[0].id
+    assert generated_id.startswith("01")  # Valid ULID start
+
+    result_delta = cast("ToolResultContentDeltaDict", deltas[2])
+    assert result_delta.get("tool_call_id") == generated_id
+    assert result_delta.get("tool_result") == {"result": "Success"}
+
+
+@pytest.mark.asyncio
+async def test_stream_graph_error_persistence_guard() -> None:
+    """Test that orphaned tool calls are flushed if the graph crashes."""
+
+    async def event_stream() -> AsyncGenerator[dict[str, Any]]:
+        yield {"event": "on_chat_model_start", "metadata": {"langgraph_node": "agent"}}
+        yield {
+            "event": "on_chat_model_end",
+            "metadata": {"langgraph_node": "agent"},
+            "data": {
+                "output": AIMessage(
+                    content="",
+                    tool_calls=[{"name": "tool_1", "args": {}, "id": "call_1"}],
+                )
+            },
+        }
+        # Simulate a crash before the action node completes
+        msg = "Graph exploded"
+        raise ValueError(msg)
+
+    deltas = []
+    with contextlib.suppress(ValueError):
+        async for delta in _stream_langgraph_to_ha(event_stream(), "agent_1"):
+            deltas.append(delta)  # noqa: PERF401
+
+    # Should have yielded the synthetic rejection in the except block
+    assert len(deltas) == 3
+    assert deltas[2]["role"] == "tool_result"
+    result_delta = cast("ToolResultContentDeltaDict", deltas[2])
+    assert result_delta.get("tool_call_id") == "call_1"
+    tool_result = cast("dict[str, Any]", result_delta.get("tool_result"))
+    assert "failed mid-stream" in tool_result["error"]
+
+
+@pytest.mark.asyncio
+async def test_stream_tool_result_id_none_stringification() -> None:
+    """Test that tool_call_id=None becomes '' instead of 'None'."""
+
+    async def event_stream() -> AsyncGenerator[dict[str, Any]]:
+        yield {"event": "on_chat_model_start", "metadata": {"langgraph_node": "agent"}}
+        yield {
+            "event": "on_chain_end",
+            "metadata": {"langgraph_node": "action"},
+            "data": {
+                "output": {
+                    "messages": [
+                        ToolMessage(content="ok", tool_call_id="", name="tool")
+                    ]
+                }
+            },
+        }
+
+    deltas = [d async for d in _stream_langgraph_to_ha(event_stream(), "agent_1")]
+    # Result for an unknown ID-less call (since we didn't provide a tool_call event)
+    # tool_call_id should be "" (not "None")
+    result_delta = cast("ToolResultContentDeltaDict", deltas[1])
+    assert result_delta.get("tool_call_id") == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/custom_components/home_generative_agent/test_conversation_stream.py
+++ b/tests/custom_components/home_generative_agent/test_conversation_stream.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import MagicMock
 
 import pytest
-from langchain_core.messages import AIMessage, AIMessageChunk, ToolMessage
+from langchain_core.messages import AIMessage, AIMessageChunk, ToolCallChunk, ToolMessage
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
@@ -180,10 +180,6 @@ async def test_stream_recursive_loops() -> None:
     roles = [d for d in deltas if d.get("role") == "assistant"]
     assert len(roles) == 2
     assert deltas[0] == {"role": "assistant"}
-    # deltas[1] is content="Thinking..."
-    # deltas[2] is tool_calls
-    # deltas[3] is role="tool_result"
-    # deltas[4] is role="assistant" (the second start)
     assert deltas[4] == {"role": "assistant"}
 
 
@@ -492,11 +488,12 @@ async def test_stream_ignores_state_chain_end() -> None:
     deltas = [d async for d in _stream_langgraph_to_ha(event_stream(), "agent_1")]
 
     # Exactly one tool result — the state event must not add a duplicate.
-    tool_results = [
-        d for d in deltas if isinstance(d, dict) and d.get("role") == "tool_result"
-    ]
+    tool_results = cast(
+        "list[ToolResultContentDeltaDict]",
+        [d for d in deltas if isinstance(d, dict) and d.get("role") == "tool_result"],
+    )
     assert len(tool_results) == 1
-    assert tool_results[0]["tool_call_id"] == "call_1"
+    assert cast(Any, tool_results[0])["tool_call_id"] == "call_1"
 
 
 @pytest.mark.asyncio
@@ -603,7 +600,7 @@ async def test_stream_drops_orphaned_tool_results() -> None:
     deltas = [d async for d in _stream_langgraph_to_ha(event_stream(), "agent_1")]
     # Result for an unknown call should be dropped, leaving only the agent start.
     assert len(deltas) == 1
-    assert deltas[0]["role"] == "assistant"
+    assert deltas[0].get("role") == "assistant"
 
 
 @pytest.mark.asyncio
@@ -619,7 +616,11 @@ async def test_stream_mixed_text_and_tools() -> None:
                 # Mixed chunk: has both content and tool_call_chunks
                 "chunk": AIMessageChunk(
                     content="Thinking... ",
-                    tool_call_chunks=[{"name": "tool", "args": "{}", "id": "call_1"}],
+                    tool_call_chunks=[
+                        ToolCallChunk(
+                            name="tool", args="{}", id="call_1", index=0
+                        )
+                    ],
                 )
             },
         }

--- a/tests/custom_components/home_generative_agent/test_conversation_units.py
+++ b/tests/custom_components/home_generative_agent/test_conversation_units.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import sys
 import types
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -45,18 +46,20 @@ def _stub_ha_conversation() -> None:
         pass
 
     # conversation module
-    conv_mod = types.ModuleType("homeassistant.components.conversation")
-    conv_mod.ConversationEntity = _ConversationEntity  # type: ignore[attr-defined]
-    conv_mod.AbstractConversationAgent = _AbstractConversationAgent  # type: ignore[attr-defined]
-    conv_mod.ConversationResult = _ConversationResult  # type: ignore[attr-defined]
-    conv_mod.UserContent = _UserContent  # type: ignore[attr-defined]
-    conv_mod.AssistantContent = _AssistantContent  # type: ignore[attr-defined]
-    conv_mod.DOMAIN = "conversation"  # type: ignore[attr-defined]
-    conv_mod.async_set_agent = MagicMock()  # type: ignore[attr-defined]
-    conv_mod.trace = MagicMock()  # type: ignore[attr-defined]
+    conv_mod: Any = types.ModuleType("homeassistant.components.conversation")
+    conv_mod.ConversationEntity = _ConversationEntity
+    conv_mod.AbstractConversationAgent = _AbstractConversationAgent
+    conv_mod.ConversationResult = _ConversationResult
+    conv_mod.UserContent = _UserContent
+    conv_mod.AssistantContent = _AssistantContent
+    conv_mod.AssistantContentDeltaDict = dict
+    conv_mod.ToolResultContentDeltaDict = dict
+    conv_mod.DOMAIN = "conversation"
+    conv_mod.async_set_agent = MagicMock()
+    conv_mod.trace = MagicMock()
 
     # conversation.models submodule
-    models_mod = types.ModuleType("homeassistant.components.conversation.models")
+    models_mod: Any = types.ModuleType("homeassistant.components.conversation.models")
     models_mod.AbstractConversationAgent = _AbstractConversationAgent  # type: ignore[attr-defined]
     conv_mod.models = models_mod  # type: ignore[attr-defined]
 

--- a/tests/custom_components/home_generative_agent/test_conversation_units.py
+++ b/tests/custom_components/home_generative_agent/test_conversation_units.py
@@ -60,8 +60,8 @@ def _stub_ha_conversation() -> None:
 
     # conversation.models submodule
     models_mod: Any = types.ModuleType("homeassistant.components.conversation.models")
-    models_mod.AbstractConversationAgent = _AbstractConversationAgent  # type: ignore[attr-defined]
-    conv_mod.models = models_mod  # type: ignore[attr-defined]
+    models_mod.AbstractConversationAgent = _AbstractConversationAgent
+    conv_mod.models = models_mod
 
     sys.modules["homeassistant.components.conversation"] = conv_mod
     sys.modules["homeassistant.components.conversation.models"] = models_mod

--- a/tests/custom_components/home_generative_agent/test_pin_detection.py
+++ b/tests/custom_components/home_generative_agent/test_pin_detection.py
@@ -1,0 +1,83 @@
+# ruff: noqa: S101
+"""Unit tests for _has_pending_pin_confirmation."""
+
+from __future__ import annotations
+
+import json
+
+from langchain_core.messages import AIMessage, ToolMessage
+
+from custom_components.home_generative_agent.agent.graph import (
+    _has_pending_pin_confirmation,
+)
+
+
+def _requires_pin_msg(action_id: str = "act1") -> ToolMessage:
+    return ToolMessage(
+        content=json.dumps({"status": "requires_pin", "action_id": action_id}),
+        tool_call_id="tc1",
+        name="HassLockLock",
+    )
+
+
+def _confirm_msg(content: str) -> ToolMessage:
+    return ToolMessage(
+        content=content,
+        tool_call_id="tc2",
+        name="confirm_sensitive_action",
+    )
+
+
+def _ai_pin_ask() -> AIMessage:
+    return AIMessage(content="Please provide your PIN to confirm the lock action.")
+
+
+class TestHasPendingPinConfirmation:
+    """Tests for _has_pending_pin_confirmation."""
+
+    def test_no_messages(self) -> None:
+        assert _has_pending_pin_confirmation([]) is False
+
+    def test_requires_pin_no_confirmation(self) -> None:
+        msgs = [_requires_pin_msg()]
+        assert _has_pending_pin_confirmation(msgs) is True
+
+    def test_requires_pin_then_success(self) -> None:
+        success_content = json.dumps({"status": "completed", "action_id": "act1"})
+        msgs = [_requires_pin_msg(), _confirm_msg(success_content)]
+        assert _has_pending_pin_confirmation(msgs) is False
+
+    def test_requires_pin_then_wrong_pin_still_pending(self) -> None:
+        """Core regression: wrong PIN should NOT clear the pending state."""
+        msgs = [
+            _requires_pin_msg(),
+            _confirm_msg("Incorrect PIN. Action not executed."),
+        ]
+        assert _has_pending_pin_confirmation(msgs) is True
+
+    def test_requires_pin_then_wrong_pin_then_correct(self) -> None:
+        """After wrong PIN, correct PIN resolves the flow."""
+        success_content = json.dumps({"status": "completed", "action_id": "act1"})
+        msgs = [
+            _requires_pin_msg(),
+            _confirm_msg("Incorrect PIN. Action not executed."),
+            _confirm_msg(success_content),
+        ]
+        assert _has_pending_pin_confirmation(msgs) is False
+
+    def test_requires_pin_then_too_many_attempts(self) -> None:
+        """Too many attempts resolves the flow (action expired, user must restart)."""
+        msgs = [
+            _requires_pin_msg(),
+            _confirm_msg("Too many incorrect attempts; please re-run the request."),
+        ]
+        assert _has_pending_pin_confirmation(msgs) is False
+
+    def test_multiple_wrong_pins_still_pending(self) -> None:
+        """Multiple wrong PINs — flow remains pending until correct or expired."""
+        msgs = [
+            _requires_pin_msg(),
+            _confirm_msg("Incorrect PIN. Action not executed."),
+            _confirm_msg("Incorrect PIN. Action not executed."),
+        ]
+        assert _has_pending_pin_confirmation(msgs) is True


### PR DESCRIPTION
## Summary

**Streaming (Issue #370)**
- `HGAConversationEntity` now sets `_attr_supports_streaming = True` and routes non-`schema_first_yaml` turns through `_async_run_astream`, which drives `astream_events` → `_stream_langgraph_to_ha` → HA ChatLog delta API. Tokens appear in the HA frontend in real time.
- `schema_first_yaml=True` paths continue to use the `ainvoke` fallback.
- Handles: tool call tracking (`pending_tool_map`), orphaned tool call flushing as synthetic rejections on generator exit, `CONTENT_ADDED` re-fire for final `AssistantContent`, `aget_state` trace append, and error recovery via graph state on streaming failure.

**Parallel Tool Execution + Timeout**
- `_call_tools` now uses `asyncio.gather(return_exceptions=True)` for concurrent multi-tool turns. Tools that previously executed sequentially now run in parallel.
- Each tool call is bounded by a 30-second `asyncio.wait_for` timeout. Stuck calls produce a descriptive error `ToolMessage`.

**PIN Flow Hardening**
- Wrong PIN entries are correctly detected via `"Incorrect PIN"` content check and skip (`continue`) — the pending action is not resolved.
- Routing errors on `confirm_sensitive_action` (e.g. tool not available in routing map) no longer bypass PIN verification (`msg.status == "error"` now treated as unresolved).
- `Sequence[AnyMessage]` type annotation for PIN helper functions replaces `list[AnyMessage]` for broader compatibility.
- `confirm_sensitive_action` is re-injected after wrong PIN entry.

**Streaming Robustness Fixes**
- HA intent-tool results with `response_type` dict no longer produce empty chat bubbles in multi-tool turns.
- JSON tool results are parsed; streaming failures fall back to graph state recovery.
- Empty chat log after swallowed `HomeAssistantError` now produces a safe fallback `AssistantContent` before `async_get_result_from_chat_log` is called.
- `CONTENT_ADDED` re-fire moved to `finally` block so it runs even on `CancelledError`.

## Test Coverage

```
feat/streaming-chatlog — Coverage Diagram
==========================================

conversation.py — Pure/Standalone Functions
────────────────────────────────────────────
_normalize_tool_result()                     [★★★ TESTED — 4 variants]
_sanitize_tool_result_dict()                 [★★★ TESTED — 3 variants]
_handle_on_chat_model_end()                  [★★★ TESTED — 3 variants]
_handle_on_chain_end()                       [★★★ TESTED — 5 variants]
_handle_on_chat_model_stream()               [★★★ TESTED — 4 variants]
_process_stream_event()                      [★★  TESTED — happy paths]
_stream_langgraph_to_ha()                    [★★★ TESTED — cancel, error, loops, roles]

HGAConversationEntity — refactored methods   [✗ NOT UNIT TESTED — HA fixture integration]
graph.py — PIN Flow (Case 1)                 [★★★ TESTED — 6 tests]
graph.py — PIN Flow (Case 2)                 [✗ NOT TESTED — deferred to follow-up]
graph.py — Parallel Tools (happy path)       [★★  via existing integration tests]
graph.py — TimeoutError path                 [✗ NOT TESTED — deferred to follow-up]

COVERAGE: 38/65 paths tested (~58%) | Streaming pipeline: ~85%
QUALITY: ★★★:12 ★★:4 ★:0 | GAPS: 27 (accepted risk per user)
```

Tests: 41 → 44 files (+3 new), 769 passed.

Coverage gate: **OVERRIDDEN at 58%** — streaming pipeline core is 85% covered; HA entity integration methods rely on existing integration tests. Integration tests for the streaming path deferred (P2 TODO added).

## Pre-Landing Review

8 issues found — all resolved:
- **[AUTO-FIXED]** Duplicate `AsyncIterable`/`AsyncIterator` imports in `TYPE_CHECKING` block
- **[AUTO-FIXED]** `cast()` line length (E501) and TC006 (unquoted type)
- **[AUTO-FIXED]** Stale `# type: ignore[attr-defined]` comments in test file
- **[FIXED]** `CancelledError` handler: `CONTENT_ADDED` re-fire moved to `finally` so it runs on cancel
- **[FIXED]** PIN guard: `confirm_sensitive_action` routing errors now treated as unresolved
- **[FIXED]** Empty chat log guard before `async_get_result_from_chat_log`
- **[SKIPPED]** `_async_get_all_tools` / `_async_get_message_history` naming — deferred rename (P3 TODO)
- **[SKIPPED]** `stream_task.cancel()` redundancy — informational, left in place for clarity

## Design Review

No frontend files changed — design review skipped.

## Eval Results

No prompt-related files changed — evals skipped.

## Greptile Review

No PR existed during review — skipped.

## Scope Drift

Scope Check: **CLEAN** — all 8 changed files are directly within scope of streaming/PIN/parallel-tools work.

## Plan Completion

- [x] `_attr_supports_streaming = True` set
- [x] `_stream_langgraph_to_ha()` implemented with full helper decomposition
- [x] `schema_first_yaml=True` fallback to `ainvoke`
- [x] `aget_state` trace append after stream
- [x] Synthetic `ToolResultContentDeltaDict` for routing-guard rejections
- [x] Persistence guard on generator exit
- [x] `HomeAssistantError` mid-stream caught; partial content committed
- [x] `asyncio.gather` parallel tool execution + LangChain timeout (cherry-pick)
- [x] PIN flow preserved through streaming path
- [x] `CONTENT_ADDED` re-fire for final `AssistantContent`
- [~] Anthropic thinking_content → filtered (deferred additive feature)
- [ ] HA fixture-level integration tests (P2 TODO added)
- [ ] Follow-ups: `_fix_entity_ids_in_text` graph relocation, truncation signal, `_SEQUENTIAL_TOOLS` guard

29 total items: 17 done, 5 changed, 7 deferred.

## Verification Results

No dev server detected — plan verification skipped. Unit test suite (769 tests) passed as verification gate.

## TODOS

No existing TODO items completed in this PR. 3 new items added:
- **P2** Integration tests for streaming conversation path (HA fixture level)
- **P2** Integration smoke test: `on_tool_end` propagation timing during action node
- **P3** Rename sync methods with `_async_` prefix in `conversation.py`

## Documentation

**README.md** updated for v3.12.0:
- Added native LLM streaming to the top-level features list (requires HA 2026.4.0+)
- Updated the Agent Graph section to describe parallel tool execution via `asyncio.gather` and the 30-second per-tool timeout
- Updated the Latency section to note that streaming reduces perceived latency and that multi-tool turns now execute tools concurrently
- Added a discoverability link to `docs/streaming-design.md` from the Architecture section

All other docs (`CHANGELOG.md`, `CLAUDE.md`, `CONTRIBUTING.md`, `TODOS.md`) are current. No VERSION file exists; version is tracked in `manifest.json` (already bumped to 3.12.0 by /ship).

## Test plan
- [x] All 769 pytest tests pass (0 failures)
- [x] `make lint` passes (ruff format + check clean)
- [x] `make typecheck` not run (not gated by /ship)

Closes #370 

🤖 Generated with [Claude Code](https://claude.com/claude-code)