### PR TITLE
fix: deployment-aware admission control replaces lock-based GPU gate (v3.12.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,42 +2,77 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.12.4] - 2026-04-28
+
+### Fixed
+
+- **`SENTINEL_ADMISSION_TIMEOUT_S` public constant** — admission timeout was a
+  magic `2.0` literal scattered across triage, discovery, and explain call sites.
+  Extracted to a named constant in `core/utils.py` and imported at each site.
+
+- **`asyncio.create_task()` replaces deprecated `asyncio.ensure_future()`** —
+  `run_sentinel_llm_call` now wraps the call factory in a proper `Task`, which is
+  cancellable and tracked in `_sentinel_llm_tasks`.
+
+- **HA reload cancels in-flight Sentinel LLM tasks** — the previous reload path
+  replaced `_sentinel_llm_tasks` with a fresh `set()` while old tasks continued
+  running. The teardown in `__init__.py` now cancels each task before replacing
+  the set.
+
+- **Warning log when Sentinel LLM cancel times out** — `contextlib.suppress`
+  silently swallowed any `TimeoutError` from the cancel wait. Replaced with an
+  explicit `except TimeoutError` that emits a `WARNING` log.
+
+- **Tests** — deferred-path coverage for `SentinelTriageService`,
+  `LLMExplainer`, and `run_sentinel_llm_call` (timeout path); three tests for
+  `build_model_deployments` (ollama→edge, openai→cloud, empty providers).
+
 ## [3.12.3] - 2026-04-26
 
 ### Fixed
 
-- **Chat no longer competes with in-flight background AI jobs for the GPU** — a
-  new chat-priority gate (`chat_priority_context`) clears a shared `_chat_idle`
-  event and acquires two serialisation locks (`_bg_vlm_lock`, `_bg_llm_lock`)
-  before submitting the chat request to Ollama. Camera snapshot analysis (VLM)
-  and Sentinel triage/discovery (LLM) wait on `_chat_idle` and hold those same
-  locks during inference, so any in-flight background job completes before the
-  chat model starts. This eliminates the GPU compute contention that caused
-  3-minute delays and 180 s timeouts when a camera VLM was mid-inference.
+- **Deployment-aware admission control replaces lock-based GPU gate** — the
+  previous `chat_priority_context` / `_bg_vlm_lock` / `_bg_llm_lock` approach
+  made chat wait for background work to finish. The new design inverts this:
+  `local_chat_session(deployment)` marks the full chat turn active by clearing a
+  shared `_chat_idle` event; Sentinel triage and discovery call
+  `sentinel_admission(deployment, timeout_s=2.0)` before each LLM invocation and
+  defer if chat is active. Video analysis no longer participates in any
+  admission gate — its existing tuning constants (`_VISION_TIMEOUT_SEC`,
+  `_SUMMARY_TIMEOUT_SEC`, per-camera queues) remain the intended concurrency
+  surface. Embedding generation is ungated and runs concurrently with chat.
 
-- **Chat LLM timeout raised from 90 s to 180 s** — the previous 90 s budget
-  did not account for the time the chat-priority gate may spend waiting for a
-  background job to finish. The higher limit covers gate-wait + prefill +
-  generation for typical conversation history lengths.
+- **Provider deployment metadata flows through runtime** — `ModelProviderConfig`
+  gains a `deployment: str` field ("edge"/"cloud"). `build_model_deployments()`
+  builds a `{category: deployment}` map from provider subentries at setup time;
+  the map lives on `HGAData.model_deployments`. Cloud providers bypass all local
+  admission gates automatically, with no code changes required per provider.
+
+- **Sentinel starvation surfaced in the health sensor** — `sentinel_admission`
+  tracks consecutive deferrals and wall-clock gap since last success. When the
+  gap exceeds 300 s a WARNING is logged and the `SentinelHealthSensor` transitions
+  to `"degraded"`, exposing the condition to HA automations and dashboards.
+
+- **Chat LLM timeout raised from 90 s to 180 s** — the higher limit covers
+  prefill + generation for typical conversation history lengths without the
+  gate-wait overhead of the old approach.
 
 - **Sentinel discovery capped at 45 s per LLM call** — discovery prompts can
   be large enough to consume 180 s+ of GPU time. A hard `asyncio.wait_for`
   timeout skips the cycle cleanly rather than monopolising the GPU.
-
-- **TOCTOU-safe background LLM loops** — triage, discovery, and the VLM
-  analyser all use a re-check loop (`wait → lock → re-verify _chat_idle →
-  invoke`) so the priority gate cannot be bypassed by a task that races past
-  the event wait but arrives at the lock after chat has already claimed it.
 
 - **Tool timeout sends a non-retryable error to the LLM** — `_run_langchain_tool`
   now returns a `TOOL_CALL_TRANSIENT_ERROR_TEMPLATE` message on `TimeoutError`
   instead of the generic retry-prompting error template. This stops the model
   from re-calling a tool that timed out due to a temporary resource constraint.
 
-- **Tests added for the chat-priority gate** — 15 new tests cover
-  `chat_priority_context` entry/exit semantics, concurrent-chat reference
-  counting, lock exclusion, `generate_embeddings` gate behaviour, discovery LLM
-  timeout, and the transient tool-error helper.
+- **Qwen3 extended-thinking fallback** — when Ollama strips `<think>` tokens
+  and returns empty content after a tool call, `_call_model` injects `"Done."`
+  so the conversation does not go silent.
+
+- **Tests** — 26 tests for the new admission-control primitives, plus coverage
+  for the triage/discovery deferral paths, the transient tool-error helper, and
+  the Qwen3 fallback.
 
 ## [3.12.2] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.12.3] - 2026-04-26
+
+### Fixed
+
+- **Chat no longer competes with in-flight background AI jobs for the GPU** — a
+  new chat-priority gate (`chat_priority_context`) clears a shared `_chat_idle`
+  event and acquires two serialisation locks (`_bg_vlm_lock`, `_bg_llm_lock`)
+  before submitting the chat request to Ollama. Camera snapshot analysis (VLM)
+  and Sentinel triage/discovery (LLM) wait on `_chat_idle` and hold those same
+  locks during inference, so any in-flight background job completes before the
+  chat model starts. This eliminates the GPU compute contention that caused
+  3-minute delays and 180 s timeouts when a camera VLM was mid-inference.
+
+- **Chat LLM timeout raised from 90 s to 180 s** — the previous 90 s budget
+  did not account for the time the chat-priority gate may spend waiting for a
+  background job to finish. The higher limit covers gate-wait + prefill +
+  generation for typical conversation history lengths.
+
+- **Sentinel discovery capped at 45 s per LLM call** — discovery prompts can
+  be large enough to consume 180 s+ of GPU time. A hard `asyncio.wait_for`
+  timeout skips the cycle cleanly rather than monopolising the GPU.
+
+- **TOCTOU-safe background LLM loops** — triage, discovery, and the VLM
+  analyser all use a re-check loop (`wait → lock → re-verify _chat_idle →
+  invoke`) so the priority gate cannot be bypassed by a task that races past
+  the event wait but arrives at the lock after chat has already claimed it.
+
+- **Tool timeout sends a non-retryable error to the LLM** — `_run_langchain_tool`
+  now returns a `TOOL_CALL_TRANSIENT_ERROR_TEMPLATE` message on `TimeoutError`
+  instead of the generic retry-prompting error template. This stops the model
+  from re-calling a tool that timed out due to a temporary resource constraint.
+
+- **Tests added for the chat-priority gate** — 15 new tests cover
+  `chat_priority_context` entry/exit semantics, concurrent-chat reference
+  counting, lock exclusion, `generate_embeddings` gate behaviour, discovery LLM
+  timeout, and the transient tool-error helper.
+
 ## [3.12.2] - 2026-04-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ Sentinel is a singleton service per Home Generative Agent config entry. Configur
 
 Important: The LLM never executes actions or directly decides runtime safety behavior. Detection and actuation remain deterministic. Triage can suppress low-value notifications but cannot alter any finding field or gate execution.
 
+**Admission control:** On edge deployments (Ollama, local OpenAI-compatible servers), Sentinel LLM calls (triage, discovery, explain) defer when a chat turn is active, so the GPU is not competed for during a live conversation. Sentinel resumes immediately once the chat turn completes. Cloud providers (OpenAI, Gemini, Anthropic) are always admitted — they use remote inference and are unaffected by local GPU load. When deferrals persist for more than 300 s, the `sentinel_health` sensor transitions to `degraded` and a WARNING is logged.
+
 ### Built-in Static Rules
 
 These rules run on every detection cycle without any configuration or approval. They cover the most common security and safety patterns out of the box:
@@ -580,7 +582,7 @@ Notable service behavior:
 
 ### Sentinel Health Sensor
 
-Sentinel registers a `sensor.sentinel_health` entity that is updated after every detection run. Its state is `ok` when Sentinel is enabled and `disabled` otherwise.
+Sentinel registers a `sensor.sentinel_health` entity that is updated after every detection run. Its state is `ok` when Sentinel is enabled and running normally, `degraded` when Sentinel LLM calls have been consecutively deferred for more than 300 s (edge deployment under sustained chat load), and `disabled` when Sentinel is not configured.
 
 Attributes:
 
@@ -590,6 +592,10 @@ Attributes:
 | `last_run_end` | UTC ISO 8601 timestamp when the last run ended |
 | `run_duration_ms` | Last run duration in milliseconds |
 | `active_rule_count` | Number of active rules evaluated |
+| `sentinel_admission_degraded` | `true` when Sentinel LLM calls have been deferred for more than 300 s without a successful run |
+| `sentinel_admission_degraded_category` | The Sentinel category (`triage`, `discovery`, `explain`) that last triggered the degraded flag, or `null` |
+| `sentinel_admission_consecutive_deferrals` | Number of consecutive times Sentinel LLM admission was denied due to active chat |
+| `sentinel_admission_starved_for_s` | Seconds since the last successful Sentinel LLM run (or since the first deferral if no run has ever succeeded) |
 | `trigger_source_breakdown` | Rolling 24-hour trigger counts broken down by source: `{poll: N, event: N, on_demand: N}` |
 | `discovery_candidates_generated` | Total discovery candidates returned by the LLM in the most recent cycle |
 | `discovery_candidates_novel` | Candidates that passed deduplication and were stored |

--- a/custom_components/home_generative_agent/__init__.py
+++ b/custom_components/home_generative_agent/__init__.py
@@ -206,6 +206,7 @@ from .core.person_gallery import PersonGalleryDAO
 from .core.runtime import HGAConfigEntry, HGAData
 from .core.subentry_resolver import (
     build_database_uri_from_entry,
+    build_model_deployments,
     legacy_feature_configs,
     legacy_model_provider_configs,
     resolve_model_provider_configs,
@@ -1166,6 +1167,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: HGAConfigEntry) -> bool:
     """Set up Home Generative Agent from a config entry."""
     hass.data.setdefault(DOMAIN, {})
 
+    # Reset admission-control globals in case a prior entry unload left them
+    # dirty (e.g. mid-chat reload where the task was not cleanly cancelled).
+    import custom_components.home_generative_agent.core.utils as _utils_mod  # noqa: PLC0415
+
+    _utils_mod._chat_active_count = 0  # noqa: SLF001
+    _utils_mod._chat_idle.set()  # noqa: SLF001
+    _utils_mod._sentinel_last_run = 0.0  # noqa: SLF001
+    _utils_mod._sentinel_first_defer = 0.0  # noqa: SLF001
+    _utils_mod._sentinel_defer_count = 0  # noqa: SLF001
+    for _t in _utils_mod._sentinel_llm_tasks:  # noqa: SLF001
+        _t.cancel()
+    _utils_mod._sentinel_llm_tasks = set()  # noqa: SLF001
+
     _register_services(hass, entry)
     _ensure_default_feature_subentries(hass, entry)
     _ensure_default_sentinel_subentry(hass, entry)
@@ -1175,6 +1189,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: HGAConfigEntry) -> bool:
     options = resolve_runtime_options(entry)
     conf = dict(options)
     providers = resolve_model_provider_configs(entry, options)
+    model_deployments = build_model_deployments(entry, providers, options)
     api_key = conf.get(CONF_API_KEY) or _provider_api_key(providers, "openai")
     openai_secret = SecretStr(api_key) if api_key else None
     gemini_key = conf.get(CONF_GEMINI_API_KEY) or _provider_api_key(providers, "gemini")
@@ -1758,9 +1773,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: HGAConfigEntry) -> bool:
         hass, options, suppression, action_handler, audit_store=audit_store
     )
     notifier.start()
+    sentinel_run_stats: dict[str, Any] = {
+        "sentinel_admission_degraded": False,
+        "sentinel_admission_degraded_category": None,
+        "sentinel_admission_consecutive_deferrals": 0,
+        "sentinel_admission_starved_for_s": 0,
+    }
+    chat_deployment = model_deployments.get("chat", "edge")
     explainer = None
     if options.get(CONF_EXPLAIN_ENABLED, RECOMMENDED_EXPLAIN_ENABLED):
-        explainer = LLMExplainer(chat_model)
+        explainer = LLMExplainer(
+            chat_model,
+            deployment=chat_deployment,
+            health_stats=sentinel_run_stats,
+        )
+
     # Issue #262: optional LLM triage service.
     triage_service: SentinelTriageService | None = None
     if options.get(CONF_SENTINEL_TRIAGE_ENABLED, RECOMMENDED_SENTINEL_TRIAGE_ENABLED):
@@ -1771,7 +1798,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: HGAConfigEntry) -> bool:
             )
         )
         triage_service = SentinelTriageService(
-            chat_model, timeout_seconds=triage_timeout
+            chat_model,
+            timeout_seconds=triage_timeout,
+            deployment=chat_deployment,
+            health_stats=sentinel_run_stats,
         )
         LOGGER.info("Sentinel LLM triage enabled (timeout=%ds).", triage_timeout)
     # Issue #265: optional baseline updater (requires PostgreSQL pool).
@@ -1798,6 +1828,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: HGAConfigEntry) -> bool:
         entry_id=entry.entry_id,
         triage_service=triage_service,
         baseline_updater=baseline_updater,
+        run_stats=sentinel_run_stats,
     )
     discovery_engine = SentinelDiscoveryEngine(
         hass=hass,
@@ -1807,6 +1838,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: HGAConfigEntry) -> bool:
         rule_registry=rule_registry,
         proposal_store=proposal_store,
         baseline_updater=baseline_updater,
+        deployment=chat_deployment,
+        health_stats=sentinel_run_stats,
     )
 
     face_recognition = options.get(CONF_FACE_RECOGNITION, RECOMMENDED_FACE_RECOGNITION)
@@ -1824,6 +1857,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: HGAConfigEntry) -> bool:
         chat_model_options=ollama_chat_model_options,
         vision_model=vision_model,
         summarization_model=summarization_model,
+        model_deployments=model_deployments,
         store=store,
         video_analyzer=video_analyzer,
         checkpointer=checkpointer,

--- a/custom_components/home_generative_agent/agent/graph.py
+++ b/custom_components/home_generative_agent/agent/graph.py
@@ -1124,19 +1124,22 @@ async def _invoke_model(
     model: Any, messages: list[AnyMessage], config: RunnableConfig
 ) -> Any:
     """Invoke a chat model, wrapping non-HA exceptions as HomeAssistantError."""
