### PR TITLE
fix: add LLM invocation timeout to prevent chat hanging under heavy VLM load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.12.2] - 2026-04-24
+
+### Fixed
+
+- **Chat streaming no longer hangs under heavy VLM load** — `_invoke_model` now
+  wraps `model.ainvoke()` in `asyncio.wait_for(_LLM_INVOKE_TIMEOUT_S=90s)`. When
+  the Ollama GPU is saturated by concurrent camera analysis, the chat LLM was
+  queuing indefinitely inside `astream_events`, stalling the streaming pipeline
+  and showing "no response" in the HA chat UI. The timeout converts an infinite
+  hang into a bounded `HomeAssistantError`. Closes #378.
+
+- **Blank chat bubble after timeout replaced with user-visible error message** —
+  The timeout `HomeAssistantError` now propagates cleanly through
+  `_stream_langgraph_to_ha` (bypassing the misleading "generator error" log path)
+  to the recovery handler, which emits "I'm sorry, I was unable to respond in time.
+  Please try again." instead of an empty bubble.
+
+- **Empty-content fallback in `_async_handle_message` now shows an error message**
+  — the `content=""` guard (hit when streaming fails with no recoverable graph
+  state) now emits "I'm sorry, I was unable to respond. Please try again." so the
+  chat UI always shows something actionable.
+
 ## [3.12.1] - 2026-04-24
 
 ### Fixed

--- a/custom_components/home_generative_agent/agent/graph.py
+++ b/custom_components/home_generative_agent/agent/graph.py
@@ -91,6 +91,14 @@ LOGGER = logging.getLogger(__name__)
 # outer HA conversation timeout.
 _LC_TOOL_TIMEOUT_S: float = 30.0
 
+# Maximum seconds to wait for the chat LLM to respond.
+# Under heavy VLM load the Ollama GPU is fully saturated; the chat model
+# queues behind concurrent vision requests and can block indefinitely inside
+# astream_events, stalling the streaming pipeline. This guard converts an
+# infinite hang into a bounded HomeAssistantError so the recovery path can
+# return a response to the user.
+_LLM_INVOKE_TIMEOUT_S: float = 90.0
+
 _PIN_LOOKBACK = 20  # messages to scan for an unresolved requires_pin
 _ROUTING_REJECTION_MARKER = "is not available for this request"
 
@@ -1106,7 +1114,12 @@ async def _invoke_model(
 ) -> Any:
     """Invoke a chat model, wrapping non-HA exceptions as HomeAssistantError."""
     try:
-        return await model.ainvoke(messages, config)
+        return await asyncio.wait_for(
+            model.ainvoke(messages, config), timeout=_LLM_INVOKE_TIMEOUT_S
+        )
+    except TimeoutError:
+        msg = f"Model invocation timed out after {_LLM_INVOKE_TIMEOUT_S}s."
+        raise HomeAssistantError(msg) from None
     except HomeAssistantError:
         raise
     except Exception as err:

--- a/custom_components/home_generative_agent/conversation.py
+++ b/custom_components/home_generative_agent/conversation.py
@@ -474,6 +474,10 @@ async def _stream_langgraph_to_ha(
     except (GeneratorExit, asyncio.CancelledError):
         # Stop iteration on cancellation or closure.
         raise
+    except HomeAssistantError:
+        # Application-level failure (e.g. model timeout) — not a generator bug.
+        # Re-raise so _async_run_astream can handle recovery and user messaging.
+        raise
     except Exception:
         _LOGGER.exception("Error in LangGraph streaming transformation generator.")
         # Persistence guard: flush pending tools as synthetic rejections so HA
@@ -938,6 +942,23 @@ class HGAConversationEntity(conversation.ConversationEntity, AbstractConversatio
                         "Recovered final AssistantContent from graph state after "
                         "streaming failure."
                     )
+                else:
+                    # Graph state has no usable AI response (e.g. model timed out
+                    # before generating a reply). Emit a user-visible error message
+                    # so the chat UI shows something instead of a blank bubble.
+                    chat_log.async_add_assistant_content_without_tools(
+                        conversation.AssistantContent(
+                            agent_id=self.entity_id,
+                            content=(
+                                "I'm sorry, I was unable to respond in time. "
+                                "Please try again."
+                            ),
+                        )
+                    )
+                    _LOGGER.debug(
+                        "Added fallback AssistantContent after streaming failure "
+                        "with no recoverable graph state."
+                    )
         except ValueError:
             # Expected when no checkpointer is configured (e.g. tests)
             _LOGGER.debug("aget_state unavailable; skipping trace for streaming turn.")
@@ -1110,7 +1131,7 @@ class HGAConversationEntity(conversation.ConversationEntity, AbstractConversatio
             chat_log.async_add_assistant_content_without_tools(
                 conversation.AssistantContent(
                     agent_id=self.entity_id,
-                    content="",
+                    content="I'm sorry, I was unable to respond. Please try again.",
                 )
             )
 

--- a/custom_components/home_generative_agent/manifest.json
+++ b/custom_components/home_generative_agent/manifest.json
@@ -33,5 +33,5 @@
     "transformers==4.57.1",
     "langchain-google-genai==3.1.0"
   ],
-  "version": "3.12.1"
+  "version": "3.12.2"
 }