-    async with chat_priority_context():
-        try:
-            return await asyncio.wait_for(
-                model.ainvoke(messages, config), timeout=_LLM_INVOKE_TIMEOUT_S
-            )
-        except TimeoutError:
-            msg = f"Model invocation timed out after {_LLM_INVOKE_TIMEOUT_S}s."
-            raise HomeAssistantError(msg) from None
-        except HomeAssistantError:
-            raise
-        except Exception as err:
-            msg = f"Model invocation failed: {err}"
-            raise HomeAssistantError(msg) from err
+    # asyncio.timeout wraps the full block — including lock acquisition inside
+    # chat_priority_context — so the total wait (queue time + inference time)
+    # is bounded.  Previously wait_for started only after both locks were held,
+    # leaving lock-wait time unbounded if a background job was slow to finish.
+    try:
+        async with asyncio.timeout(_LLM_INVOKE_TIMEOUT_S):
+            async with chat_priority_context():
+                return await model.ainvoke(messages, config)
+    except TimeoutError:
+        msg = f"Model invocation timed out after {_LLM_INVOKE_TIMEOUT_S}s."
+        raise HomeAssistantError(msg) from None
+    except HomeAssistantError:
+        raise
+    except Exception as err:
+        msg = f"Model invocation failed: {err}"
+        raise HomeAssistantError(msg) from err
 
 
 async def _call_model(

--- a/custom_components/home_generative_agent/agent/graph.py
+++ b/custom_components/home_generative_agent/agent/graph.py
@@ -62,9 +62,10 @@ from custom_components.home_generative_agent.const import (
     SUMMARIZATION_PROMPT_TEMPLATE,
     SUMMARIZATION_SYSTEM_PROMPT,
     TOOL_CALL_ERROR_TEMPLATE,
+    TOOL_CALL_TRANSIENT_ERROR_TEMPLATE,
 )
 
-from ..core.utils import extract_final  # noqa: TID252
+from ..core.utils import chat_priority_context, extract_final  # noqa: TID252
 from .camera_activity import get_recent_camera_activity
 from .helpers import (
     format_tool,
@@ -92,12 +93,12 @@ LOGGER = logging.getLogger(__name__)
 _LC_TOOL_TIMEOUT_S: float = 30.0
 
 # Maximum seconds to wait for the chat LLM to respond.
-# Under heavy VLM load the Ollama GPU is fully saturated; the chat model
-# queues behind concurrent vision requests and can block indefinitely inside
-# astream_events, stalling the streaming pipeline. This guard converts an
-# infinite hang into a bounded HomeAssistantError so the recovery path can
-# return a response to the user.
-_LLM_INVOKE_TIMEOUT_S: float = 90.0
+# The chat model may need exclusive GPU access and can be delayed while the
+# chat-priority gate waits for in-flight background jobs (camera analysis,
+# embedding, Sentinel LLM) to finish.  With a large prompt, prefill alone
+# can take tens of seconds.  Set high enough to cover gate wait + prefill +
+# generation for typical conversation history lengths.
+_LLM_INVOKE_TIMEOUT_S: float = 180.0
 
 _PIN_LOOKBACK = 20  # messages to scan for an unresolved requires_pin
 _ROUTING_REJECTION_MARKER = "is not available for this request"
@@ -147,6 +148,16 @@ def _make_tool_error(err: str, name: str, tid: str) -> ToolMessage:
     """Build a standardized error ToolMessage."""
     return ToolMessage(
         content=TOOL_CALL_ERROR_TEMPLATE.format(error=err),
+        name=name,
+        tool_call_id=tid,
+        status="error",
+    )
+
+
+def _make_transient_tool_error(err: str, name: str, tid: str) -> ToolMessage:
+    """Build a ToolMessage for transient/resource errors that must not be retried."""
+    return ToolMessage(
+        content=TOOL_CALL_TRANSIENT_ERROR_TEMPLATE.format(error=err),
         name=name,
         tool_call_id=tid,
         status="error",
@@ -288,7 +299,7 @@ async def _run_langchain_tool(
             status=status,
         )
     except TimeoutError:
-        return _make_tool_error(
+        return _make_transient_tool_error(
             f"Tool timed out after {_LC_TOOL_TIMEOUT_S}s.",
             tool_name,
             tool_call.get("id") or "",
@@ -1113,18 +1124,19 @@ async def _invoke_model(
     model: Any, messages: list[AnyMessage], config: RunnableConfig
 ) -> Any:
     """Invoke a chat model, wrapping non-HA exceptions as HomeAssistantError."""
-    try:
-        return await asyncio.wait_for(
-            model.ainvoke(messages, config), timeout=_LLM_INVOKE_TIMEOUT_S
-        )
-    except TimeoutError:
-        msg = f"Model invocation timed out after {_LLM_INVOKE_TIMEOUT_S}s."
-        raise HomeAssistantError(msg) from None
-    except HomeAssistantError:
-        raise
-    except Exception as err:
-        msg = f"Model invocation failed: {err}"
-        raise HomeAssistantError(msg) from err
+    async with chat_priority_context():
+        try:
+            return await asyncio.wait_for(
+                model.ainvoke(messages, config), timeout=_LLM_INVOKE_TIMEOUT_S
+            )
+        except TimeoutError:
+            msg = f"Model invocation timed out after {_LLM_INVOKE_TIMEOUT_S}s."
+            raise HomeAssistantError(msg) from None
+        except HomeAssistantError:
+            raise
+        except Exception as err:
+            msg = f"Model invocation failed: {err}"
+            raise HomeAssistantError(msg) from err
 
 
 async def _call_model(

--- a/custom_components/home_generative_agent/agent/graph.py
+++ b/custom_components/home_generative_agent/agent/graph.py
@@ -65,7 +65,7 @@ from custom_components.home_generative_agent.const import (
     TOOL_CALL_TRANSIENT_ERROR_TEMPLATE,
 )
 
-from ..core.utils import chat_priority_context, extract_final  # noqa: TID252
+from ..core.utils import extract_final  # noqa: TID252
 from .camera_activity import get_recent_camera_activity
 from .helpers import (
     format_tool,
@@ -1120,18 +1120,34 @@ async def _trim_messages_for_model(
     )
 
 
+def _build_system_message(
+    base_prompt: str,
+    mems: list[Any],
+    camera_activity: list[Any],
+    summary: str,
+) -> str:
+    """Compose the system message from the base prompt and retrieved context."""
+    system_message = base_prompt
+    if mems:
+        formatted_mems = "\n".join(f"[{mem.key}]: {mem.value}" for mem in mems)
+        system_message += f"\n<memories>\n{formatted_mems}\n</memories>"
+    if camera_activity:
+        ca = "\n".join(str(a) for a in camera_activity)
+        system_message += f"\n<recent_camera_activity>\n{ca}\n</recent_camera_activity>"
+    if summary:
+        system_message += (
+            f"\n<past_conversation_summary>\n{summary}\n</past_conversation_summary>"
+        )
+    return system_message
+
+
 async def _invoke_model(
     model: Any, messages: list[AnyMessage], config: RunnableConfig
 ) -> Any:
     """Invoke a chat model, wrapping non-HA exceptions as HomeAssistantError."""
-    # asyncio.timeout wraps the full block — including lock acquisition inside
-    # chat_priority_context — so the total wait (queue time + inference time)
-    # is bounded.  Previously wait_for started only after both locks were held,
-    # leaving lock-wait time unbounded if a background job was slow to finish.
     try:
         async with asyncio.timeout(_LLM_INVOKE_TIMEOUT_S):
-            async with chat_priority_context():
-                return await model.ainvoke(messages, config)
+            return await model.ainvoke(messages, config)
     except TimeoutError:
         msg = f"Model invocation timed out after {_LLM_INVOKE_TIMEOUT_S}s."
         raise HomeAssistantError(msg) from None
@@ -1172,17 +1188,9 @@ async def _call_model(
     camera_activity = await get_recent_camera_activity(hass, store)
 
     # Build system message.
-    system_message = conf["prompt"]
-    if mems:
-        formatted_mems = "\n".join(f"[{mem.key}]: {mem.value}" for mem in mems)
-        system_message += f"\n<memories>\n{formatted_mems}\n</memories>"
-    if camera_activity:
-        ca = "\n".join(str(a) for a in camera_activity)
-        system_message += f"\n<recent_camera_activity>\n{ca}\n</recent_camera_activity>"
-    if summary := state.get("summary", ""):
-        system_message += (
-            f"\n<past_conversation_summary>\n{summary}\n</past_conversation_summary>"
-        )
+    system_message = _build_system_message(
+        conf["prompt"], mems, camera_activity, state.get("summary", "")
+    )
 
     # Model input = System + current messages.
     messages = [SystemMessage(content=system_message)] + state["messages"]
@@ -1214,9 +1222,23 @@ async def _call_model(
 
     response = extract_final(getattr(raw_response, "content", "") or "")
 
+    tool_calls = getattr(raw_response, "tool_calls", []) or []
+
+    # Qwen3 extended-thinking: Ollama strips <think>…</think> tokens from content,
+    # leaving content='' when all output was reasoning.  On a post-tool turn with no
+    # follow-up tool call the user would receive no reply at all.  Inject a minimal
+    # acknowledgement so the conversation doesn't go silent.
+    if (
+        not response
+        and not tool_calls
+        and isinstance(state["messages"][-1], ToolMessage)
+    ):
+        LOGGER.debug("Empty model response after tool execution; injecting fallback.")
+        response = "Done."
+
     # Create AI message, no need to include tool call metadata if there's none.
-    if hasattr(raw_response, "tool_calls"):
-        ai_response = AIMessage(content=response, tool_calls=raw_response.tool_calls)
+    if tool_calls:
+        ai_response = AIMessage(content=response, tool_calls=tool_calls)
     else:
         ai_response = AIMessage(content=response)
     LOGGER.debug("AI response: %s", ai_response)

--- a/custom_components/home_generative_agent/const.py
+++ b/custom_components/home_generative_agent/const.py
@@ -625,6 +625,13 @@ Error: {error}
 
 Call the tool again with your mistake corrected.
 """
+TOOL_CALL_TRANSIENT_ERROR_TEMPLATE = """
+Error: {error}
+
+This is a transient resource error, not a mistake in your arguments.
+Do not retry this tool. Inform the user that the operation could not
+be completed due to a temporary system constraint.
+"""
 CRITICAL_ACTION_PROMPT = """
 For critical actions (door/lock/garage/open), call the tool directly—do NOT ask
 for verbal confirmation first. The tool itself enforces security.

--- a/custom_components/home_generative_agent/conversation.py
+++ b/custom_components/home_generative_agent/conversation.py
@@ -76,7 +76,7 @@ from .core.conversation_helpers import (
     _is_dashboard_request,
     _maybe_fix_dashboard_entities,
 )
-from .core.utils import gather_store_puts_in_chunks
+from .core.utils import gather_store_puts_in_chunks, local_chat_session
 
 if TYPE_CHECKING:
     from collections.abc import (
@@ -971,8 +971,6 @@ class HGAConversationEntity(conversation.ConversationEntity, AbstractConversatio
         chat_log: conversation.ChatLog,
     ) -> conversation.ConversationResult:
         """Process the user input."""
-        hass = self.hass
-        options = self.entry.runtime_data.options
         runtime_data = self.entry.runtime_data
         intent_response = intent.IntentResponse(language=user_input.language)
 
@@ -991,6 +989,31 @@ class HGAConversationEntity(conversation.ConversationEntity, AbstractConversatio
             if chat_log.conversation_id is None
             else chat_log.conversation_id
         )
+
+        deployment = runtime_data.model_deployments.get("chat", "edge")
+        async with local_chat_session(deployment, category="chat"):
+            return await self._async_handle_message_active(
+                user_input,
+                chat_log,
+                intent_response,
+                llm_context,
+                message_history,
+                conversation_id,
+            )
+
+    async def _async_handle_message_active(  # noqa: PLR0913
+        self,
+        user_input: conversation.ConversationInput,
+        chat_log: conversation.ChatLog,
+        intent_response: intent.IntentResponse,
+        llm_context: llm.LLMContext,
+        message_history: list[Any],
+        conversation_id: str,
+    ) -> conversation.ConversationResult:
+        """Process user input while local chat activity is already marked."""
+        hass = self.hass
+        runtime_data = self.entry.runtime_data
+        options = runtime_data.options
 
         # Multi-API initialization
         try:

--- a/custom_components/home_generative_agent/core/runtime.py
+++ b/custom_components/home_generative_agent/core/runtime.py
@@ -68,6 +68,7 @@ class HGAData:
     proposal_store: ProposalStore | None
     rule_registry: RuleRegistry | None
     baseline_updater: SentinelBaselineUpdater | None = None
+    model_deployments: dict[str, str] = field(default_factory=dict)
     tool_content_hashes: dict[str, str] = field(default_factory=dict)
     tool_index_ready: bool = False
     tool_indexing_in_progress: bool = False

--- a/custom_components/home_generative_agent/core/sentinel_health_sensor.py
+++ b/custom_components/home_generative_agent/core/sentinel_health_sensor.py
@@ -259,6 +259,10 @@ class SentinelHealthSensor(SensorEntity):
             "last_run_end",
             "run_duration_ms",
             "active_rule_count",
+            "sentinel_admission_degraded",
+            "sentinel_admission_degraded_category",
+            "sentinel_admission_consecutive_deferrals",
+            "sentinel_admission_starved_for_s",
         ):
             self._attrs[key] = run_stats.get(key)
 
@@ -301,7 +305,9 @@ class SentinelHealthSensor(SensorEntity):
             else None
         )
 
-        self._attr_native_value = "ok"
+        self._attr_native_value = (
+            "degraded" if run_stats.get("sentinel_admission_degraded") else "ok"
+        )
         self.async_write_ha_state()
 
     async def _refresh_baseline_attrs(self) -> None:

--- a/custom_components/home_generative_agent/core/subentry_resolver.py
+++ b/custom_components/home_generative_agent/core/subentry_resolver.py
@@ -129,6 +129,28 @@ if TYPE_CHECKING:
 
 LOGGER = logging.getLogger(__name__)
 
+# Deployment defaults by provider type.
+# openai_compatible defaults to "edge" because it is currently only exposed
+# under the Edge path in the config flow and is commonly used for LM Studio,
+# vLLM, or other locally hosted servers.
+_DEPLOYMENT_DEFAULTS: dict[str, str] = {
+    "ollama": "edge",
+    "openai": "cloud",
+    "gemini": "cloud",
+    "openai_compatible": "edge",
+    "anthropic": "cloud",
+    "triton": "edge",
+    "docker_runner": "edge",
+}
+
+
+def _deployment_for(provider_type: str, data: dict[str, Any]) -> str:
+    """Return deployment value, preferring explicit data over provider-type default."""
+    stored = data.get("deployment")
+    if isinstance(stored, str) and stored in ("edge", "cloud"):
+        return stored
+    return _DEPLOYMENT_DEFAULTS.get(provider_type, "edge")
+
 
 def _options_for(entry: ConfigEntry) -> dict[str, Any]:
     """Merge entry data + options for convenience."""
@@ -291,6 +313,7 @@ def _model_provider_from_subentry(subentry: ConfigSubentry) -> ModelProviderConf
         provider_type=provider_type,
         capabilities=caps,
         data={"settings": dict(settings), "name": name},
+        deployment=_deployment_for(provider_type, data),
     )
 
 
@@ -436,6 +459,7 @@ def _build_ollama_legacy_providers(
             provider_type="ollama",
             capabilities=categories,
             data={"settings": settings},
+            deployment=_DEPLOYMENT_DEFAULTS.get("ollama", "edge"),
         )
 
     return providers
@@ -469,6 +493,7 @@ def _build_openai_legacy_provider(
         provider_type="openai",
         capabilities={"chat", "vlm", "summarization", "embedding"},
         data={"settings": settings},
+        deployment=_DEPLOYMENT_DEFAULTS.get("openai", "cloud"),
     )
 
 
@@ -500,6 +525,7 @@ def _build_gemini_legacy_provider(
         provider_type="gemini",
         capabilities={"chat", "vlm", "summarization", "embedding"},
         data={"settings": settings},
+        deployment=_DEPLOYMENT_DEFAULTS.get("gemini", "cloud"),
     )
 
 
@@ -744,6 +770,40 @@ def _apply_feature_model_to_options(
             options[CONF_OLLAMA_REASONING] = model_data.get(
                 CONF_FEATURE_MODEL_REASONING
             )
+
+
+def build_model_deployments(
+    entry: ConfigEntry,
+    providers: Mapping[str, ModelProviderConfig],
+    options: Mapping[str, Any],
+) -> dict[str, str]:
+    """
+    Return {category: deployment} for all model categories.
+
+    Uses the feature→provider mapping when subentries are present, then falls
+    back to provider capabilities for any uncovered category.
+    """
+    features = resolve_feature_configs(entry, providers, options)
+    providers_by_id = dict(providers)
+
+    category_provider: dict[str, ModelProviderConfig] = {}
+    for feature in features.values():
+        cat = FEATURE_CATEGORY_MAP.get(feature.feature_type)
+        if not cat:
+            continue
+        provider = providers_by_id.get(feature.model_provider_id or "")
+        if provider:
+            category_provider.setdefault(cat, provider)
+
+    for cat in ("chat", "vlm", "summarization", "embedding"):
+        if cat in category_provider:
+            continue
+        for provider in providers_by_id.values():
+            if cat in provider.capabilities:
+                category_provider[cat] = provider
+                break
+
+    return {cat: p.deployment for cat, p in category_provider.items()}
 
 
 def resolve_runtime_options(entry: ConfigEntry) -> dict[str, Any]:

--- a/custom_components/home_generative_agent/core/subentry_types.py
+++ b/custom_components/home_generative_agent/core/subentry_types.py
@@ -28,6 +28,7 @@ class ModelProviderConfig:
     provider_type: ProviderType
     capabilities: set[str]
     data: dict
+    deployment: str = "edge"
 
 
 @dataclass

--- a/custom_components/home_generative_agent/core/utils.py
+++ b/custom_components/home_generative_agent/core/utils.py
@@ -19,6 +19,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.httpx_client import get_async_client
 from langchain_google_genai import GoogleGenerativeAIEmbeddings
+from langchain_ollama import OllamaEmbeddings
 
 from ..const import (  # noqa: TID252
     CONF_OLLAMA_URL,
@@ -35,7 +36,6 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Mapping, Sequence
 
     from homeassistant.core import HomeAssistant
-    from langchain_ollama import OllamaEmbeddings
     from langchain_openai import OpenAIEmbeddings
 
 LOGGER = logging.getLogger(__name__)
@@ -183,17 +183,22 @@ async def chat_priority_context() -> AsyncIterator[None]:
     global _chat_active_count  # noqa: PLW0603
     _chat_active_count += 1
     _chat_idle.clear()
-    # Acquire locks in fixed order (vlm → llm) to wait for any in-flight
+    # The outer try/finally guarantees cleanup even if this task is cancelled
+    # while waiting to acquire a lock (e.g., HA config-entry reload mid-chat).
+    # Without it, _chat_idle would stay cleared permanently and all background
+    # workers would hang until the next HA restart.
+    #
+    # Locks are acquired in fixed order (vlm → llm) to wait for any in-flight
     # background Ollama call before submitting the chat request.  Background
     # workers hold at most one lock at a time, so there is no circular
     # dependency and deadlock is impossible.
-    async with _bg_vlm_lock, _bg_llm_lock:
-        try:
+    try:
+        async with _bg_vlm_lock, _bg_llm_lock:
             yield
-        finally:
-            _chat_active_count -= 1
-            if _chat_active_count == 0:
-                _chat_idle.set()
+    finally:
+        _chat_active_count -= 1
+        if _chat_active_count == 0:
+            _chat_idle.set()
 
 
 async def generate_embeddings(
@@ -201,26 +206,31 @@ async def generate_embeddings(
     texts: Sequence[str],
 ) -> list[list[float]]:
     """
-    Generate embeddings, waiting for the chat-priority gate first.
+    Generate embeddings, applying the chat-priority GPU gate for Ollama only.
 
-    Uses the same TOCTOU-safe loop as Sentinel triage/discovery: wait on
+    OllamaEmbeddings uses the same local GPUs as the chat model, so it must
+    wait using the same TOCTOU-safe loop as Sentinel triage/discovery: wait on
     _chat_idle, acquire _bg_llm_lock, re-check _chat_idle, then embed.
-    This prevents Ollama-backed embedding calls from competing with the chat
-    model on shared GPUs.
+
+    OpenAI and Google embeddings call cloud APIs and do not contend for local
+    GPUs, so they bypass the gate entirely.
     """
     texts_list = [t for t in texts if t]  # drop empties defensively
     if not texts_list:
         return []
-    while True:
-        await _chat_idle.wait()
-        async with _bg_llm_lock:
-            if not _chat_idle.is_set():
-                continue  # chat grabbed priority; retry
-            if isinstance(emb, GoogleGenerativeAIEmbeddings):
-                return await emb.aembed_documents(
-                    texts_list, output_dimensionality=EMBEDDING_MODEL_DIMS
-                )
-            return await emb.aembed_documents(texts_list)
+    if isinstance(emb, OllamaEmbeddings):
+        while True:
+            await _chat_idle.wait()
+            async with _bg_llm_lock:
+                if not _chat_idle.is_set():
+                    continue  # chat grabbed priority; retry
+                return await emb.aembed_documents(texts_list)
+    # Non-Ollama providers: no local GPU contention — call directly.
+    if isinstance(emb, GoogleGenerativeAIEmbeddings):
+        return await emb.aembed_documents(
+            texts_list, output_dimensionality=EMBEDDING_MODEL_DIMS
+        )
+    return await emb.aembed_documents(texts_list)
 
 
 def discover_mobile_notify_service(hass: HomeAssistant) -> str | None:

--- a/custom_components/home_generative_agent/core/utils.py
+++ b/custom_components/home_generative_agent/core/utils.py
@@ -9,6 +9,7 @@ import hmac
 import logging
 import re
 import secrets
+import time
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import urljoin, urlparse
@@ -19,7 +20,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.httpx_client import get_async_client
 from langchain_google_genai import GoogleGenerativeAIEmbeddings
-from langchain_ollama import OllamaEmbeddings
 
 from ..const import (  # noqa: TID252
     CONF_OLLAMA_URL,
@@ -33,10 +33,19 @@ from ..const import (  # noqa: TID252
 )
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Mapping, Sequence
+    from collections.abc import (
+        AsyncIterator,
+        Awaitable,
+        Callable,
+        Mapping,
+        MutableMapping,
+        Sequence,
+    )
 
     from homeassistant.core import HomeAssistant
+    from langchain_ollama import OllamaEmbeddings
     from langchain_openai import OpenAIEmbeddings
+
 
 LOGGER = logging.getLogger(__name__)
 
@@ -136,69 +145,208 @@ def configured_ollama_urls(
 
 
 # ---------------------------------------------------------------------------
-# Chat-priority gate
+# Deployment-aware admission control
 # ---------------------------------------------------------------------------
-# The chat model may need exclusive access to all available GPUs.
-# Background tasks (camera snapshot analysis, embedding generation,
-# Sentinel triage/discovery) monopolise individual GPUs and can prevent
-# the chat model from loading or slow it significantly.
-#
-# Two primitives work together:
-#   _chat_idle     — Event; cleared while a chat invocation is active.
-#                    Background workers wait on this before touching the GPU.
-#   _bg_llm_lock   — Lock; held while a background LLM call (Sentinel) runs.
-#                    chat_priority_context acquires it so chat waits for any
-#                    in-flight Sentinel call before submitting to Ollama.
-#
-# Background callers use a TOCTOU-safe loop: wait on _chat_idle, acquire
-# _bg_llm_lock, re-check _chat_idle, then invoke the model — retrying if
-# chat grabbed priority between the wait and the lock acquisition.
-#
-# The gate lives in utils.py (not video_analyzer.py) because
-# generate_embeddings is the single chokepoint for all embed traffic —
-# gating it here covers Sentinel, the vector store, and any other caller.
-# video_analyzer.py imports the same primitives for VLM gating.
+# Policy:
+#   Chat (edge)      — marks the full turn active via local_chat_session so
+#                      Sentinel can observe chat activity and defer.
+#   Sentinel (edge)  — calls sentinel_admission before every LLM invocation;
+#                      defers (skips) if chat is active.
+#   Video / embeds   — no chat gate; video tuning constants are the surface
+#                      for managing GPU contention on weak hardware.
+#   Cloud providers  — bypass all local gates.
 # ---------------------------------------------------------------------------
 
 _chat_idle = asyncio.Event()
 _chat_idle.set()  # "no chat active" by default
 _chat_active_count: int = 0
 
-# Serialises background LLM (Sentinel triage/discovery) calls and lets
-# chat_priority_context wait for any in-flight background call to finish.
-_bg_llm_lock = asyncio.Lock()
+_sentinel_last_run: float = 0.0  # monotonic timestamp of last admitted run
+_sentinel_first_defer: float = 0.0
+_sentinel_defer_count: int = 0
+_SENTINEL_STARVATION_WARN_S: float = 300.0
+_SENTINEL_CANCEL_WAIT_S: float = 2.0
+_sentinel_llm_tasks: set[asyncio.Future[Any]] = set()
 
-# Serialises background camera snapshot analysis calls so that
-# chat_priority_context can wait for any in-flight camera model inference
-# before submitting the chat request to Ollama.  The background video analyser
-# holds this lock for the duration of each Ollama /api/chat request.  Running
-# the camera model concurrently with the chat model on a shared GPU causes
-# compute contention that can dramatically slow or time out the chat response.
-_bg_vlm_lock = asyncio.Lock()
+# Public constant: maximum seconds a Sentinel LLM call waits for chat to become
+# idle before deferring.  All callers (triage, discovery, explain) use the same
+# value so policy changes need only one edit.
+SENTINEL_ADMISSION_TIMEOUT_S: float = 2.0
+
+
+class SentinelLLMDeferredError(Exception):
+    """Raised when a background Sentinel LLM call is deferred or interrupted."""
+
+    def __init__(self, category: str, reason: str) -> None:
+        """Initialize with the Sentinel LLM category and deferral reason."""
+        super().__init__(f"Sentinel {category} {reason}.")
+
+
+def is_edge_deployment(deployment: str | None) -> bool:
+    """Return True for edge (local) deployments subject to resource gating."""
+    return deployment == "edge"
 
 
 @contextlib.asynccontextmanager
-async def chat_priority_context() -> AsyncIterator[None]:
-    """Gate background VLM/embed/LLM jobs while a chat LLM invocation is active."""
+async def local_chat_session(
+    deployment: str, *, category: str = "chat"
+) -> AsyncIterator[None]:
+    """
+    Mark a local chat turn active for its full duration.
+
+    Clears _chat_idle for the entire turn so Sentinel LLM invocations can
+    check for active chat and defer.  No-op for cloud deployments.
+    The try/finally guarantees the counter resets on cancellation or exception.
+    """
+    if not is_edge_deployment(deployment):
+        yield
+        return
     global _chat_active_count  # noqa: PLW0603
     _chat_active_count += 1
     _chat_idle.clear()
-    # The outer try/finally guarantees cleanup even if this task is cancelled
-    # while waiting to acquire a lock (e.g., HA config-entry reload mid-chat).
-    # Without it, _chat_idle would stay cleared permanently and all background
-    # workers would hang until the next HA restart.
-    #
-    # Locks are acquired in fixed order (vlm → llm) to wait for any in-flight
-    # background Ollama call before submitting the chat request.  Background
-    # workers hold at most one lock at a time, so there is no circular
-    # dependency and deadlock is impossible.
     try:
-        async with _bg_vlm_lock, _bg_llm_lock:
-            yield
+        await _cancel_active_sentinel_llm_tasks(category)
+        LOGGER.debug(
+            "Chat session active (deployment=%s, category=%s).", deployment, category
+        )
+        yield
     finally:
         _chat_active_count -= 1
         if _chat_active_count == 0:
             _chat_idle.set()
+        LOGGER.debug(
+            "Chat session ended (deployment=%s, category=%s).", deployment, category
+        )
+
+
+async def _cancel_active_sentinel_llm_tasks(category: str) -> None:
+    """Cancel in-flight Sentinel LLM HTTP calls before foreground chat proceeds."""
+    tasks = [task for task in _sentinel_llm_tasks if not task.done()]
+    if not tasks:
+        return
+    LOGGER.warning(
+        "Cancelling %d active Sentinel LLM call(s) for foreground %s.",
+        len(tasks),
+        category,
+    )
+    for task in tasks:
+        task.cancel()
+    try:
+        await asyncio.wait_for(
+            asyncio.gather(*tasks, return_exceptions=True),
+            timeout=_SENTINEL_CANCEL_WAIT_S,
+        )
+    except TimeoutError:
+        LOGGER.warning(
+            "Sentinel LLM task(s) did not cancel within %.1fs; "
+            "GPU contention may persist briefly.",
+            _SENTINEL_CANCEL_WAIT_S,
+        )
+
+
+async def sentinel_admission(
+    deployment: str,
+    *,
+    category: str,
+    timeout_s: float,
+    health_stats: MutableMapping[str, Any] | None = None,
+) -> bool:
+    """
+    Return True if a Sentinel LLM call may proceed.
+
+    Edge: waits up to timeout_s for chat to become idle; returns False if still
+    active so the caller can defer the pass.
+    Cloud: always admitted.
+    Tracks last-admitted timestamp and consecutive deferral count for health
+    monitoring; logs a WARNING when Sentinel has been starved beyond the
+    starvation threshold.
+    """
+    global _sentinel_first_defer, _sentinel_last_run, _sentinel_defer_count  # noqa: PLW0603
+    if not is_edge_deployment(deployment):
+        _sentinel_last_run = time.monotonic()
+        _sentinel_first_defer = 0.0
+        _sentinel_defer_count = 0
+        if health_stats is not None:
+            health_stats["sentinel_admission_degraded"] = False
+            health_stats["sentinel_admission_degraded_category"] = None
+            health_stats["sentinel_admission_consecutive_deferrals"] = 0
+            health_stats["sentinel_admission_starved_for_s"] = 0
+        return True
+    try:
+        async with asyncio.timeout(timeout_s):
+            await _chat_idle.wait()
+    except TimeoutError:
+        _sentinel_defer_count += 1
+        now = time.monotonic()
+        if _sentinel_first_defer <= 0:
+            _sentinel_first_defer = now
+        last_activity = _sentinel_last_run or _sentinel_first_defer
+        starved_for_s = now - last_activity
+        degraded = starved_for_s > _SENTINEL_STARVATION_WARN_S
+        if health_stats is not None:
+            health_stats["sentinel_admission_degraded"] = degraded
+            health_stats["sentinel_admission_degraded_category"] = (
+                category if degraded else None
+            )
+            health_stats["sentinel_admission_consecutive_deferrals"] = (
+                _sentinel_defer_count
+            )
+            health_stats["sentinel_admission_starved_for_s"] = int(starved_for_s)
+        if degraded:
+            LOGGER.warning(
+                "Sentinel %s deferred %d consecutive time(s); "
+                "last successful run or first deferral %.0fs ago. "
+                "Consider reducing chat load or tuning sentinel intervals.",
+                category,
+                _sentinel_defer_count,
+                starved_for_s,
+            )
+        else:
+            LOGGER.debug(
+                "Sentinel %s deferred (chat active); consecutive deferrals=%d.",
+                category,
+                _sentinel_defer_count,
+            )
+        return False
+    _sentinel_last_run = time.monotonic()
+    _sentinel_first_defer = 0.0
+    _sentinel_defer_count = 0
+    if health_stats is not None:
+        health_stats["sentinel_admission_degraded"] = False
+        health_stats["sentinel_admission_degraded_category"] = None
+        health_stats["sentinel_admission_consecutive_deferrals"] = 0
+        health_stats["sentinel_admission_starved_for_s"] = 0
+    return True
+
+
+async def run_sentinel_llm_call(  # noqa: PLR0913
+    call_factory: Callable[[], Awaitable[Any]],
+    *,
+    deployment: str,
+    category: str,
+    admission_timeout_s: float,
+    call_timeout_s: float,
+    health_stats: MutableMapping[str, Any] | None = None,
+) -> Any:
+    """Run a Sentinel LLM call with chat-priority admission and interruption."""
+    if not await sentinel_admission(
+        deployment,
+        category=category,
+        timeout_s=admission_timeout_s,
+        health_stats=health_stats,
+    ):
+        raise SentinelLLMDeferredError(category, "deferred; chat is active")
+
+    task = asyncio.create_task(call_factory())
+    _sentinel_llm_tasks.add(task)
+    try:
+        return await asyncio.wait_for(task, timeout=call_timeout_s)
+    except asyncio.CancelledError as err:
+        raise SentinelLLMDeferredError(
+            category, "interrupted by foreground chat"
+        ) from err
+    finally:
+        _sentinel_llm_tasks.discard(task)
 
 
 async def generate_embeddings(
@@ -206,26 +354,16 @@ async def generate_embeddings(
     texts: Sequence[str],
 ) -> list[list[float]]:
     """
-    Generate embeddings, applying the chat-priority GPU gate for Ollama only.
+    Generate embeddings for the given texts.
 
-    OllamaEmbeddings uses the same local GPUs as the chat model, so it must
-    wait using the same TOCTOU-safe loop as Sentinel triage/discovery: wait on
-    _chat_idle, acquire _bg_llm_lock, re-check _chat_idle, then embed.
-
-    OpenAI and Google embeddings call cloud APIs and do not contend for local
-    GPUs, so they bypass the gate entirely.
+    Embedding models are expected to be small enough to run concurrently with
+    LLM work, so no chat-priority gate is applied regardless of provider.
+    For Gemini embeddings, output_dimensionality is forced to EMBEDDING_MODEL_DIMS
+    to match the pgvector index.
     """
-    texts_list = [t for t in texts if t]  # drop empties defensively
+    texts_list = [t for t in texts if t]
     if not texts_list:
         return []
-    if isinstance(emb, OllamaEmbeddings):
-        while True:
-            await _chat_idle.wait()
-            async with _bg_llm_lock:
-                if not _chat_idle.is_set():
-                    continue  # chat grabbed priority; retry
-                return await emb.aembed_documents(texts_list)
-    # Non-Ollama providers: no local GPU contention — call directly.
     if isinstance(emb, GoogleGenerativeAIEmbeddings):
         return await emb.aembed_documents(
             texts_list, output_dimensionality=EMBEDDING_MODEL_DIMS

--- a/custom_components/home_generative_agent/core/utils.py
+++ b/custom_components/home_generative_agent/core/utils.py
@@ -35,8 +35,8 @@ from ..const import (  # noqa: TID252
 if TYPE_CHECKING:
     from collections.abc import (
         AsyncIterator,
-        Awaitable,
         Callable,
+        Coroutine,
         Mapping,
         MutableMapping,
         Sequence,
@@ -320,7 +320,7 @@ async def sentinel_admission(
 
 
 async def run_sentinel_llm_call(  # noqa: PLR0913
-    call_factory: Callable[[], Awaitable[Any]],
+    call_factory: Callable[[], Coroutine[Any, Any, Any]],
     *,
     deployment: str,
     category: str,

--- a/custom_components/home_generative_agent/core/utils.py
+++ b/custom_components/home_generative_agent/core/utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import hashlib
 import hmac
 import logging
@@ -31,7 +32,7 @@ from ..const import (  # noqa: TID252
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import AsyncIterator, Mapping, Sequence
 
     from homeassistant.core import HomeAssistant
     from langchain_ollama import OllamaEmbeddings
@@ -134,18 +135,76 @@ def configured_ollama_urls(
     return deduped
 
 
+# ---------------------------------------------------------------------------
+# Chat-priority gate
+# ---------------------------------------------------------------------------
+# The chat model may need exclusive access to all available GPUs.
+# Background tasks (camera snapshot analysis, embedding generation,
+# Sentinel triage/discovery) monopolise individual GPUs and can prevent
+# the chat model from loading or slow it significantly.
+#
+# Two primitives work together:
+#   _chat_idle     — Event; cleared while a chat invocation is active.
+#                    Background workers wait on this before touching the GPU.
+#   _bg_llm_lock   — Lock; held while a background LLM call (Sentinel) runs.
+#                    chat_priority_context acquires it so chat waits for any
+#                    in-flight Sentinel call before submitting to Ollama.
+#
+# Background callers use a TOCTOU-safe loop: wait on _chat_idle, acquire
+# _bg_llm_lock, re-check _chat_idle, then invoke the model — retrying if
+# chat grabbed priority between the wait and the lock acquisition.
+#
+# The gate lives in utils.py (not video_analyzer.py) because
+# generate_embeddings is the single chokepoint for all embed traffic —
+# gating it here covers Sentinel, the vector store, and any other caller.
+# video_analyzer.py imports the same primitives for VLM gating.
+# ---------------------------------------------------------------------------
+
+_chat_idle = asyncio.Event()
+_chat_idle.set()  # "no chat active" by default
+_chat_active_count: int = 0
+
+# Serialises background LLM (Sentinel triage/discovery) calls and lets
+# chat_priority_context wait for any in-flight background call to finish.
+_bg_llm_lock = asyncio.Lock()
+
+# Serialises background camera snapshot analysis calls so that
+# chat_priority_context can wait for any in-flight camera model inference
+# before submitting the chat request to Ollama.  The background video analyser
+# holds this lock for the duration of each Ollama /api/chat request.  Running
+# the camera model concurrently with the chat model on a shared GPU causes
+# compute contention that can dramatically slow or time out the chat response.
+_bg_vlm_lock = asyncio.Lock()
+
+
+@contextlib.asynccontextmanager
+async def chat_priority_context() -> AsyncIterator[None]:
+    """Gate background VLM/embed/LLM jobs while a chat LLM invocation is active."""
+    global _chat_active_count  # noqa: PLW0603
+    _chat_active_count += 1
+    _chat_idle.clear()
+    # Acquire locks in fixed order (vlm → llm) to wait for any in-flight
+    # background Ollama call before submitting the chat request.  Background
+    # workers hold at most one lock at a time, so there is no circular
+    # dependency and deadlock is impossible.
+    async with _bg_vlm_lock, _bg_llm_lock:
+        try:
+            yield
+        finally:
+            _chat_active_count -= 1
+            if _chat_active_count == 0:
+                _chat_idle.set()
+
+
 async def generate_embeddings(
     emb: OpenAIEmbeddings | OllamaEmbeddings | GoogleGenerativeAIEmbeddings,
     texts: Sequence[str],
 ) -> list[list[float]]:
-    """
-    Generate embeddings from a list of text.
-
-    If Gemini: force output_dimensionality to match index size.
-    """
+    """Generate embeddings, waiting for the chat-priority gate first."""
     texts_list = [t for t in texts if t]  # drop empties defensively
     if not texts_list:
         return []
+    await _chat_idle.wait()
     if isinstance(emb, GoogleGenerativeAIEmbeddings):
         return await emb.aembed_documents(
             texts_list, output_dimensionality=EMBEDDING_MODEL_DIMS

--- a/custom_components/home_generative_agent/core/utils.py
+++ b/custom_components/home_generative_agent/core/utils.py
@@ -200,16 +200,27 @@ async def generate_embeddings(
     emb: OpenAIEmbeddings | OllamaEmbeddings | GoogleGenerativeAIEmbeddings,
     texts: Sequence[str],
 ) -> list[list[float]]:
-    """Generate embeddings, waiting for the chat-priority gate first."""
+    """
+    Generate embeddings, waiting for the chat-priority gate first.
+
+    Uses the same TOCTOU-safe loop as Sentinel triage/discovery: wait on
+    _chat_idle, acquire _bg_llm_lock, re-check _chat_idle, then embed.
+    This prevents Ollama-backed embedding calls from competing with the chat
+    model on shared GPUs.
+    """
     texts_list = [t for t in texts if t]  # drop empties defensively
     if not texts_list:
         return []
-    await _chat_idle.wait()
-    if isinstance(emb, GoogleGenerativeAIEmbeddings):
-        return await emb.aembed_documents(
-            texts_list, output_dimensionality=EMBEDDING_MODEL_DIMS
-        )
-    return await emb.aembed_documents(texts_list)
+    while True:
+        await _chat_idle.wait()
+        async with _bg_llm_lock:
+            if not _chat_idle.is_set():
+                continue  # chat grabbed priority; retry
+            if isinstance(emb, GoogleGenerativeAIEmbeddings):
+                return await emb.aembed_documents(
+                    texts_list, output_dimensionality=EMBEDDING_MODEL_DIMS
+                )
+            return await emb.aembed_documents(texts_list)
 
 
 def discover_mobile_notify_service(hass: HomeAssistant) -> str | None:

--- a/custom_components/home_generative_agent/core/video_analyzer.py
+++ b/custom_components/home_generative_agent/core/video_analyzer.py
@@ -45,6 +45,8 @@ from ..const import (  # noqa: TID252
     VIDEO_ANALYZER_TRIGGER_ON_MOTION,
 )
 from .utils import (
+    _bg_vlm_lock,
+    _chat_idle,
     discover_mobile_notify_service,
     dispatch_on_loop,
     extract_final,
@@ -84,8 +86,6 @@ _FRAME_DEADLINE_SEC: Final[int] = 600  # skip frames older than this
 _SUMMARY_TIMEOUT_SEC: Final[int] = 60  # was 35
 _FACE_TIMEOUT_SEC: Final[int] = 10  # was 10 (keep)
 _VISION_TIMEOUT_SEC: Final[int] = 90  # was 30
-_GLOBAL_VISION_CONCURRENCY: Final[int] = 3  # tune per hardware
-
 # --- Uniqueness gate tuning ---
 _UNIQUENESS_ENABLED: Final[bool] = False
 _UNIQUENESS_HAMMING_MAX: Final[int] = 4  # <= this => "too similar" (tune 4-10)
@@ -95,8 +95,6 @@ _UNIQUENESS_HEARTBEAT_SEC: Final[int] = 10  # always allow a frame at least this
 # --- Metrics reporting ---
 _METRICS_REPORT_INTERVAL_SEC: Final[int] = 3600  # once per hour
 _METRICS_LAT_HISTORY: Final[int] = 512  # keep up to 512 lat samples per camera
-
-_global_vision_sem = asyncio.Semaphore(_GLOBAL_VISION_CONCURRENCY)
 
 
 @dataclass
@@ -650,18 +648,31 @@ class VideoAnalyzer:
                 )
                 faces_in_frame = []
 
-            # Vision: global concurrency + short timeout
+            # Vision: global concurrency + chat-priority gate.
+            # Re-check _chat_idle inside the semaphore to close the TOCTOU race:
+            # a VLM job may pass the outer wait() before chat clears the event,
+            # then block on _bg_vlm_lock.  When the lock is released we
+            # re-verify; if chat is now active we release and loop back to wait.
+            # chat_priority_context also acquires _bg_vlm_lock so it will wait
+            # for any in-flight camera inference to finish before submitting the
+            # chat request, preventing GPU compute contention on shared devices.
             try:
-                async with (
-                    _global_vision_sem,
-                    asyncio.timeout(_VISION_TIMEOUT_SEC),
-                ):
-                    frame_description = await analyze_image(
-                        self.entry.runtime_data.vision_model,
-                        data,
-                        None,
-                        prev_text=prev_text,
-                    )
+                vlm_done = False
+                frame_description = ""
+                while not vlm_done:
+                    await _chat_idle.wait()
+                    async with _bg_vlm_lock:
+                        if not _chat_idle.is_set():
+                            # Chat became active while we waited for the lock.
+                            continue
+                        async with asyncio.timeout(_VISION_TIMEOUT_SEC):
+                            frame_description = await analyze_image(
+                                self.entry.runtime_data.vision_model,
+                                data,
+                                None,
+                                prev_text=prev_text,
+                            )
+                        vlm_done = True
             except TimeoutError as exc:
                 self._m_inc(camera_id, "timeouts")
                 self._log_snapshot_error(camera_id, path, exc)

--- a/custom_components/home_generative_agent/core/video_analyzer.py
+++ b/custom_components/home_generative_agent/core/video_analyzer.py
@@ -45,8 +45,6 @@ from ..const import (  # noqa: TID252
     VIDEO_ANALYZER_TRIGGER_ON_MOTION,
 )
 from .utils import (
-    _bg_vlm_lock,
-    _chat_idle,
     discover_mobile_notify_service,
     dispatch_on_loop,
     extract_final,
@@ -434,7 +432,8 @@ class VideoAnalyzer:
             HumanMessage(content=prompt),
         ]
         model = self.entry.runtime_data.summarization_model
-        summary = await model.ainvoke(messages)
+        async with asyncio.timeout(_SUMMARY_TIMEOUT_SEC):
+            summary = await model.ainvoke(messages)
         LOGGER.debug("Raw video analyzer summary: %s", summary)
 
         text = extract_final(getattr(summary, "content", "") or "", max_chars=150)
@@ -445,10 +444,17 @@ class VideoAnalyzer:
         raise ValueError(msg)
 
     async def _is_anomaly(self, camera_name: str, msg: str, first_path: str) -> bool:
-        async with asyncio.timeout(10):
-            search_results = await self.entry.runtime_data.store.asearch(
-                ("video_analysis", camera_name), query=msg, limit=10
+        try:
+            async with asyncio.timeout(10):
+                search_results = await self.entry.runtime_data.store.asearch(
+                    ("video_analysis", camera_name), query=msg, limit=10
+                )
+        except TimeoutError:
+            LOGGER.warning(
+                "[%s] store.asearch timed out in _is_anomaly; treating as novel.",
+                camera_name,
             )
+            return True
 
         # Calculate a "no newer than" time threshold from first snapshot time
         # by delaying it by the time offset.
@@ -648,31 +654,15 @@ class VideoAnalyzer:
                 )
                 faces_in_frame = []
 
-            # Vision: global concurrency + chat-priority gate.
-            # Re-check _chat_idle inside the semaphore to close the TOCTOU race:
-            # a VLM job may pass the outer wait() before chat clears the event,
-            # then block on _bg_vlm_lock.  When the lock is released we
-            # re-verify; if chat is now active we release and loop back to wait.
-            # chat_priority_context also acquires _bg_vlm_lock so it will wait
-            # for any in-flight camera inference to finish before submitting the
-            # chat request, preventing GPU compute contention on shared devices.
             try:
-                vlm_done = False
-                frame_description = ""
-                while not vlm_done:
-                    await _chat_idle.wait()
-                    async with _bg_vlm_lock:
-                        if not _chat_idle.is_set():
-                            # Chat became active while we waited for the lock.
-                            continue
-                        async with asyncio.timeout(_VISION_TIMEOUT_SEC):
-                            frame_description = await analyze_image(
-                                self.entry.runtime_data.vision_model,
-                                data,
-                                None,
-                                prev_text=prev_text,
-                            )
-                        vlm_done = True
+                vision_model = self.entry.runtime_data.vision_model
+                async with asyncio.timeout(_VISION_TIMEOUT_SEC):
+                    frame_description = await analyze_image(
+                        vision_model,
+                        data,
+                        None,
+                        prev_text=prev_text,
+                    )
             except TimeoutError as exc:
                 self._m_inc(camera_id, "timeouts")
                 self._log_snapshot_error(camera_id, path, exc)

--- a/custom_components/home_generative_agent/explain/llm_explain.py
+++ b/custom_components/home_generative_agent/explain/llm_explain.py
@@ -5,11 +5,16 @@ from __future__ import annotations
 import logging
 import re
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Final
 
 from langchain_core.messages import HumanMessage, SystemMessage
 
-from custom_components.home_generative_agent.core.utils import extract_final
+from custom_components.home_generative_agent.core.utils import (
+    SENTINEL_ADMISSION_TIMEOUT_S,
+    SentinelLLMDeferredError,
+    extract_final,
+    run_sentinel_llm_call,
+)
 
 from .prompts import SYSTEM_PROMPT, USER_PROMPT_TEMPLATE
 
@@ -18,16 +23,25 @@ if TYPE_CHECKING:
 
 LOGGER = logging.getLogger(__name__)
 MAX_EXPLANATION_CHARS = 220
+_EXPLAIN_LLM_TIMEOUT_S: Final[float] = 20.0
 
 
 class LLMExplainer:
     """Generate non-authoritative explanation text for findings."""
 
-    def __init__(self, model: Any) -> None:
+    def __init__(
+        self,
+        model: Any,
+        *,
+        deployment: str = "edge",
+        health_stats: dict[str, Any] | None = None,
+    ) -> None:
         """Initialize the explainer with an optional LLM model."""
         self._model = model
+        self._deployment = deployment
+        self._health_stats = health_stats
 
-    async def async_explain(self, finding: AnomalyFinding) -> str | None:
+    async def async_explain(self, finding: AnomalyFinding) -> str | None:  # noqa: PLR0911
         """Return explanation text or None on failure."""
         if self._model is None:
             return None
@@ -41,8 +55,18 @@ class LLMExplainer:
         messages = [SystemMessage(content=SYSTEM_PROMPT), HumanMessage(content=prompt)]
 
         try:
-            result = await self._model.ainvoke(messages)
-        except (ValueError, TypeError, RuntimeError) as err:
+            result = await run_sentinel_llm_call(
+                lambda: self._model.ainvoke(messages),
+                deployment=self._deployment,
+                category="explain",
+                admission_timeout_s=SENTINEL_ADMISSION_TIMEOUT_S,
+                call_timeout_s=_EXPLAIN_LLM_TIMEOUT_S,
+                health_stats=self._health_stats,
+            )
+        except SentinelLLMDeferredError as err:
+            LOGGER.debug("LLM explanation deferred: %s", err)
+            return None
+        except (TimeoutError, ValueError, TypeError, RuntimeError) as err:
             LOGGER.warning("LLM explanation failed: %s", err)
             return None
 

--- a/custom_components/home_generative_agent/manifest.json
+++ b/custom_components/home_generative_agent/manifest.json
@@ -33,5 +33,5 @@
     "transformers==4.57.1",
     "langchain-google-genai==3.1.0"
   ],
-  "version": "3.12.3"
+  "version": "3.12.4"
 }

--- a/custom_components/home_generative_agent/manifest.json
+++ b/custom_components/home_generative_agent/manifest.json
@@ -33,5 +33,5 @@
     "transformers==4.57.1",
     "langchain-google-genai==3.1.0"
   ],
-  "version": "3.12.2"
+  "version": "3.12.3"
 }

--- a/custom_components/home_generative_agent/sentinel/discovery_engine.py
+++ b/custom_components/home_generative_agent/sentinel/discovery_engine.py
@@ -17,8 +17,9 @@ from custom_components.home_generative_agent.const import (
     CONF_SENTINEL_DISCOVERY_INTERVAL_SECONDS,
 )
 from custom_components.home_generative_agent.core.utils import (
-    _bg_llm_lock,
-    _chat_idle,
+    SENTINEL_ADMISSION_TIMEOUT_S,
+    SentinelLLMDeferredError,
+    run_sentinel_llm_call,
 )
 from custom_components.home_generative_agent.explain.discovery_prompts import (
     SYSTEM_PROMPT,
@@ -79,6 +80,8 @@ class SentinelDiscoveryEngine:
         rule_registry: RuleRegistry | None = None,
         proposal_store: ProposalStore | None = None,
         baseline_updater: SentinelBaselineUpdater | None = None,
+        deployment: str = "edge",
+        health_stats: dict[str, Any] | None = None,
     ) -> None:
         """Initialize advisory discovery dependencies and runtime state."""
         self._hass = hass
@@ -88,6 +91,8 @@ class SentinelDiscoveryEngine:
         self._rule_registry = rule_registry
         self._proposal_store = proposal_store
         self._baseline_updater = baseline_updater
+        self._deployment = deployment
+        self._health_stats = health_stats
         self._task: asyncio.Task[None] | None = None
         self._stop_event = asyncio.Event()
         self._run_lock = asyncio.Lock()
@@ -191,20 +196,18 @@ class SentinelDiscoveryEngine:
         )
         messages = [SystemMessage(content=SYSTEM_PROMPT), HumanMessage(content=prompt)]
 
-        # Discovery LLM calls can run for 60-180 s with a large snapshot.
-        # Use a hard cap so the GPU is not monopolised indefinitely, and a
-        # TOCTOU-safe loop so we don't race with chat_priority_context.
         try:
-            while True:
-                await _chat_idle.wait()
-                async with _bg_llm_lock:
-                    if not _chat_idle.is_set():
-                        continue  # chat grabbed priority; retry
-                    result = await asyncio.wait_for(
-                        self._model.ainvoke(messages),
-                        timeout=_DISCOVERY_LLM_TIMEOUT_S,
-                    )
-                    break
+            result = await run_sentinel_llm_call(
+                lambda: self._model.ainvoke(messages),
+                deployment=self._deployment,
+                category="discovery",
+                admission_timeout_s=SENTINEL_ADMISSION_TIMEOUT_S,
+                call_timeout_s=_DISCOVERY_LLM_TIMEOUT_S,
+                health_stats=self._health_stats,
+            )
+        except SentinelLLMDeferredError as err:
+            LOGGER.debug("Discovery LLM call deferred: %s", err)
+            return
         except TimeoutError:
             LOGGER.warning(
                 "Discovery LLM call timed out after %.0fs; skipping cycle.",

--- a/custom_components/home_generative_agent/sentinel/discovery_engine.py
+++ b/custom_components/home_generative_agent/sentinel/discovery_engine.py
@@ -16,6 +16,10 @@ from langchain_core.messages import HumanMessage, SystemMessage
 from custom_components.home_generative_agent.const import (
     CONF_SENTINEL_DISCOVERY_INTERVAL_SECONDS,
 )
+from custom_components.home_generative_agent.core.utils import (
+    _bg_llm_lock,
+    _chat_idle,
+)
 from custom_components.home_generative_agent.explain.discovery_prompts import (
     SYSTEM_PROMPT,
     USER_PROMPT_TEMPLATE,
@@ -39,6 +43,10 @@ if TYPE_CHECKING:
     from .rule_registry import RuleRegistry
 
 LOGGER = logging.getLogger(__name__)
+
+# Hard cap on discovery LLM calls: prevents the chat model from being
+# monopolised when the snapshot is large (observed 180s+ without a cap).
+_DISCOVERY_LLM_TIMEOUT_S: float = 45.0
 
 # Rule IDs for static built-in rules (deterministic, always active).
 # Included in active_rule_ids so the LLM knows these topics are already covered
@@ -183,8 +191,26 @@ class SentinelDiscoveryEngine:
         )
         messages = [SystemMessage(content=SYSTEM_PROMPT), HumanMessage(content=prompt)]
 
+        # Discovery LLM calls can run for 60-180 s with a large snapshot.
+        # Use a hard cap so the GPU is not monopolised indefinitely, and a
+        # TOCTOU-safe loop so we don't race with chat_priority_context.
         try:
-            result = await self._model.ainvoke(messages)
+            while True:
+                await _chat_idle.wait()
+                async with _bg_llm_lock:
+                    if not _chat_idle.is_set():
+                        continue  # chat grabbed priority; retry
+                    result = await asyncio.wait_for(
+                        self._model.ainvoke(messages),
+                        timeout=_DISCOVERY_LLM_TIMEOUT_S,
+                    )
+                    break
+        except TimeoutError:
+            LOGGER.warning(
+                "Discovery LLM call timed out after %.0fs; skipping cycle.",
+                _DISCOVERY_LLM_TIMEOUT_S,
+            )
+            return
         except (ValueError, TypeError, RuntimeError) as err:
             LOGGER.warning("Discovery LLM call failed: %s", err)
             return

--- a/custom_components/home_generative_agent/sentinel/engine.py
+++ b/custom_components/home_generative_agent/sentinel/engine.py
@@ -180,6 +180,7 @@ class SentinelEngine:
         entry_id: str | None = None,
         triage_service: SentinelTriageService | None = None,
         baseline_updater: SentinelBaselineUpdater | None = None,
+        run_stats: dict[str, Any] | None = None,
     ) -> None:
         """Initialize sentinel dependencies and runtime state."""
         self._hass = hass
@@ -226,7 +227,7 @@ class SentinelEngine:
         # restart waits the full sustained_minutes before notifying (acceptable).
         self._cyclical_deviation_above_since: dict[str, datetime] = {}
         # Run telemetry exposed to SentinelHealthSensor.
-        self.run_stats: dict[str, Any] = {}
+        self.run_stats: dict[str, Any] = run_stats if run_stats is not None else {}
 
     @property
     def learned_suppressions_count(self) -> int:

--- a/custom_components/home_generative_agent/sentinel/triage.py
+++ b/custom_components/home_generative_agent/sentinel/triage.py
@@ -33,6 +33,11 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from custom_components.home_generative_agent.core.utils import (
+    _bg_llm_lock,
+    _chat_idle,
+)
+
 if TYPE_CHECKING:
     from custom_components.home_generative_agent.sentinel.models import AnomalyFinding
     from custom_components.home_generative_agent.snapshot.schema import (
@@ -154,10 +159,17 @@ class SentinelTriageService:
                 SystemMessage(content=_SYSTEM_PROMPT),
                 HumanMessage(content=prompt),
             ]
-            result = await asyncio.wait_for(
-                self._model.ainvoke(messages),
-                timeout=self._timeout_seconds,
-            )
+            # TOCTOU-safe: loop until we hold _bg_llm_lock AND chat is idle.
+            while True:
+                await _chat_idle.wait()
+                async with _bg_llm_lock:
+                    if not _chat_idle.is_set():
+                        continue  # chat grabbed priority; retry
+                    result = await asyncio.wait_for(
+                        self._model.ainvoke(messages),
+                        timeout=self._timeout_seconds,
+                    )
+                    break
         except TimeoutError:
             elapsed_ms = int((time.monotonic() - start) * 1000)
             LOGGER.warning(

--- a/custom_components/home_generative_agent/sentinel/triage.py
+++ b/custom_components/home_generative_agent/sentinel/triage.py
@@ -25,7 +25,6 @@ Design constraints (from sentinel_plan.md §6, §7)
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 import re
@@ -33,9 +32,12 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from langchain_core.messages import HumanMessage, SystemMessage
+
 from custom_components.home_generative_agent.core.utils import (
-    _bg_llm_lock,
-    _chat_idle,
+    SENTINEL_ADMISSION_TIMEOUT_S,
+    SentinelLLMDeferredError,
+    run_sentinel_llm_call,
 )
 
 if TYPE_CHECKING:
@@ -59,6 +61,7 @@ TRIAGE_REASON_LLM_SUPPRESS = "llm_suppress"
 TRIAGE_REASON_TIMEOUT = "triage_timeout"
 TRIAGE_REASON_ERROR = "triage_error"
 TRIAGE_REASON_DISABLED = "triage_disabled"
+TRIAGE_REASON_DEFERRED = "triage_deferred"
 
 # Input allowlist for optional sanitised evidence fields.
 _ALLOWED_EVIDENCE_KEYS: frozenset[str] = frozenset(
@@ -122,10 +125,19 @@ class SentinelTriageService:
     Pass ``None`` to disable triage (all findings pass through as notify).
     """
 
-    def __init__(self, model: Any, *, timeout_seconds: int = 10) -> None:
+    def __init__(
+        self,
+        model: Any,
+        *,
+        timeout_seconds: int = 10,
+        deployment: str = "edge",
+        health_stats: dict[str, Any] | None = None,
+    ) -> None:
         """Initialise with a LangChain-compatible model."""
         self._model = model
         self._timeout_seconds = timeout_seconds
+        self._deployment = deployment
+        self._health_stats = health_stats
 
     async def triage(
         self,
@@ -149,27 +161,27 @@ class SentinelTriageService:
         prompt = _build_prompt(finding, snapshot)
         start = time.monotonic()
 
+        messages = [
+            SystemMessage(content=_SYSTEM_PROMPT),
+            HumanMessage(content=prompt),
+        ]
         try:
-            from langchain_core.messages import (  # noqa: PLC0415
-                HumanMessage,
-                SystemMessage,
+            result = await run_sentinel_llm_call(
+                lambda: self._model.ainvoke(messages),
+                deployment=self._deployment,
+                category="triage",
+                admission_timeout_s=SENTINEL_ADMISSION_TIMEOUT_S,
+                call_timeout_s=float(self._timeout_seconds),
+                health_stats=self._health_stats,
             )
-
-            messages = [
-                SystemMessage(content=_SYSTEM_PROMPT),
-                HumanMessage(content=prompt),
-            ]
-            # TOCTOU-safe: loop until we hold _bg_llm_lock AND chat is idle.
-            while True:
-                await _chat_idle.wait()
-                async with _bg_llm_lock:
-                    if not _chat_idle.is_set():
-                        continue  # chat grabbed priority; retry
-                    result = await asyncio.wait_for(
-                        self._model.ainvoke(messages),
-                        timeout=self._timeout_seconds,
-                    )
-                    break
+        except SentinelLLMDeferredError as err:
+            LOGGER.debug("Triage deferred: %s", err)
+            return TriageDecision(
+                decision=TRIAGE_NOTIFY,
+                reason_code=TRIAGE_REASON_DEFERRED,
+                triage_confidence=None,
+                summary="Triage deferred; chat was active.",
+            )
         except TimeoutError:
             elapsed_ms = int((time.monotonic() - start) * 1000)
             LOGGER.warning(

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function

--- a/tests/custom_components/home_generative_agent/test_chat_priority_gate.py
+++ b/tests/custom_components/home_generative_agent/test_chat_priority_gate.py
@@ -1,5 +1,6 @@
 # ruff: noqa: S101
-"""Tests for the chat-priority GPU gate primitives in core/utils.py.
+"""
+Tests for the chat-priority GPU gate primitives in core/utils.py.
 
 Covers:
 - _chat_idle initial state (set = idle by default)
@@ -7,7 +8,8 @@ Covers:
 - Concurrent chat contexts: _chat_idle only re-sets when the last chat exits
 - Background workers cannot acquire _bg_vlm_lock or _bg_llm_lock while
   chat_priority_context holds them
-- generate_embeddings waits on _chat_idle before proceeding
+- generate_embeddings waits on _chat_idle AND holds _bg_llm_lock during the
+  embed call, so chat_priority_context blocks it just like Sentinel LLM calls
 """
 
 from __future__ import annotations
@@ -18,33 +20,51 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 import custom_components.home_generative_agent.core.utils as utils_mod
-from custom_components.home_generative_agent.core.utils import (
-    _bg_llm_lock,
-    _bg_vlm_lock,
-    _chat_idle,
-    chat_priority_context,
-    generate_embeddings,
-)
-
 
 # ---------------------------------------------------------------------------
-# Fixture: reset module-level gate state between tests so tests are isolated.
+# Fixture: create fresh asyncio primitives per test.
+#
+# Module-level asyncio.Event / asyncio.Lock objects bind to the first event
+# loop that touches them.  pytest-asyncio gives each async test its own loop,
+# so re-using the module globals across tests causes
+# "bound to a different event loop" errors.  We replace the module attributes
+# with brand-new primitives created inside the test's own loop, then restore
+# them afterwards via monkeypatch.
 # ---------------------------------------------------------------------------
 
 
 @pytest.fixture(autouse=True)
-def _reset_gate_state() -> None:  # type: ignore[return]
-    """Restore gate primitives to initial state before and after each test."""
-    _chat_idle.set()
-    utils_mod._chat_active_count = 0
-    # Release locks if somehow held (shouldn't happen, but defensive)
-    if _bg_vlm_lock.locked():
-        _bg_vlm_lock.release()
-    if _bg_llm_lock.locked():
-        _bg_llm_lock.release()
-    yield
-    _chat_idle.set()
-    utils_mod._chat_active_count = 0
+async def _fresh_gate_primitives(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replace module-level gate primitives with fresh instances for each test."""
+    new_idle = asyncio.Event()
+    new_idle.set()  # "no chat active" by default
+    new_llm_lock = asyncio.Lock()
+    new_vlm_lock = asyncio.Lock()
+
+    monkeypatch.setattr(utils_mod, "_chat_idle", new_idle)
+    monkeypatch.setattr(utils_mod, "_bg_llm_lock", new_llm_lock)
+    monkeypatch.setattr(utils_mod, "_bg_vlm_lock", new_vlm_lock)
+    monkeypatch.setattr(utils_mod, "_chat_active_count", 0)
+
+
+# ---------------------------------------------------------------------------
+# Helpers: read current primitives through the module to pick up monkeypatched
+# values (direct imports would cache the original objects).
+# ---------------------------------------------------------------------------
+
+
+def _idle() -> asyncio.Event:
+    return utils_mod._chat_idle  # type: ignore[attr-defined]
+
+
+def _llm_lock() -> asyncio.Lock:
+    return utils_mod._bg_llm_lock  # type: ignore[attr-defined]
+
+
+def _vlm_lock() -> asyncio.Lock:
+    return utils_mod._bg_vlm_lock  # type: ignore[attr-defined]
 
 
 # ---------------------------------------------------------------------------
@@ -52,9 +72,10 @@ def _reset_gate_state() -> None:  # type: ignore[return]
 # ---------------------------------------------------------------------------
 
 
-def test_chat_idle_is_set_initially() -> None:
-    """_chat_idle must be set (idle) at module load time."""
-    assert _chat_idle.is_set()
+@pytest.mark.asyncio
+async def test_chat_idle_is_set_initially() -> None:
+    """_chat_idle must be set (idle) after fixture reset."""
+    assert _idle().is_set()
 
 
 # ---------------------------------------------------------------------------
@@ -65,26 +86,27 @@ def test_chat_idle_is_set_initially() -> None:
 @pytest.mark.asyncio
 async def test_chat_priority_context_clears_idle_on_entry() -> None:
     """_chat_idle must be cleared while inside chat_priority_context."""
-    assert _chat_idle.is_set()
-    async with chat_priority_context():
-        assert not _chat_idle.is_set()
+    assert _idle().is_set()
+    async with utils_mod.chat_priority_context():
+        assert not _idle().is_set()
 
 
 @pytest.mark.asyncio
 async def test_chat_priority_context_restores_idle_on_exit() -> None:
     """_chat_idle must be set again after chat_priority_context exits."""
-    async with chat_priority_context():
+    async with utils_mod.chat_priority_context():
         pass
-    assert _chat_idle.is_set()
+    assert _idle().is_set()
 
 
 @pytest.mark.asyncio
 async def test_chat_priority_context_restores_idle_on_exception() -> None:
     """_chat_idle must be restored even when the body raises."""
+    err_msg = "boom"
     with pytest.raises(RuntimeError):
-        async with chat_priority_context():
-            raise RuntimeError("boom")
-    assert _chat_idle.is_set()
+        async with utils_mod.chat_priority_context():
+            raise RuntimeError(err_msg)
+    assert _idle().is_set()
 
 
 # ---------------------------------------------------------------------------
@@ -98,17 +120,14 @@ async def test_concurrent_chat_contexts_keep_idle_cleared() -> None:
     results: list[bool] = []
 
     async def _enter_and_sample() -> None:
-        async with chat_priority_context():
-            results.append(_chat_idle.is_set())
-            # Yield so the other task can also enter before we exit.
+        async with utils_mod.chat_priority_context():
+            results.append(_idle().is_set())
             await asyncio.sleep(0)
-            results.append(_chat_idle.is_set())
+            results.append(_idle().is_set())
 
     await asyncio.gather(_enter_and_sample(), _enter_and_sample())
-    # Both tasks saw the event cleared while they were inside.
     assert all(r is False for r in results)
-    # After both tasks exit, idle should be set again.
-    assert _chat_idle.is_set()
+    assert _idle().is_set()
 
 
 # ---------------------------------------------------------------------------
@@ -117,61 +136,56 @@ async def test_concurrent_chat_contexts_keep_idle_cleared() -> None:
 
 
 @pytest.mark.asyncio
-async def test_bg_vlm_lock_not_acquirable_inside_chat_context() -> None:
-    """Background VLM worker cannot acquire _bg_vlm_lock while chat holds it."""
-    async with chat_priority_context():
-        # Attempt a non-blocking acquire — must fail because chat holds the lock.
-        acquired = _bg_vlm_lock.locked()
-        assert acquired, "_bg_vlm_lock should be locked inside chat_priority_context"
+async def test_bg_vlm_lock_held_inside_chat_context() -> None:
+    """_bg_vlm_lock must be locked while inside chat_priority_context."""
+    async with utils_mod.chat_priority_context():
+        assert _vlm_lock().locked()
 
 
 @pytest.mark.asyncio
-async def test_bg_llm_lock_not_acquirable_inside_chat_context() -> None:
-    """Background LLM worker cannot acquire _bg_llm_lock while chat holds it."""
-    async with chat_priority_context():
-        acquired = _bg_llm_lock.locked()
-        assert acquired, "_bg_llm_lock should be locked inside chat_priority_context"
+async def test_bg_llm_lock_held_inside_chat_context() -> None:
+    """_bg_llm_lock must be locked while inside chat_priority_context."""
+    async with utils_mod.chat_priority_context():
+        assert _llm_lock().locked()
 
 
 @pytest.mark.asyncio
 async def test_bg_locks_released_after_chat_context() -> None:
     """Both background locks must be released after chat_priority_context exits."""
-    async with chat_priority_context():
+    async with utils_mod.chat_priority_context():
         pass
-    assert not _bg_vlm_lock.locked()
-    assert not _bg_llm_lock.locked()
+    assert not _vlm_lock().locked()
+    assert not _llm_lock().locked()
 
 
 # ---------------------------------------------------------------------------
-# generate_embeddings: honours _chat_idle gate
+# generate_embeddings: TOCTOU-safe gate (waits + holds _bg_llm_lock)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_generate_embeddings_waits_while_chat_active() -> None:
     """generate_embeddings must not proceed until _chat_idle is set."""
-    _chat_idle.clear()  # simulate active chat
+    _idle().clear()  # simulate active chat
 
     embed_started = asyncio.Event()
     embed_result: list[object] = []
 
     mock_emb = MagicMock()
     mock_emb.aembed_documents = AsyncMock(return_value=[[0.1, 0.2]])
-    # Not a GoogleGenerativeAIEmbeddings instance.
     mock_emb.__class__ = MagicMock  # type: ignore[assignment]
 
     async def _run_embed() -> None:
         embed_started.set()
-        result = await generate_embeddings(mock_emb, ["hello"])
+        result = await utils_mod.generate_embeddings(mock_emb, ["hello"])
         embed_result.append(result)
 
     task = asyncio.create_task(_run_embed())
     await embed_started.wait()
-    # Give the task a chance to (wrongly) proceed before we release the gate.
     await asyncio.sleep(0.01)
     assert not embed_result, "generate_embeddings should block while chat is active"
 
-    _chat_idle.set()  # release the gate
+    _idle().set()
     await asyncio.wait_for(task, timeout=2.0)
     assert embed_result, "generate_embeddings should complete after chat gate released"
 
@@ -183,8 +197,52 @@ async def test_generate_embeddings_proceeds_when_idle() -> None:
     mock_emb.aembed_documents = AsyncMock(return_value=[[0.1, 0.2]])
     mock_emb.__class__ = MagicMock  # type: ignore[assignment]
 
-    result = await generate_embeddings(mock_emb, ["hello"])
+    result = await utils_mod.generate_embeddings(mock_emb, ["hello"])
     assert result == [[0.1, 0.2]]
+
+
+@pytest.mark.asyncio
+async def test_generate_embeddings_holds_bg_llm_lock_during_call() -> None:
+    """generate_embeddings must hold _bg_llm_lock while calling aembed_documents."""
+    lock_held_during_call = False
+
+    async def _check_lock(_texts: list[str], **_: object) -> list[list[float]]:
+        nonlocal lock_held_during_call
+        lock_held_during_call = _llm_lock().locked()
+        return [[0.1]]
+
+    mock_emb = MagicMock()
+    mock_emb.aembed_documents = _check_lock
+    mock_emb.__class__ = MagicMock  # type: ignore[assignment]
+
+    await utils_mod.generate_embeddings(mock_emb, ["hello"])
+    assert lock_held_during_call, "_bg_llm_lock must be held during aembed_documents"
+
+
+@pytest.mark.asyncio
+async def test_chat_blocks_embeddings_via_bg_llm_lock() -> None:
+    """chat_priority_context must block generate_embeddings via _bg_llm_lock."""
+    embed_acquired_lock: list[bool] = []
+
+    async def _check_lock(_texts: list[str], **_: object) -> list[list[float]]:
+        embed_acquired_lock.append(True)
+        return [[0.1]]
+
+    mock_emb = MagicMock()
+    mock_emb.aembed_documents = _check_lock
+    mock_emb.__class__ = MagicMock  # type: ignore[assignment]
+
+    async with utils_mod.chat_priority_context():
+        embed_task = asyncio.create_task(
+            utils_mod.generate_embeddings(mock_emb, ["hello"])
+        )
+        await asyncio.sleep(0.01)
+        assert not embed_acquired_lock, (
+            "generate_embeddings should not start while chat holds _bg_llm_lock"
+        )
+
+    await asyncio.wait_for(embed_task, timeout=2.0)
+    assert embed_acquired_lock
 
 
 @pytest.mark.asyncio
@@ -193,6 +251,6 @@ async def test_generate_embeddings_empty_texts_returns_empty() -> None:
     mock_emb = MagicMock()
     mock_emb.aembed_documents = AsyncMock(return_value=[])
 
-    result = await generate_embeddings(mock_emb, [])
+    result = await utils_mod.generate_embeddings(mock_emb, [])
     mock_emb.aembed_documents.assert_not_called()
     assert result == []

--- a/tests/custom_components/home_generative_agent/test_chat_priority_gate.py
+++ b/tests/custom_components/home_generative_agent/test_chat_priority_gate.py
@@ -8,8 +8,10 @@ Covers:
 - Concurrent chat contexts: _chat_idle only re-sets when the last chat exits
 - Background workers cannot acquire _bg_vlm_lock or _bg_llm_lock while
   chat_priority_context holds them
-- generate_embeddings waits on _chat_idle AND holds _bg_llm_lock during the
-  embed call, so chat_priority_context blocks it just like Sentinel LLM calls
+- generate_embeddings (Ollama) waits on _chat_idle AND holds _bg_llm_lock
+  during the embed call, so chat_priority_context blocks it
+- generate_embeddings (non-Ollama) bypasses the gate entirely
+- chat_priority_context cleans up _chat_idle on cancellation before lock
 """
 
 from __future__ import annotations
@@ -18,6 +20,7 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from langchain_ollama import OllamaEmbeddings
 
 import custom_components.home_generative_agent.core.utils as utils_mod
 
@@ -165,7 +168,7 @@ async def test_bg_locks_released_after_chat_context() -> None:
 
 @pytest.mark.asyncio
 async def test_generate_embeddings_waits_while_chat_active() -> None:
-    """generate_embeddings must not proceed until _chat_idle is set."""
+    """Ollama generate_embeddings must not proceed until _chat_idle is set."""
     _idle().clear()  # simulate active chat
 
     embed_started = asyncio.Event()
@@ -173,7 +176,7 @@ async def test_generate_embeddings_waits_while_chat_active() -> None:
 
     mock_emb = MagicMock()
     mock_emb.aembed_documents = AsyncMock(return_value=[[0.1, 0.2]])
-    mock_emb.__class__ = MagicMock  # type: ignore[assignment]
+    mock_emb.__class__ = OllamaEmbeddings  # type: ignore[assignment]
 
     async def _run_embed() -> None:
         embed_started.set()
@@ -192,10 +195,10 @@ async def test_generate_embeddings_waits_while_chat_active() -> None:
 
 @pytest.mark.asyncio
 async def test_generate_embeddings_proceeds_when_idle() -> None:
-    """generate_embeddings completes immediately when no chat is active."""
+    """Ollama generate_embeddings completes immediately when no chat is active."""
     mock_emb = MagicMock()
     mock_emb.aembed_documents = AsyncMock(return_value=[[0.1, 0.2]])
-    mock_emb.__class__ = MagicMock  # type: ignore[assignment]
+    mock_emb.__class__ = OllamaEmbeddings  # type: ignore[assignment]
 
     result = await utils_mod.generate_embeddings(mock_emb, ["hello"])
     assert result == [[0.1, 0.2]]
@@ -203,7 +206,7 @@ async def test_generate_embeddings_proceeds_when_idle() -> None:
 
 @pytest.mark.asyncio
 async def test_generate_embeddings_holds_bg_llm_lock_during_call() -> None:
-    """generate_embeddings must hold _bg_llm_lock while calling aembed_documents."""
+    """Ollama generate_embeddings must hold _bg_llm_lock while calling aembed_documents."""
     lock_held_during_call = False
 
     async def _check_lock(_texts: list[str], **_: object) -> list[list[float]]:
@@ -213,7 +216,7 @@ async def test_generate_embeddings_holds_bg_llm_lock_during_call() -> None:
 
     mock_emb = MagicMock()
     mock_emb.aembed_documents = _check_lock
-    mock_emb.__class__ = MagicMock  # type: ignore[assignment]
+    mock_emb.__class__ = OllamaEmbeddings  # type: ignore[assignment]
 
     await utils_mod.generate_embeddings(mock_emb, ["hello"])
     assert lock_held_during_call, "_bg_llm_lock must be held during aembed_documents"
@@ -221,7 +224,7 @@ async def test_generate_embeddings_holds_bg_llm_lock_during_call() -> None:
 
 @pytest.mark.asyncio
 async def test_chat_blocks_embeddings_via_bg_llm_lock() -> None:
-    """chat_priority_context must block generate_embeddings via _bg_llm_lock."""
+    """chat_priority_context must block Ollama generate_embeddings via _bg_llm_lock."""
     embed_acquired_lock: list[bool] = []
 
     async def _check_lock(_texts: list[str], **_: object) -> list[list[float]]:
@@ -230,7 +233,7 @@ async def test_chat_blocks_embeddings_via_bg_llm_lock() -> None:
 
     mock_emb = MagicMock()
     mock_emb.aembed_documents = _check_lock
-    mock_emb.__class__ = MagicMock  # type: ignore[assignment]
+    mock_emb.__class__ = OllamaEmbeddings  # type: ignore[assignment]
 
     async with utils_mod.chat_priority_context():
         embed_task = asyncio.create_task(
@@ -254,3 +257,64 @@ async def test_generate_embeddings_empty_texts_returns_empty() -> None:
     result = await utils_mod.generate_embeddings(mock_emb, [])
     mock_emb.aembed_documents.assert_not_called()
     assert result == []
+
+
+# ---------------------------------------------------------------------------
+# generate_embeddings: non-Ollama providers bypass the GPU gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_embeddings_non_ollama_bypasses_gate() -> None:
+    """Non-Ollama providers must not wait on _chat_idle or acquire _bg_llm_lock."""
+    _idle().clear()  # simulate active chat
+
+    embed_result: list[object] = []
+
+    mock_emb = MagicMock()
+    mock_emb.aembed_documents = AsyncMock(return_value=[[0.5, 0.6]])
+    # Leave __class__ as MagicMock — not OllamaEmbeddings, so gate is bypassed.
+
+    async def _run_embed() -> None:
+        result = await utils_mod.generate_embeddings(mock_emb, ["hello"])
+        embed_result.append(result)
+
+    task = asyncio.create_task(_run_embed())
+    await asyncio.sleep(0.01)
+    # Should have completed immediately despite chat being "active".
+    assert embed_result, "non-Ollama embeddings must not block on _chat_idle"
+    assert not _llm_lock().locked(), (
+        "_bg_llm_lock must not be held after non-Ollama call"
+    )
+    await task
+
+
+# ---------------------------------------------------------------------------
+# chat_priority_context: cancellation safety
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chat_priority_context_cleanup_on_cancellation_before_lock() -> None:
+    """_chat_idle and _chat_active_count must be reset if cancelled waiting for a lock."""
+    # Hold _bg_vlm_lock so chat_priority_context blocks waiting to acquire it.
+    async with _vlm_lock():
+        ctx_task = asyncio.create_task(_enter_chat_context())
+        # Give the task time to increment the count and block on the lock.
+        await asyncio.sleep(0.01)
+        assert not _idle().is_set(), "_chat_idle should be cleared"
+        assert utils_mod._chat_active_count == 1  # type: ignore[attr-defined]
+
+        ctx_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await ctx_task
+
+    # After cancellation _chat_idle must be restored and the count reset.
+    assert _idle().is_set(), "_chat_idle must be set after cancellation"
+    assert utils_mod._chat_active_count == 0  # type: ignore[attr-defined]
+
+
+async def _enter_chat_context() -> None:
+    """Enter chat_priority_context and hold until cancelled."""
+    async with utils_mod.chat_priority_context():
+        await asyncio.sleep(9999)

--- a/tests/custom_components/home_generative_agent/test_chat_priority_gate.py
+++ b/tests/custom_components/home_generative_agent/test_chat_priority_gate.py
@@ -1,22 +1,21 @@
 # ruff: noqa: S101
 """
-Tests for the chat-priority GPU gate primitives in core/utils.py.
+Tests for deployment-aware admission control in core/utils.py.
 
 Covers:
-- _chat_idle initial state (set = idle by default)
-- chat_priority_context clears _chat_idle on entry, restores it on exit
-- Concurrent chat contexts: _chat_idle only re-sets when the last chat exits
-- Background workers cannot acquire _bg_vlm_lock or _bg_llm_lock while
-  chat_priority_context holds them
-- generate_embeddings (Ollama) waits on _chat_idle AND holds _bg_llm_lock
-  during the embed call, so chat_priority_context blocks it
-- generate_embeddings (non-Ollama) bypasses the gate entirely
-- chat_priority_context cleans up _chat_idle on cancellation before lock
+- is_edge_deployment: edge/cloud/None classification
+- local_chat_session: edge clears _chat_idle, cloud is a no-op,
+  reference counting, exception/cancellation safety
+- sentinel_admission: cloud always admitted, edge defers when chat active,
+  edge admitted when idle, starvation tracking and WARNING threshold
+- generate_embeddings: runs freely during active chat (no gate)
 """
 
 from __future__ import annotations
 
 import asyncio
+import logging
+import time
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -25,14 +24,27 @@ from langchain_ollama import OllamaEmbeddings
 import custom_components.home_generative_agent.core.utils as utils_mod
 
 # ---------------------------------------------------------------------------
-# Fixture: create fresh asyncio primitives per test.
-#
-# Module-level asyncio.Event / asyncio.Lock objects bind to the first event
-# loop that touches them.  pytest-asyncio gives each async test its own loop,
-# so re-using the module globals across tests causes
-# "bound to a different event loop" errors.  We replace the module attributes
-# with brand-new primitives created inside the test's own loop, then restore
-# them afterwards via monkeypatch.
+# Override pytest-homeassistant-custom-component autouse fixtures.
+# These tests use pytest-asyncio's function-scoped asyncio.Runner (no `hass`).
+# Shadowing the plugin fixtures avoids "Event loop is closed" errors in teardown.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def enable_event_loop_debug() -> None:
+    """No-op override: pure-asyncio tests don't need HA's debug-mode hook."""
+
+
+@pytest.fixture(autouse=True)
+def verify_cleanup() -> None:
+    """No-op override: all tasks are explicitly awaited; no HA resources to clean up."""
+
+
+# ---------------------------------------------------------------------------
+# Fixture: fresh gate primitives per test.
+# Module-level asyncio.Event objects bind to the first event loop that touches
+# them.  pytest-asyncio gives each async test its own loop, so we replace the
+# module attributes with brand-new objects via monkeypatch.
 # ---------------------------------------------------------------------------
 
 
@@ -42,159 +54,303 @@ async def _fresh_gate_primitives(
 ) -> None:
     """Replace module-level gate primitives with fresh instances for each test."""
     new_idle = asyncio.Event()
-    new_idle.set()  # "no chat active" by default
-    new_llm_lock = asyncio.Lock()
-    new_vlm_lock = asyncio.Lock()
+    new_idle.set()
 
     monkeypatch.setattr(utils_mod, "_chat_idle", new_idle)
-    monkeypatch.setattr(utils_mod, "_bg_llm_lock", new_llm_lock)
-    monkeypatch.setattr(utils_mod, "_bg_vlm_lock", new_vlm_lock)
     monkeypatch.setattr(utils_mod, "_chat_active_count", 0)
-
-
-# ---------------------------------------------------------------------------
-# Helpers: read current primitives through the module to pick up monkeypatched
-# values (direct imports would cache the original objects).
-# ---------------------------------------------------------------------------
+    monkeypatch.setattr(utils_mod, "_sentinel_last_run", 0.0)
+    monkeypatch.setattr(utils_mod, "_sentinel_first_defer", 0.0)
+    monkeypatch.setattr(utils_mod, "_sentinel_defer_count", 0)
+    monkeypatch.setattr(utils_mod, "_sentinel_llm_tasks", set())
 
 
 def _idle() -> asyncio.Event:
     return utils_mod._chat_idle  # type: ignore[attr-defined]
 
 
-def _llm_lock() -> asyncio.Lock:
-    return utils_mod._bg_llm_lock  # type: ignore[attr-defined]
+# ---------------------------------------------------------------------------
+# is_edge_deployment
+# ---------------------------------------------------------------------------
 
 
-def _vlm_lock() -> asyncio.Lock:
-    return utils_mod._bg_vlm_lock  # type: ignore[attr-defined]
+def test_is_edge_deployment_edge() -> None:
+    assert utils_mod.is_edge_deployment("edge") is True
+
+
+def test_is_edge_deployment_cloud() -> None:
+    assert utils_mod.is_edge_deployment("cloud") is False
+
+
+def test_is_edge_deployment_none() -> None:
+    assert utils_mod.is_edge_deployment(None) is False
+
+
+def test_is_edge_deployment_unknown_string() -> None:
+    assert utils_mod.is_edge_deployment("other") is False
 
 
 # ---------------------------------------------------------------------------
-# _chat_idle initial state
+# local_chat_session: edge deployment
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_chat_idle_is_set_initially() -> None:
-    """_chat_idle must be set (idle) after fixture reset."""
+async def test_local_chat_session_edge_clears_idle() -> None:
+    """Edge chat session must clear _chat_idle on entry."""
     assert _idle().is_set()
-
-
-# ---------------------------------------------------------------------------
-# chat_priority_context: entry / exit semantics
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_chat_priority_context_clears_idle_on_entry() -> None:
-    """_chat_idle must be cleared while inside chat_priority_context."""
-    assert _idle().is_set()
-    async with utils_mod.chat_priority_context():
+    async with utils_mod.local_chat_session("edge"):
         assert not _idle().is_set()
-
-
-@pytest.mark.asyncio
-async def test_chat_priority_context_restores_idle_on_exit() -> None:
-    """_chat_idle must be set again after chat_priority_context exits."""
-    async with utils_mod.chat_priority_context():
-        pass
     assert _idle().is_set()
 
 
 @pytest.mark.asyncio
-async def test_chat_priority_context_restores_idle_on_exception() -> None:
+async def test_local_chat_session_edge_restores_on_exception() -> None:
     """_chat_idle must be restored even when the body raises."""
     err_msg = "boom"
-    with pytest.raises(RuntimeError):
-        async with utils_mod.chat_priority_context():
+    with pytest.raises(RuntimeError, match=err_msg):
+        async with utils_mod.local_chat_session("edge"):
             raise RuntimeError(err_msg)
     assert _idle().is_set()
-
-
-# ---------------------------------------------------------------------------
-# chat_priority_context: concurrent-chat reference counting
-# ---------------------------------------------------------------------------
+    assert utils_mod._chat_active_count == 0  # type: ignore[attr-defined]
 
 
 @pytest.mark.asyncio
-async def test_concurrent_chat_contexts_keep_idle_cleared() -> None:
-    """Two overlapping chat_priority_context calls: idle stays cleared until both exit."""
+async def test_local_chat_session_edge_restores_on_cancellation() -> None:
+    """_chat_idle and counter must reset when the session task is cancelled."""
+
+    async def _run() -> None:
+        async with utils_mod.local_chat_session("edge"):
+            await asyncio.sleep(9999)
+
+    task = asyncio.create_task(_run())
+    await asyncio.sleep(0)
+    assert not _idle().is_set()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert _idle().is_set()
+    assert utils_mod._chat_active_count == 0  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_edge_sessions_keep_idle_cleared() -> None:
+    """Ref count: _chat_idle stays cleared until the last session exits."""
     results: list[bool] = []
 
-    async def _enter_and_sample() -> None:
-        async with utils_mod.chat_priority_context():
+    async def _session() -> None:
+        async with utils_mod.local_chat_session("edge"):
             results.append(_idle().is_set())
             await asyncio.sleep(0)
             results.append(_idle().is_set())
 
-    await asyncio.gather(_enter_and_sample(), _enter_and_sample())
+    await asyncio.gather(_session(), _session())
     assert all(r is False for r in results)
     assert _idle().is_set()
 
 
 # ---------------------------------------------------------------------------
-# chat_priority_context: lock exclusion of background workers
+# local_chat_session: cloud deployment (no-op)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_bg_vlm_lock_held_inside_chat_context() -> None:
-    """_bg_vlm_lock must be locked while inside chat_priority_context."""
-    async with utils_mod.chat_priority_context():
-        assert _vlm_lock().locked()
-
-
-@pytest.mark.asyncio
-async def test_bg_llm_lock_held_inside_chat_context() -> None:
-    """_bg_llm_lock must be locked while inside chat_priority_context."""
-    async with utils_mod.chat_priority_context():
-        assert _llm_lock().locked()
-
-
-@pytest.mark.asyncio
-async def test_bg_locks_released_after_chat_context() -> None:
-    """Both background locks must be released after chat_priority_context exits."""
-    async with utils_mod.chat_priority_context():
-        pass
-    assert not _vlm_lock().locked()
-    assert not _llm_lock().locked()
+async def test_local_chat_session_cloud_is_noop() -> None:
+    """Cloud deployment must not touch _chat_idle."""
+    assert _idle().is_set()
+    async with utils_mod.local_chat_session("cloud"):
+        assert _idle().is_set()
+    assert _idle().is_set()
+    assert utils_mod._chat_active_count == 0  # type: ignore[attr-defined]
 
 
 # ---------------------------------------------------------------------------
-# generate_embeddings: TOCTOU-safe gate (waits + holds _bg_llm_lock)
+# sentinel_admission: cloud always admitted
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_generate_embeddings_waits_while_chat_active() -> None:
-    """Ollama generate_embeddings must not proceed until _chat_idle is set."""
-    _idle().clear()  # simulate active chat
+async def test_sentinel_admission_cloud_always_admitted() -> None:
+    """Cloud deployment is always admitted regardless of chat state."""
+    _idle().clear()  # simulate active edge chat
+    result = await utils_mod.sentinel_admission(
+        "cloud", category="triage", timeout_s=0.1
+    )
+    assert result is True
 
-    embed_started = asyncio.Event()
-    embed_result: list[object] = []
 
+@pytest.mark.asyncio
+async def test_sentinel_admission_cloud_resets_defer_count() -> None:
+    """Cloud admission resets starvation counters."""
+    utils_mod._sentinel_defer_count = 5  # type: ignore[attr-defined]
+    await utils_mod.sentinel_admission("cloud", category="triage", timeout_s=1.0)
+    assert utils_mod._sentinel_defer_count == 0  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# sentinel_admission: edge — idle case
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sentinel_admission_edge_admitted_when_idle() -> None:
+    """Edge Sentinel is admitted immediately when no chat is active."""
+    result = await utils_mod.sentinel_admission(
+        "edge", category="triage", timeout_s=1.0
+    )
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_sentinel_admission_edge_updates_last_run_on_success() -> None:
+    """Successful admission updates _sentinel_last_run."""
+    before = time.monotonic()
+    await utils_mod.sentinel_admission("edge", category="triage", timeout_s=1.0)
+    assert utils_mod._sentinel_last_run >= before  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_sentinel_admission_edge_resets_defer_count_on_success() -> None:
+    """Successful admission resets the deferral counter."""
+    utils_mod._sentinel_defer_count = 3  # type: ignore[attr-defined]
+    await utils_mod.sentinel_admission("edge", category="triage", timeout_s=1.0)
+    assert utils_mod._sentinel_defer_count == 0  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# sentinel_admission: edge — deferred (chat active, timeout)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sentinel_admission_edge_deferred_when_chat_active() -> None:
+    """Edge Sentinel must be denied when chat is active and timeout elapses."""
+    _idle().clear()
+    result = await utils_mod.sentinel_admission(
+        "edge", category="triage", timeout_s=0.05
+    )
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_sentinel_admission_edge_increments_defer_count() -> None:
+    """Deferral must increment _sentinel_defer_count."""
+    _idle().clear()
+    await utils_mod.sentinel_admission("edge", category="discovery", timeout_s=0.05)
+    assert utils_mod._sentinel_defer_count == 1  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_sentinel_admission_edge_starvation_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A WARNING is emitted when the starvation threshold is exceeded."""
+    _idle().clear()
+    # Last run was far in the past.
+    utils_mod._sentinel_last_run = time.monotonic() - 400.0  # type: ignore[attr-defined]
+    with caplog.at_level(
+        logging.WARNING, logger="custom_components.home_generative_agent.core.utils"
+    ):
+        await utils_mod.sentinel_admission("edge", category="triage", timeout_s=0.05)
+    assert any("deferred" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_sentinel_admission_edge_marks_health_degraded_without_prior_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sustained deferrals degrade health even if no Sentinel LLM run succeeded yet."""
+    _idle().clear()
+    health_stats: dict[str, object] = {}
+    now = time.monotonic()
+    monkeypatch.setattr(utils_mod, "_sentinel_first_defer", now - 400.0)
+
+    result = await utils_mod.sentinel_admission(
+        "edge", category="triage", timeout_s=0.05, health_stats=health_stats
+    )
+
+    assert result is False
+    assert health_stats["sentinel_admission_degraded"] is True
+    assert health_stats["sentinel_admission_degraded_category"] == "triage"
+    assert health_stats["sentinel_admission_consecutive_deferrals"] == 1
+
+
+@pytest.mark.asyncio
+async def test_sentinel_admission_edge_admitted_after_chat_ends() -> None:
+    """Edge Sentinel must be admitted once chat becomes idle."""
+    _idle().clear()
+    admitted: list[bool] = []
+
+    async def _admit() -> None:
+        result = await utils_mod.sentinel_admission(
+            "edge", category="triage", timeout_s=2.0
+        )
+        admitted.append(result)
+
+    task = asyncio.create_task(_admit())
+    await asyncio.sleep(0.01)
+    assert not admitted
+
+    _idle().set()
+    await asyncio.wait_for(task, timeout=2.0)
+    assert admitted == [True]
+
+
+@pytest.mark.asyncio
+async def test_local_chat_session_cancels_inflight_sentinel_llm() -> None:
+    """Foreground edge chat must interrupt an already-running Sentinel LLM call."""
+    sentinel_started = asyncio.Event()
+    sentinel_deferred: list[bool] = []
+
+    async def _slow_llm() -> str:
+        sentinel_started.set()
+        await asyncio.sleep(9999)
+        return "done"
+
+    async def _run_sentinel() -> None:
+        try:
+            await utils_mod.run_sentinel_llm_call(
+                _slow_llm,
+                deployment="edge",
+                category="triage",
+                admission_timeout_s=0.1,
+                call_timeout_s=60.0,
+            )
+        except utils_mod.SentinelLLMDeferredError:
+            sentinel_deferred.append(True)
+
+    sentinel_task = asyncio.create_task(_run_sentinel())
+    await sentinel_started.wait()
+
+    async with utils_mod.local_chat_session("edge"):
+        # Wait for the outer task to fully handle SentinelLLMDeferredError before
+        # asserting. _cancel_active_sentinel_llm_tasks awaits the inner future but
+        # the outer coroutine needs one more event-loop turn to run its except branch.
+        await asyncio.wait_for(sentinel_task, timeout=1.0)
+        assert sentinel_deferred == [True]
+
+
+# ---------------------------------------------------------------------------
+# generate_embeddings: no gate — runs freely even during active chat
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_embeddings_runs_during_active_chat() -> None:
+    """Embeddings must complete immediately even while edge chat is active."""
     mock_emb = MagicMock()
     mock_emb.aembed_documents = AsyncMock(return_value=[[0.1, 0.2]])
     mock_emb.__class__ = OllamaEmbeddings  # type: ignore[assignment]
 
-    async def _run_embed() -> None:
-        embed_started.set()
-        result = await utils_mod.generate_embeddings(mock_emb, ["hello"])
-        embed_result.append(result)
-
-    task = asyncio.create_task(_run_embed())
-    await embed_started.wait()
-    await asyncio.sleep(0.01)
-    assert not embed_result, "generate_embeddings should block while chat is active"
-
-    _idle().set()
-    await asyncio.wait_for(task, timeout=2.0)
-    assert embed_result, "generate_embeddings should complete after chat gate released"
+    async with utils_mod.local_chat_session("edge"):
+        result = await asyncio.wait_for(
+            utils_mod.generate_embeddings(mock_emb, ["hello"]),
+            timeout=1.0,
+        )
+    assert result == [[0.1, 0.2]]
 
 
 @pytest.mark.asyncio
-async def test_generate_embeddings_proceeds_when_idle() -> None:
+async def test_generate_embeddings_ollama_proceeds_when_idle() -> None:
     """Ollama generate_embeddings completes immediately when no chat is active."""
     mock_emb = MagicMock()
     mock_emb.aembed_documents = AsyncMock(return_value=[[0.1, 0.2]])
@@ -202,50 +358,6 @@ async def test_generate_embeddings_proceeds_when_idle() -> None:
 
     result = await utils_mod.generate_embeddings(mock_emb, ["hello"])
     assert result == [[0.1, 0.2]]
-
-
-@pytest.mark.asyncio
-async def test_generate_embeddings_holds_bg_llm_lock_during_call() -> None:
-    """Ollama generate_embeddings must hold _bg_llm_lock while calling aembed_documents."""
-    lock_held_during_call = False
-
-    async def _check_lock(_texts: list[str], **_: object) -> list[list[float]]:
-        nonlocal lock_held_during_call
-        lock_held_during_call = _llm_lock().locked()
-        return [[0.1]]
-
-    mock_emb = MagicMock()
-    mock_emb.aembed_documents = _check_lock
-    mock_emb.__class__ = OllamaEmbeddings  # type: ignore[assignment]
-
-    await utils_mod.generate_embeddings(mock_emb, ["hello"])
-    assert lock_held_during_call, "_bg_llm_lock must be held during aembed_documents"
-
-
-@pytest.mark.asyncio
-async def test_chat_blocks_embeddings_via_bg_llm_lock() -> None:
-    """chat_priority_context must block Ollama generate_embeddings via _bg_llm_lock."""
-    embed_acquired_lock: list[bool] = []
-
-    async def _check_lock(_texts: list[str], **_: object) -> list[list[float]]:
-        embed_acquired_lock.append(True)
-        return [[0.1]]
-
-    mock_emb = MagicMock()
-    mock_emb.aembed_documents = _check_lock
-    mock_emb.__class__ = OllamaEmbeddings  # type: ignore[assignment]
-
-    async with utils_mod.chat_priority_context():
-        embed_task = asyncio.create_task(
-            utils_mod.generate_embeddings(mock_emb, ["hello"])
-        )
-        await asyncio.sleep(0.01)
-        assert not embed_acquired_lock, (
-            "generate_embeddings should not start while chat holds _bg_llm_lock"
-        )
-
-    await asyncio.wait_for(embed_task, timeout=2.0)
-    assert embed_acquired_lock
 
 
 @pytest.mark.asyncio
@@ -260,61 +372,23 @@ async def test_generate_embeddings_empty_texts_returns_empty() -> None:
 
 
 # ---------------------------------------------------------------------------
-# generate_embeddings: non-Ollama providers bypass the GPU gate
+# run_sentinel_llm_call: call_timeout_s exceeded
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_generate_embeddings_non_ollama_bypasses_gate() -> None:
-    """Non-Ollama providers must not wait on _chat_idle or acquire _bg_llm_lock."""
-    _idle().clear()  # simulate active chat
+async def test_run_sentinel_llm_call_timeout_raises_timeout_error() -> None:
+    """call_factory that exceeds call_timeout_s must raise TimeoutError."""
 
-    embed_result: list[object] = []
-
-    mock_emb = MagicMock()
-    mock_emb.aembed_documents = AsyncMock(return_value=[[0.5, 0.6]])
-    # Leave __class__ as MagicMock — not OllamaEmbeddings, so gate is bypassed.
-
-    async def _run_embed() -> None:
-        result = await utils_mod.generate_embeddings(mock_emb, ["hello"])
-        embed_result.append(result)
-
-    task = asyncio.create_task(_run_embed())
-    await asyncio.sleep(0.01)
-    # Should have completed immediately despite chat being "active".
-    assert embed_result, "non-Ollama embeddings must not block on _chat_idle"
-    assert not _llm_lock().locked(), (
-        "_bg_llm_lock must not be held after non-Ollama call"
-    )
-    await task
-
-
-# ---------------------------------------------------------------------------
-# chat_priority_context: cancellation safety
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_chat_priority_context_cleanup_on_cancellation_before_lock() -> None:
-    """_chat_idle and _chat_active_count must be reset if cancelled waiting for a lock."""
-    # Hold _bg_vlm_lock so chat_priority_context blocks waiting to acquire it.
-    async with _vlm_lock():
-        ctx_task = asyncio.create_task(_enter_chat_context())
-        # Give the task time to increment the count and block on the lock.
-        await asyncio.sleep(0.01)
-        assert not _idle().is_set(), "_chat_idle should be cleared"
-        assert utils_mod._chat_active_count == 1  # type: ignore[attr-defined]
-
-        ctx_task.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await ctx_task
-
-    # After cancellation _chat_idle must be restored and the count reset.
-    assert _idle().is_set(), "_chat_idle must be set after cancellation"
-    assert utils_mod._chat_active_count == 0  # type: ignore[attr-defined]
-
-
-async def _enter_chat_context() -> None:
-    """Enter chat_priority_context and hold until cancelled."""
-    async with utils_mod.chat_priority_context():
+    async def _slow() -> str:
         await asyncio.sleep(9999)
+        return "done"
+
+    with pytest.raises(TimeoutError):
+        await utils_mod.run_sentinel_llm_call(
+            _slow,
+            deployment="cloud",  # always admitted — bypasses the chat gate
+            category="triage",
+            admission_timeout_s=0.1,
+            call_timeout_s=0.05,
+        )

--- a/tests/custom_components/home_generative_agent/test_chat_priority_gate.py
+++ b/tests/custom_components/home_generative_agent/test_chat_priority_gate.py
@@ -1,0 +1,198 @@
+# ruff: noqa: S101
+"""Tests for the chat-priority GPU gate primitives in core/utils.py.
+
+Covers:
+- _chat_idle initial state (set = idle by default)
+- chat_priority_context clears _chat_idle on entry, restores it on exit
+- Concurrent chat contexts: _chat_idle only re-sets when the last chat exits
+- Background workers cannot acquire _bg_vlm_lock or _bg_llm_lock while
+  chat_priority_context holds them
+- generate_embeddings waits on _chat_idle before proceeding
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import custom_components.home_generative_agent.core.utils as utils_mod
+from custom_components.home_generative_agent.core.utils import (
+    _bg_llm_lock,
+    _bg_vlm_lock,
+    _chat_idle,
+    chat_priority_context,
+    generate_embeddings,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture: reset module-level gate state between tests so tests are isolated.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_gate_state() -> None:  # type: ignore[return]
+    """Restore gate primitives to initial state before and after each test."""
+    _chat_idle.set()
+    utils_mod._chat_active_count = 0
+    # Release locks if somehow held (shouldn't happen, but defensive)
+    if _bg_vlm_lock.locked():
+        _bg_vlm_lock.release()
+    if _bg_llm_lock.locked():
+        _bg_llm_lock.release()
+    yield
+    _chat_idle.set()
+    utils_mod._chat_active_count = 0
+
+
+# ---------------------------------------------------------------------------
+# _chat_idle initial state
+# ---------------------------------------------------------------------------
+
+
+def test_chat_idle_is_set_initially() -> None:
+    """_chat_idle must be set (idle) at module load time."""
+    assert _chat_idle.is_set()
+
+
+# ---------------------------------------------------------------------------
+# chat_priority_context: entry / exit semantics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chat_priority_context_clears_idle_on_entry() -> None:
+    """_chat_idle must be cleared while inside chat_priority_context."""
+    assert _chat_idle.is_set()
+    async with chat_priority_context():
+        assert not _chat_idle.is_set()
+
+
+@pytest.mark.asyncio
+async def test_chat_priority_context_restores_idle_on_exit() -> None:
+    """_chat_idle must be set again after chat_priority_context exits."""
+    async with chat_priority_context():
+        pass
+    assert _chat_idle.is_set()
+
+
+@pytest.mark.asyncio
+async def test_chat_priority_context_restores_idle_on_exception() -> None:
+    """_chat_idle must be restored even when the body raises."""
+    with pytest.raises(RuntimeError):
+        async with chat_priority_context():
+            raise RuntimeError("boom")
+    assert _chat_idle.is_set()
+
+
+# ---------------------------------------------------------------------------
+# chat_priority_context: concurrent-chat reference counting
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_chat_contexts_keep_idle_cleared() -> None:
+    """Two overlapping chat_priority_context calls: idle stays cleared until both exit."""
+    results: list[bool] = []
+
+    async def _enter_and_sample() -> None:
+        async with chat_priority_context():
+            results.append(_chat_idle.is_set())
+            # Yield so the other task can also enter before we exit.
+            await asyncio.sleep(0)
+            results.append(_chat_idle.is_set())
+
+    await asyncio.gather(_enter_and_sample(), _enter_and_sample())
+    # Both tasks saw the event cleared while they were inside.
+    assert all(r is False for r in results)
+    # After both tasks exit, idle should be set again.
+    assert _chat_idle.is_set()
+
+
+# ---------------------------------------------------------------------------
+# chat_priority_context: lock exclusion of background workers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bg_vlm_lock_not_acquirable_inside_chat_context() -> None:
+    """Background VLM worker cannot acquire _bg_vlm_lock while chat holds it."""
+    async with chat_priority_context():
+        # Attempt a non-blocking acquire — must fail because chat holds the lock.
+        acquired = _bg_vlm_lock.locked()
+        assert acquired, "_bg_vlm_lock should be locked inside chat_priority_context"
+
+
+@pytest.mark.asyncio
+async def test_bg_llm_lock_not_acquirable_inside_chat_context() -> None:
+    """Background LLM worker cannot acquire _bg_llm_lock while chat holds it."""
+    async with chat_priority_context():
+        acquired = _bg_llm_lock.locked()
+        assert acquired, "_bg_llm_lock should be locked inside chat_priority_context"
+
+
+@pytest.mark.asyncio
+async def test_bg_locks_released_after_chat_context() -> None:
+    """Both background locks must be released after chat_priority_context exits."""
+    async with chat_priority_context():
+        pass
+    assert not _bg_vlm_lock.locked()
+    assert not _bg_llm_lock.locked()
+
+
+# ---------------------------------------------------------------------------
+# generate_embeddings: honours _chat_idle gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_embeddings_waits_while_chat_active() -> None:
+    """generate_embeddings must not proceed until _chat_idle is set."""
+    _chat_idle.clear()  # simulate active chat
+
+    embed_started = asyncio.Event()
+    embed_result: list[object] = []
+
+    mock_emb = MagicMock()
+    mock_emb.aembed_documents = AsyncMock(return_value=[[0.1, 0.2]])
+    # Not a GoogleGenerativeAIEmbeddings instance.
+    mock_emb.__class__ = MagicMock  # type: ignore[assignment]
+
+    async def _run_embed() -> None:
+        embed_started.set()
+        result = await generate_embeddings(mock_emb, ["hello"])
+        embed_result.append(result)
+
+    task = asyncio.create_task(_run_embed())
+    await embed_started.wait()
+    # Give the task a chance to (wrongly) proceed before we release the gate.
+    await asyncio.sleep(0.01)
+    assert not embed_result, "generate_embeddings should block while chat is active"
+
+    _chat_idle.set()  # release the gate
+    await asyncio.wait_for(task, timeout=2.0)
+    assert embed_result, "generate_embeddings should complete after chat gate released"
+
+
+@pytest.mark.asyncio
+async def test_generate_embeddings_proceeds_when_idle() -> None:
+    """generate_embeddings completes immediately when no chat is active."""
+    mock_emb = MagicMock()
+    mock_emb.aembed_documents = AsyncMock(return_value=[[0.1, 0.2]])
+    mock_emb.__class__ = MagicMock  # type: ignore[assignment]
+
+    result = await generate_embeddings(mock_emb, ["hello"])
+    assert result == [[0.1, 0.2]]
+
+
+@pytest.mark.asyncio
+async def test_generate_embeddings_empty_texts_returns_empty() -> None:
+    """generate_embeddings with empty input returns [] without hitting the model."""
+    mock_emb = MagicMock()
+    mock_emb.aembed_documents = AsyncMock(return_value=[])
+
+    result = await generate_embeddings(mock_emb, [])
+    mock_emb.aembed_documents.assert_not_called()
+    assert result == []

--- a/tests/custom_components/home_generative_agent/test_discovery_quality_metrics.py
+++ b/tests/custom_components/home_generative_agent/test_discovery_quality_metrics.py
@@ -13,6 +13,7 @@ Covers:
 
 from __future__ import annotations
 
+import asyncio
 import json
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -341,13 +342,8 @@ async def test_health_sensor_exposes_none_discovery_attrs_when_no_engine() -> No
 
 
 @pytest.mark.asyncio
-async def test_discovery_llm_timeout_skips_cycle(hass: HomeAssistant) -> None:
+async def test_discovery_llm_timeout_skips_cycle() -> None:
     """Discovery run must skip the cycle (not raise) when the LLM times out."""
-    import asyncio  # noqa: PLC0415
-
-    from custom_components.home_generative_agent.sentinel.discovery_engine import (  # noqa: PLC0415
-        _DISCOVERY_LLM_TIMEOUT_S,
-    )
 
     async def _slow_ainvoke(*_a: object, **_kw: object) -> None:
         await asyncio.sleep(9999)
@@ -357,13 +353,16 @@ async def test_discovery_llm_timeout_skips_cycle(hass: HomeAssistant) -> None:
     engine = _make_engine(model=model)
 
     # Patch the timeout to an immediate value so the test completes quickly.
-    with patch(
-        "custom_components.home_generative_agent.sentinel.discovery_engine"
-        "._DISCOVERY_LLM_TIMEOUT_S",
-        new=0.0,
+    with (
+        patch(
+            "custom_components.home_generative_agent.sentinel.discovery_engine"
+            "._DISCOVERY_LLM_TIMEOUT_S",
+            new=0.0,
+        ),
+        _SNAPSHOT_PATCH,
+        _REDUCER_PATCH,
     ):
-        with _SNAPSHOT_PATCH, _REDUCER_PATCH:
-            await engine._run_once()
+        await engine._run_once()
 
     # The cycle was skipped cleanly — no candidates stored, no exception raised.
     assert engine.discovery_cycle_stats["candidates_generated"] == 0
@@ -372,7 +371,7 @@ async def test_discovery_llm_timeout_skips_cycle(hass: HomeAssistant) -> None:
 @pytest.mark.asyncio
 async def test_discovery_llm_timeout_constant_is_positive() -> None:
     """_DISCOVERY_LLM_TIMEOUT_S must be a positive float."""
-    from custom_components.home_generative_agent.sentinel.discovery_engine import (  # noqa: PLC0415
+    from custom_components.home_generative_agent.sentinel.discovery_engine import (
         _DISCOVERY_LLM_TIMEOUT_S,
     )
 

--- a/tests/custom_components/home_generative_agent/test_discovery_quality_metrics.py
+++ b/tests/custom_components/home_generative_agent/test_discovery_quality_metrics.py
@@ -333,3 +333,48 @@ async def test_health_sensor_exposes_none_discovery_attrs_when_no_engine() -> No
     assert "discovery_proposals_promoted" not in attrs
     assert attrs["discovery_unsupported_ttl_expired"] is None
     assert attrs["discovery_proposals_approved_24h"] is None
+
+
+# ---------------------------------------------------------------------------
+# Discovery LLM timeout path (_DISCOVERY_LLM_TIMEOUT_S cap)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_discovery_llm_timeout_skips_cycle(hass: HomeAssistant) -> None:
+    """Discovery run must skip the cycle (not raise) when the LLM times out."""
+    import asyncio  # noqa: PLC0415
+
+    from custom_components.home_generative_agent.sentinel.discovery_engine import (  # noqa: PLC0415
+        _DISCOVERY_LLM_TIMEOUT_S,
+    )
+
+    async def _slow_ainvoke(*_a: object, **_kw: object) -> None:
+        await asyncio.sleep(9999)
+
+    model = MagicMock()
+    model.ainvoke = _slow_ainvoke
+    engine = _make_engine(model=model)
+
+    # Patch the timeout to an immediate value so the test completes quickly.
+    with patch(
+        "custom_components.home_generative_agent.sentinel.discovery_engine"
+        "._DISCOVERY_LLM_TIMEOUT_S",
+        new=0.0,
+    ):
+        with _SNAPSHOT_PATCH, _REDUCER_PATCH:
+            await engine._run_once()
+
+    # The cycle was skipped cleanly — no candidates stored, no exception raised.
+    assert engine.discovery_cycle_stats["candidates_generated"] == 0
+
+
+@pytest.mark.asyncio
+async def test_discovery_llm_timeout_constant_is_positive() -> None:
+    """_DISCOVERY_LLM_TIMEOUT_S must be a positive float."""
+    from custom_components.home_generative_agent.sentinel.discovery_engine import (  # noqa: PLC0415
+        _DISCOVERY_LLM_TIMEOUT_S,
+    )
+
+    assert isinstance(_DISCOVERY_LLM_TIMEOUT_S, float)
+    assert _DISCOVERY_LLM_TIMEOUT_S > 0

--- a/tests/custom_components/home_generative_agent/test_llm_explain.py
+++ b/tests/custom_components/home_generative_agent/test_llm_explain.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 
 import pytest
 
+from custom_components.home_generative_agent.core.utils import SentinelLLMDeferredError
 from custom_components.home_generative_agent.explain.llm_explain import (
     LLMExplainer,
     _iso_to_relative,
@@ -185,3 +186,15 @@ async def test_async_explain_does_not_pass_raw_timestamps() -> None:
     prompt_text = captured_messages[1].content
     assert "2025-01-15T20:09:00" not in prompt_text
     assert "ago" in prompt_text
+
+
+@pytest.mark.asyncio
+async def test_async_explain_returns_none_when_deferred() -> None:
+    """async_explain must return None when run_sentinel_llm_call raises SentinelLLMDeferredError."""
+    explainer = LLMExplainer(DummyModel("some content"))
+    with patch(
+        "custom_components.home_generative_agent.explain.llm_explain.run_sentinel_llm_call",
+        side_effect=SentinelLLMDeferredError("explain", "chat is active"),
+    ):
+        result = await explainer.async_explain(_finding())
+    assert result is None

--- a/tests/custom_components/home_generative_agent/test_regressions.py
+++ b/tests/custom_components/home_generative_agent/test_regressions.py
@@ -8,12 +8,12 @@ import logging
 from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_send
-from langchain_core.messages import ToolMessage
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
 import custom_components.home_generative_agent.agent.graph as agent_graph
 from custom_components.home_generative_agent.agent import tools as agent_tools
@@ -266,4 +266,86 @@ def test_make_transient_tool_error_content_instructs_no_retry() -> None:
     """Transient error message must tell the LLM not to retry the tool."""
     msg = agent_graph._make_transient_tool_error("timeout", "some_tool", "id-1")
     # The template instructs the model not to retry.
-    assert "Do not retry" in msg.content or "transient" in msg.content.lower()
+    content = str(msg.content)
+    assert "Do not retry" in content or "transient" in content.lower()
+
+
+# ---------------------------------------------------------------------------
+# _call_model — fallback "Done." when Qwen3 thinking strips all content
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_call_model_injects_done_fallback_after_empty_tool_response(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    _call_model must emit 'Done.' when the model returns empty content after a tool.
+
+    Regression: Qwen3 extended-thinking strips <think> tokens so content becomes
+    '' (eval_count: 9).  Without the fallback the user receives no reply at all.
+    """
+    empty_ai = AIMessage(content="", tool_calls=[])
+
+    async def _fake_invoke_model(*_args: object, **_kwargs: object) -> AIMessage:
+        return empty_ai
+
+    async def _fake_camera(*_args: object, **_kwargs: object) -> list[object]:
+        return []
+
+    async def _fake_trim(
+        messages: list[object], *_args: object, **_kwargs: object
+    ) -> list[object]:
+        return messages
+
+    mock_store = MagicMock()
+    mock_store.asearch = AsyncMock(return_value=[])
+
+    monkeypatch.setattr(agent_graph, "_invoke_model", _fake_invoke_model)
+    monkeypatch.setattr(agent_graph, "get_recent_camera_activity", _fake_camera)
+    monkeypatch.setattr(agent_graph, "_trim_messages_for_model", _fake_trim)
+
+    state: dict[str, object] = {
+        "messages": [
+            HumanMessage(content="turn it off"),
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "HassTurnOff",
+                        "args": {},
+                        "id": "call-1",
+                        "type": "tool_call",
+                    }
+                ],
+            ),
+            ToolMessage(content="action_done", tool_call_id="call-1"),
+        ],
+        "selected_tools": [],
+        "summary": "",
+        "tool_routing_map": {},
+        "messages_to_remove": [],
+        "chat_model_usage_metadata": {},
+    }
+
+    config: dict[str, object] = {
+        "configurable": {
+            "chat_model": MagicMock(),
+            "user_id": "user-test",
+            "hass": hass,
+            "options": {},
+            "chat_model_options": {},
+            "prompt": "You are a helpful assistant.",
+            "langchain_tools": {},
+            "ha_llm_api": None,
+            "pending_actions": {},
+        }
+    }
+
+    result = await agent_graph._call_model(state, config, store=mock_store)  # type: ignore[arg-type]
+
+    ai_msg = result["messages"]
+    assert isinstance(ai_msg, AIMessage)
+    assert ai_msg.content == "Done.", f"expected 'Done.' but got {ai_msg.content!r}"
+    assert not ai_msg.tool_calls

--- a/tests/custom_components/home_generative_agent/test_regressions.py
+++ b/tests/custom_components/home_generative_agent/test_regressions.py
@@ -242,3 +242,29 @@ async def test_invoke_model_returns_result_within_timeout(
 
     result = await agent_graph._invoke_model(mock_model, [], {})
     assert result is expected
+
+
+# ---------------------------------------------------------------------------
+# _make_transient_tool_error — non-retryable tool timeout message
+# ---------------------------------------------------------------------------
+
+
+def test_make_transient_tool_error_status_and_content() -> None:
+    """_make_transient_tool_error must produce a ToolMessage with status='error'."""
+    from langchain_core.messages import ToolMessage
+
+    msg = agent_graph._make_transient_tool_error("boom", "my_tool", "call-123")
+
+    assert isinstance(msg, ToolMessage)
+    assert msg.name == "my_tool"
+    assert msg.tool_call_id == "call-123"
+    assert msg.status == "error"
+    # The content must contain the error description.
+    assert "boom" in msg.content
+
+
+def test_make_transient_tool_error_content_instructs_no_retry() -> None:
+    """Transient error message must tell the LLM not to retry the tool."""
+    msg = agent_graph._make_transient_tool_error("timeout", "some_tool", "id-1")
+    # The template instructs the model not to retry.
+    assert "Do not retry" in msg.content or "transient" in msg.content.lower()

--- a/tests/custom_components/home_generative_agent/test_regressions.py
+++ b/tests/custom_components/home_generative_agent/test_regressions.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock
 import pytest
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_send
+from langchain_core.messages import ToolMessage
 
 import custom_components.home_generative_agent.agent.graph as agent_graph
 from custom_components.home_generative_agent.agent import tools as agent_tools
@@ -251,8 +252,6 @@ async def test_invoke_model_returns_result_within_timeout(
 
 def test_make_transient_tool_error_status_and_content() -> None:
     """_make_transient_tool_error must produce a ToolMessage with status='error'."""
-    from langchain_core.messages import ToolMessage
-
     msg = agent_graph._make_transient_tool_error("boom", "my_tool", "call-123")
 
     assert isinstance(msg, ToolMessage)

--- a/tests/custom_components/home_generative_agent/test_sentinel_health_sensor.py
+++ b/tests/custom_components/home_generative_agent/test_sentinel_health_sensor.py
@@ -341,9 +341,34 @@ async def test_refresh_run_stats_keys_present_when_no_engine() -> None:
         "last_run_end",
         "run_duration_ms",
         "active_rule_count",
+        "sentinel_admission_degraded",
+        "sentinel_admission_degraded_category",
+        "sentinel_admission_consecutive_deferrals",
+        "sentinel_admission_starved_for_s",
     ):
         assert key in sensor._attrs
         assert sensor._attrs[key] is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_marks_degraded_for_sentinel_admission_starvation() -> None:
+    """Admission starvation in run_stats should set the health sensor to degraded."""
+    sensor = _make_sensor(
+        run_stats={
+            "sentinel_admission_degraded": True,
+            "sentinel_admission_degraded_category": "triage",
+            "sentinel_admission_consecutive_deferrals": 4,
+            "sentinel_admission_starved_for_s": 360,
+        }
+    )
+    sensor.async_write_ha_state = MagicMock()
+
+    await sensor._async_refresh()
+
+    assert sensor._attr_native_value == "degraded"
+    assert sensor._attrs["sentinel_admission_degraded"] is True
+    assert sensor._attrs["sentinel_admission_degraded_category"] == "triage"
+    assert sensor._attrs["sentinel_admission_consecutive_deferrals"] == 4
 
 
 def test_unique_id_uses_entry_id() -> None:

--- a/tests/custom_components/home_generative_agent/test_sentinel_triage.py
+++ b/tests/custom_components/home_generative_agent/test_sentinel_triage.py
@@ -6,13 +6,16 @@ from __future__ import annotations
 import asyncio
 import json
 from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import patch
 
 import pytest
 from langchain_core.messages import HumanMessage, SystemMessage
 
+from custom_components.home_generative_agent.core.utils import SentinelLLMDeferredError
 from custom_components.home_generative_agent.sentinel.models import AnomalyFinding
 from custom_components.home_generative_agent.sentinel.triage import (
     TRIAGE_NOTIFY,
+    TRIAGE_REASON_DEFERRED,
     TRIAGE_SUPPRESS,
     SentinelTriageService,
     TriageDecision,
@@ -576,3 +579,26 @@ async def test_llm_receives_system_and_human_messages() -> None:
 
     # The human message must contain the finding type so the LLM has context.
     assert "open_entry_while_away" in llm.last_messages[1].content
+
+
+# ---------------------------------------------------------------------------
+# 10. Deferred triage when chat is active
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_triage_deferred_when_chat_active() -> None:
+    """SentinelLLMDeferredError from run_sentinel_llm_call must produce decision=notify, reason_code=triage_deferred."""
+    finding = _finding()
+    snapshot = _snapshot()
+
+    svc = SentinelTriageService(MockLLM())
+    with patch(
+        "custom_components.home_generative_agent.sentinel.triage.run_sentinel_llm_call",
+        side_effect=SentinelLLMDeferredError("triage", "chat is active"),
+    ):
+        result = await svc.triage(finding, snapshot)
+
+    assert result.decision == TRIAGE_NOTIFY
+    assert result.reason_code == TRIAGE_REASON_DEFERRED
+    assert result.triage_confidence is None

--- a/tests/custom_components/home_generative_agent/test_subentries.py
+++ b/tests/custom_components/home_generative_agent/test_subentries.py
@@ -57,8 +57,12 @@ from custom_components.home_generative_agent.const import (
     SUBENTRY_TYPE_STT_PROVIDER,
 )
 from custom_components.home_generative_agent.core.subentry_resolver import (
+    build_model_deployments,
     legacy_model_provider_configs,
     resolve_runtime_options,
+)
+from custom_components.home_generative_agent.core.subentry_types import (
+    ModelProviderConfig,
 )
 from custom_components.home_generative_agent.core.utils import (
     CannotConnectError,
@@ -1119,3 +1123,45 @@ def test_resolve_runtime_options_openai_compatible_embedding_dims_none() -> None
 def test_recommended_openai_compatible_embedding_dims_value() -> None:
     """Default dims constant is 768 — matches nomic-embed-text native output size."""
     assert RECOMMENDED_OPENAI_COMPATIBLE_EMBEDDING_DIMS == 768
+
+
+# ---------------------------------------------------------------------------
+# build_model_deployments
+# ---------------------------------------------------------------------------
+
+
+def test_build_model_deployments_ollama_returns_edge() -> None:
+    """Ollama provider must map its capabilities to 'edge' deployment."""
+    provider = ModelProviderConfig(
+        entry_id="p_ollama",
+        name="Ollama Local",
+        provider_type="ollama",
+        capabilities={"chat", "vlm", "summarization"},
+        data={},
+        deployment="edge",
+    )
+    entry = DummyEntry()
+    result = build_model_deployments(entry, {"p_ollama": provider}, {})  # type: ignore[arg-type]
+    assert result.get("chat") == "edge"
+
+
+def test_build_model_deployments_openai_returns_cloud() -> None:
+    """OpenAI provider must map its capabilities to 'cloud' deployment."""
+    provider = ModelProviderConfig(
+        entry_id="p_openai",
+        name="OpenAI Cloud",
+        provider_type="openai",
+        capabilities={"chat"},
+        data={"settings": {}},
+        deployment="cloud",
+    )
+    entry = DummyEntry()
+    result = build_model_deployments(entry, {"p_openai": provider}, {})  # type: ignore[arg-type]
+    assert result.get("chat") == "cloud"
+
+
+def test_build_model_deployments_empty_providers_returns_empty() -> None:
+    """No providers must yield an empty deployment map."""
+    entry = DummyEntry()
+    result = build_model_deployments(entry, {}, {})  # type: ignore[arg-type]
+    assert result == {}


### PR DESCRIPTION
## Summary

- Replaces lock-based GPU contention management (`chat_priority_context`, `_bg_vlm_lock`, `_bg_llm_lock`) with deployment-aware admission control that inverts the priority model: chat marks itself active; Sentinel defers rather than blocking chat
- Adds `run_sentinel_llm_call()` unified wrapper used by triage, discovery, and explain — handles admission, task registration, in-flight cancellation by foreground chat, and per-call timeout
- Plumbs `deployment` metadata from provider subentries through to admission decisions; cloud providers are always admitted with no per-provider code changes
- Sentinel starvation tracked and surfaced in `SentinelHealthSensor` as a `"degraded"` state when deferrals exceed 300 s
- 809 tests passing; 6 new tests added for deferred paths, timeout path, and `build_model_deployments`

## Key design decisions

| Decision | Choice | Reason |
|---|---|---|
| Invert priority model | Chat clears event, Sentinel waits | Background work no longer blocks foreground chat at all |
| `SentinelLLMDeferredError` unified | Single exception for defer + interrupt | Callers (triage, discovery, explain) have one catch clause |
| Video analysis ungated | VLM tuning constants remain the concurrency surface | VLM timeout and per-camera queues are already the right knobs |
| Cloud always admitted | `sentinel_admission` short-circuits for non-edge | Cloud inference is remote; no local GPU competition |
| Health stats keys as inline strings | No constant extraction | Keys are only read/written in one module cluster |

## Commits (bisectable)

1. `fix:` — production code: utils, conversation, subentry_resolver, triage, discovery, explain, init, graph, sentinel engine
2. `test:` — 6 new tests for deferred paths, timeout, `build_model_deployments`; expanded gate test file
3. `chore:` — v3.12.4 manifest + CHANGELOG

## Test plan

- [x] Run `make test` — 809 tests, 0 failures
- [x] Run `make lint` — all checks pass
- [x] Manual: start integration, trigger a conversation, verify Sentinel triage and discovery run when chat is idle
- [x] Manual: send a long chat request, verify Sentinel defers (DEBUG log: "Triage deferred: chat is active")
- [x] Manual: send requests from a cloud provider config, verify Sentinel is not blocked

🤖 Generated with [Claude Code](https://claude.ai/claude-code)