--- a/tests/custom_components/home_generative_agent/test_regressions.py
+++ b/tests/custom_components/home_generative_agent/test_regressions.py
@@ -3,14 +3,18 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import MagicMock
 
 import pytest
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
+import custom_components.home_generative_agent.agent.graph as agent_graph
 from custom_components.home_generative_agent.agent import tools as agent_tools
 from custom_components.home_generative_agent.const import SIGNAL_HGA_RECOGNIZED
 from custom_components.home_generative_agent.core.image_entity import LastEventImage
@@ -198,3 +202,43 @@ def test_agent_tools_uses_direct_tool_node_injected_store_import() -> None:
     source = Path(agent_tools.__file__).read_text(encoding="utf-8")
     assert "from langgraph.prebuilt.tool_node import InjectedStore" in source
     assert "from langgraph.prebuilt import InjectedStore" not in source
+
+
+@pytest.mark.asyncio
+async def test_invoke_model_raises_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    _invoke_model raises HomeAssistantError when the LLM hangs under load.
+
+    Regression: without asyncio.wait_for the model.ainvoke() call blocked
+    indefinitely when the Ollama GPU was saturated by background VLM work,
+    stalling astream_events and showing 'no response' in the chat UI.
+    """
+    monkeypatch.setattr(agent_graph, "_LLM_INVOKE_TIMEOUT_S", 0.05)
+
+    async def _slow_ainvoke(*_args: object, **_kwargs: object) -> None:
+        await asyncio.sleep(10)
+
+    mock_model = MagicMock()
+    mock_model.ainvoke = _slow_ainvoke
+
+    with pytest.raises(HomeAssistantError, match="timed out"):
+        await agent_graph._invoke_model(mock_model, [], {})
+
+
+@pytest.mark.asyncio
+async def test_invoke_model_returns_result_within_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_invoke_model returns the model result when the LLM responds in time."""
+    monkeypatch.setattr(agent_graph, "_LLM_INVOKE_TIMEOUT_S", 5.0)
+
+    expected = MagicMock()
+
+    async def _fast_ainvoke(*_args: object, **_kwargs: object) -> MagicMock:
+        return expected
+
+    mock_model = MagicMock()
+    mock_model.ainvoke = _fast_ainvoke
+
+    result = await agent_graph._invoke_model(mock_model, [], {})
+    assert result is expected


### PR DESCRIPTION
## Summary

- Wraps `model.ainvoke()` in `asyncio.wait_for()` (90s timeout) in `_invoke_model` so GPU saturation from concurrent camera analysis converts an infinite hang into a bounded `HomeAssistantError`
- Fixes `HomeAssistantError` passthrough in `_stream_langgraph_to_ha` to bypass the misleading "generator error" log path
- Replaces the `content=""` empty fallback (blank chat bubble) with a user-visible "I'm sorry, I was unable to respond" message in both recovery paths
- Adds two regression tests covering the timeout and fast-response paths

## Root cause

Under heavy VLM load (camera analysis running on the same Ollama GPU), the chat LLM queues indefinitely inside `astream_events`. Without a timeout, `model.ainvoke()` blocked forever, stalling the streaming pipeline. The HA chat UI showed no response at all.

After adding the timeout, the `HomeAssistantError` was silently falling through to a recovery path that had no AIMessage in graph state, committing `content=""` to the chat log — producing a blank bubble instead of an error message.

## Test plan

- [x] `make test` — 774/774 pass
- [x] `make lint` — clean
- [x] `make typecheck` — clean
- [x] Two regression tests in `test_regressions.py`: `test_invoke_model_raises_on_timeout`, `test_invoke_model_returns_result_within_timeout`
- [x] Manual: trigger under load — chat should show "I'm sorry, I was unable to respond in time. Please try again." within 90s

🤖 Generated with [Claude Code](https://claude.com/claude-code)