### PR TITLE
feat: video model priority — semaphore, chat-wait, config-merge fix

### DIFF
--- a/custom_components/home_generative_agent/__init__.py
+++ b/custom_components/home_generative_agent/__init__.py
@@ -1043,7 +1043,7 @@ class NullChat:
         """Return self, as tool binding is a no-op for the fallback model."""
         return self
 
-    def with_config(self, **_cfg: Any) -> NullChat:
+    def with_config(self, _config: Any = None, **_cfg: Any) -> NullChat:
         """Return self, as this is a no-op."""
         return self
 
@@ -1163,6 +1163,66 @@ def _register_services(hass: HomeAssistant, entry: HGAConfigEntry) -> None:
     )
 
 
+async def _log_ollama_server_info(
+    hass: HomeAssistant,
+    urls_by_category: dict[str, str],
+) -> None:
+    """Query Ollama /api/ps at startup and log loaded models and swap-risk notes."""
+    client = get_async_client(hass)
+
+    # Log which categories share each URL so operators can spot contention.
+    url_to_cats: dict[str, list[str]] = {}
+    for cat, url in urls_by_category.items():
+        url_to_cats.setdefault(url, []).append(cat)
+    for url, cats in url_to_cats.items():
+        LOGGER.info(
+            "subsystem=model_server url=%s categories=%s",
+            url,
+            ",".join(sorted(cats)),
+        )
+
+    # Query /api/ps on each unique URL and log loaded models.
+    for url, cats in url_to_cats.items():
+        try:
+            async with asyncio.timeout(5.0):
+                resp = await client.get(f"{url.rstrip('/')}/api/ps")
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception as err:  # noqa: BLE001
+            LOGGER.warning(
+                "subsystem=model_server url=%s probe_failed reason=%s",
+                url,
+                err,
+            )
+            continue
+
+        models = data.get("models", [])
+        if not models:
+            LOGGER.info("subsystem=model_server url=%s loaded_models=none", url)
+            continue
+
+        for m in models:
+            name = m.get("name", "unknown")
+            size_mb = int(m.get("size", 0)) // (1024 * 1024)
+            vram_mb = int(m.get("size_vram", 0)) // (1024 * 1024)
+            LOGGER.info(
+                "subsystem=model_server url=%s model=%s size_mb=%d vram_mb=%d",
+                url,
+                name,
+                size_mb,
+                vram_mb,
+            )
+
+        if len(cats) > 1:
+            LOGGER.info(
+                "subsystem=model_server url=%s shared_by=%d categories=%s "
+                "note=model_swapping_may_add_latency",
+                url,
+                len(cats),
+                ",".join(sorted(cats)),
+            )
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: HGAConfigEntry) -> bool:  # noqa: C901, PLR0912, PLR0915
     """Set up Home Generative Agent from a config entry."""
     hass.data.setdefault(DOMAIN, {})
@@ -1173,6 +1233,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: HGAConfigEntry) -> bool:
 
     _utils_mod._chat_active_count = 0  # noqa: SLF001
     _utils_mod._chat_idle.set()  # noqa: SLF001
+    _utils_mod._video_active_count = 0  # noqa: SLF001
+    _utils_mod._video_idle.set()  # noqa: SLF001
     _utils_mod._sentinel_last_run = 0.0  # noqa: SLF001
     _utils_mod._sentinel_first_defer = 0.0  # noqa: SLF001
     _utils_mod._sentinel_defer_count = 0  # noqa: SLF001
@@ -1902,6 +1964,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: HGAConfigEntry) -> bool:
         hass.data[DOMAIN]["http_registered"] = True
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    if ollama_any_ok:
+        ollama_probe_urls: dict[str, str] = {
+            "chat": ollama_chat_url,
+            "vlm": ollama_vlm_url,
+            "summarization": ollama_sum_url,
+        }
+        if embedding_provider not in {"openai", "openai_compatible", "gemini"}:
+            ollama_probe_urls["embeddings"] = base_ollama_url
+        hass.async_create_task(_log_ollama_server_info(hass, ollama_probe_urls))
 
     if options.get(CONF_VIDEO_ANALYZER_MODE) != "disable":
         video_analyzer.start()

--- a/custom_components/home_generative_agent/const.py
+++ b/custom_components/home_generative_agent/const.py
@@ -364,7 +364,12 @@ RECOMMENDED_OLLAMA_VLM: VLM_OLLAMA_SUPPORTED = "qwen3-vl:8b"
 CONF_OLLAMA_VLM_KEEPALIVE = "ollama_vlm_keepalive"
 RECOMMENDED_OLLAMA_VLM_KEEPALIVE: KeepAliveSeconds = 300
 CONF_OLLAMA_VLM_CONTEXT_SIZE = "ollama_vlm_context_size"
-VLM_NUM_PREDICT = -2  # Ollama only, -2 = fill context
+VLM_NUM_PREDICT = (
+    -2
+)  # Ollama only, -2 = fill context; do not change — governs ad-hoc agent image analysis
+VIDEO_VLM_NUM_PREDICT: int = (
+    256  # video-role token limit (see video-sentinel-priority-plan.md)
+)
 VLM_REPEAT_PENALTY = 1.05  # Ollama only
 VLM_MIRO_STAT = 0  # Ollama only
 
@@ -455,7 +460,12 @@ RECOMMENDED_OLLAMA_SUMMARIZATION_MODEL: SUMMARIZATION_MODEL_OLLAMA_SUPPORTED = (
 CONF_OLLAMA_SUMMARIZATION_KEEPALIVE = "ollama_summarization_keepalive"
 RECOMMENDED_OLLAMA_SUMMARIZATION_KEEPALIVE: KeepAliveSeconds = 300
 CONF_OLLAMA_SUMMARIZATION_CONTEXT_SIZE = "ollama_summarization_context_size"
-SUMMARIZATION_MODEL_PREDICT = -2  # Ollama only, -2 = fill context
+SUMMARIZATION_MODEL_PREDICT = (
+    -2
+)  # Ollama only, -2 = fill context; do not change — governs conversation summarization
+VIDEO_SUMMARY_NUM_PREDICT: int = (
+    128  # video-role token limit (see video-sentinel-priority-plan.md)
+)
 SUMMARIZATION_MODEL_REPEAT_PENALTY = 1.05  # Ollama only
 SUMMARIZATION_MIRO_STAT = 0  # Ollama only
 
@@ -523,6 +533,20 @@ EMBEDDING_MODEL_CTX = 512
 EMBEDDING_MODEL_PROMPT_TEMPLATE = """
 Represent this sentence for searching relevant passages: {query}
 """
+
+# ---------------- Model provider contention gate ----------------
+# When True, the integration bypasses the video semaphore, video foreground
+# context, and Sentinel deferral.  Set True for dedicated high-capacity servers
+# that do not need local resource protection.
+# Currently read from global entry options (not per-provider subentry).
+CONF_MODEL_PROVIDER_UNCONTENDED = "model_provider_uncontended"
+RECOMMENDED_MODEL_PROVIDER_UNCONTENDED: bool = False
+
+# ---------------- Video model concurrency ----------------
+# Semaphore size for concurrent video model calls (VLM + summary) per entry.
+# Read from the video feature config subentry; this is the fallback default.
+CONF_VIDEO_MODEL_SEMAPHORE = "video_model_semaphore"
+RECOMMENDED_VIDEO_MODEL_SEMAPHORE: int = 1
 
 # ---------------- OpenAI-compatible endpoint (edge) ----------------
 CONF_OPENAI_COMPATIBLE_BASE_URL = "openai_compatible_base_url"

--- a/custom_components/home_generative_agent/core/utils.py
+++ b/custom_components/home_generative_agent/core/utils.py
@@ -147,30 +147,39 @@ def configured_ollama_urls(
 # ---------------------------------------------------------------------------
 # Deployment-aware admission control
 # ---------------------------------------------------------------------------
-# Policy:
-#   Chat (edge)      — marks the full turn active via local_chat_session so
-#                      Sentinel can observe chat activity and defer.
-#   Sentinel (edge)  — calls sentinel_admission before every LLM invocation;
-#                      defers (skips) if chat is active.
-#   Video / embeds   — no chat gate; video tuning constants are the surface
-#                      for managing GPU contention on weak hardware.
-#   Cloud providers  — bypass all local gates.
+# Priority order (highest to lowest):
+#   1. Chat (edge)      — marks the full turn active via local_chat_session.
+#                         Cancels in-flight Sentinel LLM tasks on entry.
+#   2. Video (edge)     — marks video model calls active via local_video_session.
+#                         Defers Sentinel LLM tasks for the entire duration:
+#                         chat-wait + semaphore-wait + model-call.  This is
+#                         intentional — video reserves its slot from entry so
+#                         Sentinel cannot interleave with a pending video turn.
+#   3. Sentinel (edge)  — calls sentinel_admission before every LLM invocation;
+#                         defers if chat OR video is active.
+#   Cloud providers     — bypass all local gates.
 # ---------------------------------------------------------------------------
 
 _chat_idle = asyncio.Event()
 _chat_idle.set()  # "no chat active" by default
 _chat_active_count: int = 0
 
+_video_idle = asyncio.Event()
+_video_idle.set()  # "no video active" by default
+_video_active_count: int = 0
+
 _sentinel_last_run: float = 0.0  # monotonic timestamp of last admitted run
 _sentinel_first_defer: float = 0.0
 _sentinel_defer_count: int = 0
+_sentinel_admissions_deferred_chat: int = 0
+_sentinel_admissions_deferred_video: int = 0
 _SENTINEL_STARVATION_WARN_S: float = 300.0
 _SENTINEL_CANCEL_WAIT_S: float = 2.0
 _sentinel_llm_tasks: set[asyncio.Future[Any]] = set()
 
-# Public constant: maximum seconds a Sentinel LLM call waits for chat to become
-# idle before deferring.  All callers (triage, discovery, explain) use the same
-# value so policy changes need only one edit.
+# Public constant: maximum seconds a Sentinel LLM call waits for chat or video
+# to become idle before deferring.  All callers (triage, discovery, explain)
+# use the same value so policy changes need only one edit.
 SENTINEL_ADMISSION_TIMEOUT_S: float = 2.0
 
 
@@ -219,6 +228,51 @@ async def local_chat_session(
         )
 
 
+@contextlib.asynccontextmanager
+async def local_video_session(deployment: str) -> AsyncIterator[None]:
+    """
+    Mark a local video model call active for its duration.
+
+    Clears _video_idle so Sentinel admission can detect and defer.
+    Reference-counted: deferral lifts only when the last concurrent video
+    context exits.  No-op when CONF_MODEL_PROVIDER_UNCONTENDED is True
+    (caller is responsible for checking) or for cloud deployments.
+    The try/finally guarantees the flag resets on cancellation or exception.
+    """
+    if not is_edge_deployment(deployment):
+        yield
+        return
+    global _video_active_count  # noqa: PLW0603
+    _video_active_count += 1
+    _video_idle.clear()
+    try:
+        LOGGER.debug("Video session active (deployment=%s).", deployment)
+        yield
+    finally:
+        _video_active_count -= 1
+        if _video_active_count == 0:
+            _video_idle.set()
+        LOGGER.debug("Video session ended (deployment=%s).", deployment)
+
+
+def video_is_active() -> bool:
+    """Return True if any video model call is currently in progress."""
+    return not _video_idle.is_set()
+
+
+async def wait_for_chat_idle(timeout_s: float) -> bool:
+    """Wait for chat to become idle. Returns True when idle, False on timeout."""
+    if _chat_idle.is_set():
+        return True
+    try:
+        async with asyncio.timeout(timeout_s):
+            await _chat_idle.wait()
+    except TimeoutError:
+        return False
+    else:
+        return True
+
+
 async def _cancel_active_sentinel_llm_tasks(category: str) -> None:
     """Cancel in-flight Sentinel LLM HTTP calls before foreground chat proceeds."""
     tasks = [task for task in _sentinel_llm_tasks if not task.done()]
@@ -254,14 +308,15 @@ async def sentinel_admission(
     """
     Return True if a Sentinel LLM call may proceed.
 
-    Edge: waits up to timeout_s for chat to become idle; returns False if still
-    active so the caller can defer the pass.
+    Edge: waits up to timeout_s for both chat and video to become idle; returns
+    False if either is still active so the caller can defer the pass.
     Cloud: always admitted.
     Tracks last-admitted timestamp and consecutive deferral count for health
     monitoring; logs a WARNING when Sentinel has been starved beyond the
     starvation threshold.
     """
     global _sentinel_first_defer, _sentinel_last_run, _sentinel_defer_count  # noqa: PLW0603
+    global _sentinel_admissions_deferred_chat, _sentinel_admissions_deferred_video  # noqa: PLW0603
     if not is_edge_deployment(deployment):
         _sentinel_last_run = time.monotonic()
         _sentinel_first_defer = 0.0
@@ -272,11 +327,25 @@ async def sentinel_admission(
             health_stats["sentinel_admission_consecutive_deferrals"] = 0
             health_stats["sentinel_admission_starved_for_s"] = 0
         return True
+
     try:
         async with asyncio.timeout(timeout_s):
-            await _chat_idle.wait()
+            # Both events must be set (idle) before Sentinel may proceed.
+            await asyncio.gather(_chat_idle.wait(), _video_idle.wait())
     except TimeoutError:
+        # Re-evaluate after timeout: both could still be blocking.
+        chat_blocking = not _chat_idle.is_set()
+        video_blocking = not _video_idle.is_set()
+        defer_reason = (
+            "chat_and_video_active"
+            if chat_blocking and video_blocking
+            else ("chat_active" if chat_blocking else "video_active")
+        )
         _sentinel_defer_count += 1
+        if chat_blocking:
+            _sentinel_admissions_deferred_chat += 1
+        if video_blocking:
+            _sentinel_admissions_deferred_video += 1
         now = time.monotonic()
         if _sentinel_first_defer <= 0:
             _sentinel_first_defer = now
@@ -303,8 +372,10 @@ async def sentinel_admission(
             )
         else:
             LOGGER.debug(
-                "Sentinel %s deferred (chat active); consecutive deferrals=%d.",
+                "sentinel_admission category=%s decision=deferred reason=%s "
+                "consecutive_deferrals=%d",
                 category,
+                defer_reason,
                 _sentinel_defer_count,
             )
         return False
@@ -316,7 +387,20 @@ async def sentinel_admission(
         health_stats["sentinel_admission_degraded_category"] = None
         health_stats["sentinel_admission_consecutive_deferrals"] = 0
         health_stats["sentinel_admission_starved_for_s"] = 0
+    LOGGER.debug("sentinel_admission category=%s decision=admitted", category)
     return True
+
+
+def sentinel_admission_counters() -> dict[str, int]:
+    """Return and reset Sentinel admission deferral counters since last call."""
+    global _sentinel_admissions_deferred_chat, _sentinel_admissions_deferred_video  # noqa: PLW0603
+    result = {
+        "deferred_chat": _sentinel_admissions_deferred_chat,
+        "deferred_video": _sentinel_admissions_deferred_video,
+    }
+    _sentinel_admissions_deferred_chat = 0
+    _sentinel_admissions_deferred_video = 0
+    return result
 
 
 async def run_sentinel_llm_call(  # noqa: PLR0913

--- a/custom_components/home_generative_agent/core/video_analyzer.py
+++ b/custom_components/home_generative_agent/core/video_analyzer.py
@@ -27,8 +27,11 @@ from PIL import Image
 
 from ..agent.tools import analyze_image  # noqa: TID252
 from ..const import (  # noqa: TID252
+    CONF_MODEL_PROVIDER_UNCONTENDED,
     CONF_NOTIFY_SERVICE,
     CONF_VIDEO_ANALYZER_MODE,
+    CONF_VIDEO_MODEL_SEMAPHORE,
+    RECOMMENDED_VIDEO_MODEL_SEMAPHORE,
     SIGNAL_HGA_NEW_LATEST,
     SIGNAL_HGA_RECOGNIZED,
     VIDEO_ANALYZER_FACE_CROP,
@@ -43,11 +46,16 @@ from ..const import (  # noqa: TID252
     VIDEO_ANALYZER_SYSTEM_MESSAGE,
     VIDEO_ANALYZER_TIME_OFFSET,
     VIDEO_ANALYZER_TRIGGER_ON_MOTION,
+    VIDEO_SUMMARY_NUM_PREDICT,
+    VIDEO_VLM_NUM_PREDICT,
 )
 from .utils import (
     discover_mobile_notify_service,
     dispatch_on_loop,
     extract_final,
+    is_edge_deployment,
+    local_video_session,
+    wait_for_chat_idle,
 )
 from .video_helpers import (
     apply_name_substitution,
@@ -84,6 +92,12 @@ _FRAME_DEADLINE_SEC: Final[int] = 600  # skip frames older than this
 _SUMMARY_TIMEOUT_SEC: Final[int] = 60  # was 35
 _FACE_TIMEOUT_SEC: Final[int] = 10  # was 10 (keep)
 _VISION_TIMEOUT_SEC: Final[int] = 90  # was 30
+_VIDEO_MODEL_SEMAPHORE_WAIT_SEC: Final[int] = (
+    30  # max wait for semaphore before dropping
+)
+_VIDEO_QUEUE_BACKLOG_THRESHOLD: Final[int] = (
+    2  # drop stale frames when queue exceeds this
+)
 # --- Uniqueness gate tuning ---
 _UNIQUENESS_ENABLED: Final[bool] = False
 _UNIQUENESS_HAMMING_MAX: Final[int] = 4  # <= this => "too similar" (tune 4-10)
@@ -96,13 +110,21 @@ _METRICS_LAT_HISTORY: Final[int] = 512  # keep up to 512 lat samples per camera
 
 
 @dataclass
+class _SnapshotItem:
+    path: Path
+    enqueued: float  # monotonic() at enqueue time
+
+
+@dataclass
 class _Metrics:
     captured: int = 0
     enqueued: int = 0
     skipped_duplicate: int = 0
     dropped_stale: int = 0
+    dropped_backlog: int = 0
     analyzed: int = 0
     timeouts: int = 0
+    semaphore_timeouts: int = 0
     # PEP 585: deque is subscriptable; keep in a field to avoid shared default
     lat_ms: deque[float] = field(
         default_factory=lambda: deque(maxlen=_METRICS_LAT_HISTORY)
@@ -116,7 +138,7 @@ class VideoAnalyzer:
         """Initialize the video analyzer."""
         self.hass = hass
         self.entry = entry
-        self._snapshot_queues: dict[str, asyncio.Queue[Path]] = {}
+        self._snapshot_queues: dict[str, asyncio.Queue[_SnapshotItem]] = {}
         self._retention_deques: dict[str, deque[Path]] = {}
         self._active_queue_tasks: dict[str, asyncio.Task] = {}
         self._initialized_dirs: set[str] = set()
@@ -136,6 +158,8 @@ class VideoAnalyzer:
         self._metrics_job_cancel: Callable[[], None] | None = (
             None  # hourly report handle
         )
+        # Initialized in start() once runtime_data.options is available.
+        self._video_model_sem: asyncio.Semaphore | None = None
 
     def _pctl(self, values: Iterable[float], q: float) -> float:
         """Nearest-rank percentile for a finite iterable."""
@@ -160,10 +184,14 @@ class VideoAnalyzer:
             m.skipped_duplicate += n
         elif key == "dropped_stale":
             m.dropped_stale += n
+        elif key == "dropped_backlog":
+            m.dropped_backlog += n
         elif key == "analyzed":
             m.analyzed += n
         elif key == "timeouts":
             m.timeouts += n
+        elif key == "semaphore_timeout":
+            m.semaphore_timeouts += n
         else:
             # ignore unknown keys silently to avoid noisy logs in prod
             return
@@ -182,7 +210,8 @@ class VideoAnalyzer:
             msg = (
                 "[%s] Metrics (last interval): "
                 "captured=%d enqueued=%d skipped_duplicate=%d "
-                "dropped_stale=%d analyzed=%d timeouts=%d "
+                "dropped_stale=%d dropped_backlog=%d analyzed=%d "
+                "timeouts=%d semaphore_timeouts=%d "
                 "avg_latency_ms=%.1f p95_latency_ms=%.1f"
             )
             LOGGER.info(
@@ -192,8 +221,10 @@ class VideoAnalyzer:
                 m.enqueued,
                 m.skipped_duplicate,
                 m.dropped_stale,
+                m.dropped_backlog,
                 m.analyzed,
                 m.timeouts,
+                m.semaphore_timeouts,
                 avg_ms,
                 p95_ms,
             )
@@ -203,8 +234,10 @@ class VideoAnalyzer:
             m.enqueued = 0
             m.skipped_duplicate = 0
             m.dropped_stale = 0
+            m.dropped_backlog = 0
             m.analyzed = 0
             m.timeouts = 0
+            m.semaphore_timeouts = 0
             m.lat_ms.clear()
 
     def protect_notify_image(self, p: Path, ttl_sec: int = 1800) -> None:
@@ -220,9 +253,9 @@ class VideoAnalyzer:
             self._notify_protected.pop(k, None)
         return self._notify_protected.get(p, 0) > now
 
-    def _get_snapshot_queue(self, camera_id: str) -> asyncio.Queue[Path]:
+    def _get_snapshot_queue(self, camera_id: str) -> asyncio.Queue[_SnapshotItem]:
         if camera_id not in self._snapshot_queues:
-            queue: asyncio.Queue[Path] = asyncio.Queue(maxsize=_QUEUE_MAXSIZE)
+            queue: asyncio.Queue[_SnapshotItem] = asyncio.Queue(maxsize=_QUEUE_MAXSIZE)
             self._snapshot_queues[camera_id] = queue
             task = self.hass.async_create_task(self._snapshot_worker(camera_id))
             self._active_queue_tasks[camera_id] = task
@@ -230,17 +263,34 @@ class VideoAnalyzer:
 
     async def _get_batch(
         self,
-        queue: asyncio.Queue[Path],
+        queue: asyncio.Queue[_SnapshotItem],
         camera_id: str,
         *,
         max_batch: int = _MAX_BATCH,
     ) -> list[Path]:
-        first: Path = await queue.get()
-        batch: list[Path] = [first]
+        first: _SnapshotItem = await queue.get()
 
-        n: int = max(max_batch - 1, 0)
-        with contextlib.suppress(asyncio.QueueEmpty):
-            batch.extend(queue.get_nowait() for _ in range(n))
+        # Backlog policy: when the queue is deep, keep only the newest frame.
+        if queue.qsize() > _VIDEO_QUEUE_BACKLOG_THRESHOLD:
+            pending: list[_SnapshotItem] = [first]
+            with contextlib.suppress(asyncio.QueueEmpty):
+                while True:
+                    pending.append(queue.get_nowait())
+            kept = max(pending, key=lambda it: it.enqueued)
+            dropped = len(pending) - 1
+            self._m_inc(camera_id, "dropped_backlog", dropped)
+            LOGGER.debug(
+                "video_backlog camera=%s dropped=%d kept=1",
+                camera_id,
+                dropped,
+            )
+            batch: list[Path] = [kept.path]
+        else:
+            batch = [first.path]
+            n: int = max(max_batch - 1, 0)
+            with contextlib.suppress(asyncio.QueueEmpty):
+                for _ in range(n):
+                    batch.append(queue.get_nowait().path)
 
         LOGGER.debug(
             "[%s] Start t=%s batch=%d qsize=%d",
@@ -285,20 +335,77 @@ class VideoAnalyzer:
         )
         return frame_descriptions, recognized
 
-    async def _summarize(
+    async def _summarize(  # noqa: PLR0911
         self, camera_id: str, frame_descriptions: list[dict[str, list[str]]]
     ) -> str | None:
         if not frame_descriptions:
             return None
-        try:
-            async with asyncio.timeout(_SUMMARY_TIMEOUT_SEC):
-                msg: str = await self._generate_summary(frame_descriptions)
-        except TimeoutError as exc:
-            LOGGER.warning("[%s] Summary timed out: %s", camera_id, exc)
-            return None
+
+        sum_deployment = self.entry.runtime_data.model_deployments.get(
+            "summarization", "edge"
+        )
+        uncontended = self.entry.runtime_data.options.get(
+            CONF_MODEL_PROVIDER_UNCONTENDED, False
+        )
+        use_gate = is_edge_deployment(sum_deployment) and not uncontended
+
+        if use_gate:
+            sem = self._video_model_sem
+            if sem is None:
+                msg = "Video model semaphore not initialized."
+                raise RuntimeError(msg)
+            async with local_video_session(sum_deployment):
+                # Sentinel defers from here; chat must clear before the model call.
+                if not await wait_for_chat_idle(_VIDEO_MODEL_SEMAPHORE_WAIT_SEC):
+                    LOGGER.debug("video_chat_wait summary result=timeout")
+                    return None
+                t_sem = monotonic()
+                try:
+                    async with asyncio.timeout(_VIDEO_MODEL_SEMAPHORE_WAIT_SEC):
+                        await sem.acquire()
+                except TimeoutError:
+                    LOGGER.debug(
+                        "video_semaphore summary wait=%ds result=timeout",
+                        _VIDEO_MODEL_SEMAPHORE_WAIT_SEC,
+                    )
+                    self._m_inc(camera_id, "semaphore_timeout")
+                    return None
+                LOGGER.debug(
+                    "video_semaphore summary wait=%.1fs result=acquired",
+                    monotonic() - t_sem,
+                )
+                t_model = monotonic()
+                try:
+                    try:
+                        async with asyncio.timeout(_SUMMARY_TIMEOUT_SEC):
+                            summary_text: str = await self._generate_summary(
+                                frame_descriptions
+                            )
+                    except TimeoutError as exc:
+                        LOGGER.warning("[%s] Summary timed out: %s", camera_id, exc)
+                        return None
+                    except ValueError as exc:
+                        LOGGER.warning("[%s] Summary failed: %s", camera_id, exc)
+                        return None
+                finally:
+                    sem.release()
+                LOGGER.debug(
+                    "video_model op=summary elapsed=%.1fs result=ok",
+                    monotonic() - t_model,
+                )
         else:
-            LOGGER.debug("[%s] Video analysis: %s", camera_id, msg)
-            return msg
+            try:
+                async with asyncio.timeout(_SUMMARY_TIMEOUT_SEC):
+                    summary_text = await self._generate_summary(frame_descriptions)
+            except TimeoutError as exc:
+                LOGGER.warning("[%s] Summary timed out: %s", camera_id, exc)
+                return None
+            except ValueError as exc:
+                LOGGER.warning("[%s] Summary failed: %s", camera_id, exc)
+                return None
+
+        LOGGER.debug("[%s] Video analysis: %s", camera_id, summary_text)
+        return summary_text
 
     async def _finalize(self, camera_id: str, batch: list[Path], msg: str) -> None:
         await self._handle_notification(camera_id, msg, batch)
@@ -431,9 +538,16 @@ class VideoAnalyzer:
             SystemMessage(content=VIDEO_ANALYZER_SYSTEM_MESSAGE),
             HumanMessage(content=prompt),
         ]
-        model = self.entry.runtime_data.summarization_model
-        async with asyncio.timeout(_SUMMARY_TIMEOUT_SEC):
-            summary = await model.ainvoke(messages)
+        sum_deployment = self.entry.runtime_data.model_deployments.get(
+            "summarization", "edge"
+        )
+        base_sum = self.entry.runtime_data.summarization_model
+        sum_cfg = dict(getattr(base_sum, "config", {}).get("configurable", {}))
+        sum_cfg["num_predict"] = VIDEO_SUMMARY_NUM_PREDICT
+        if is_edge_deployment(sum_deployment):
+            sum_cfg["reasoning"] = False
+        model = base_sum.with_config(config={"configurable": sum_cfg})
+        summary = await model.ainvoke(messages)
         LOGGER.debug("Raw video analyzer summary: %s", summary)
 
         text = extract_final(getattr(summary, "content", "") or "", max_chars=150)
@@ -612,17 +726,17 @@ class VideoAnalyzer:
         else:
             LOGGER.exception("[%s] Unexpected error analyzing %s.", camera_id, path)
 
-    def _drain_queue(self, queue: asyncio.Queue[Path]) -> list[Path]:
+    def _drain_queue(self, queue: asyncio.Queue[_SnapshotItem]) -> list[Path]:
         """Drain all items from the asyncio queue into a list."""
         batch: list[Path] = []
         try:
             while True:
-                batch.append(queue.get_nowait())
+                batch.append(queue.get_nowait().path)
         except asyncio.QueueEmpty:
             pass
         return batch
 
-    async def _process_snapshot(
+    async def _process_snapshot(  # noqa: PLR0911, PLR0912, PLR0915
         self, path: Path, camera_id: str, prev_text: str | None = None
     ) -> dict[str, list[str]]:
         """Process a single snapshot: recognize faces and describe the frame."""
@@ -655,14 +769,67 @@ class VideoAnalyzer:
                 faces_in_frame = []
 
             try:
-                vision_model = self.entry.runtime_data.vision_model
-                async with asyncio.timeout(_VISION_TIMEOUT_SEC):
-                    frame_description = await analyze_image(
-                        vision_model,
-                        data,
-                        None,
-                        prev_text=prev_text,
-                    )
+                vlm_deployment = self.entry.runtime_data.model_deployments.get(
+                    "vlm", "edge"
+                )
+                uncontended = self.entry.runtime_data.options.get(
+                    CONF_MODEL_PROVIDER_UNCONTENDED, False
+                )
+                use_gate = is_edge_deployment(vlm_deployment) and not uncontended
+                base_vlm = self.entry.runtime_data.vision_model
+                vlm_cfg = dict(getattr(base_vlm, "config", {}).get("configurable", {}))
+                vlm_cfg["num_predict"] = VIDEO_VLM_NUM_PREDICT
+                if is_edge_deployment(vlm_deployment):
+                    vlm_cfg["reasoning"] = False
+                vision_model = base_vlm.with_config(config={"configurable": vlm_cfg})
+                if use_gate:
+                    sem = self._video_model_sem
+                    if sem is None:
+                        return {}
+                    async with local_video_session(vlm_deployment):
+                        # Sentinel defers; chat must clear before model call.
+                        if not await wait_for_chat_idle(
+                            _VIDEO_MODEL_SEMAPHORE_WAIT_SEC
+                        ):
+                            LOGGER.debug(
+                                "video_chat_wait camera=%s result=timeout", camera_id
+                            )
+                            return {}
+                        t_sem = monotonic()
+                        try:
+                            async with asyncio.timeout(_VIDEO_MODEL_SEMAPHORE_WAIT_SEC):
+                                await sem.acquire()
+                        except TimeoutError:
+                            LOGGER.debug(
+                                "video_semaphore camera=%s wait=%ds result=timeout",
+                                camera_id,
+                                _VIDEO_MODEL_SEMAPHORE_WAIT_SEC,
+                            )
+                            self._m_inc(camera_id, "semaphore_timeout")
+                            return {}
+                        LOGGER.debug(
+                            "video_semaphore camera=%s wait=%.1fs result=acquired",
+                            camera_id,
+                            monotonic() - t_sem,
+                        )
+                        t_model = monotonic()
+                        try:
+                            async with asyncio.timeout(_VISION_TIMEOUT_SEC):
+                                frame_description = await analyze_image(
+                                    vision_model, data, None, prev_text=prev_text
+                                )
+                        finally:
+                            sem.release()
+                        LOGGER.debug(
+                            "video_model camera=%s op=frame elapsed=%.1fs result=ok",
+                            camera_id,
+                            monotonic() - t_model,
+                        )
+                else:
+                    async with asyncio.timeout(_VISION_TIMEOUT_SEC):
+                        frame_description = await analyze_image(
+                            vision_model, data, None, prev_text=prev_text
+                        )
             except TimeoutError as exc:
                 self._m_inc(camera_id, "timeouts")
                 self._log_snapshot_error(camera_id, path, exc)
@@ -761,7 +928,9 @@ class VideoAnalyzer:
 
     async def _process_snapshot_queue(self, camera_id: str) -> None:
         """Flush any queued snapshots for a camera as one ordered batch."""
-        queue: asyncio.Queue[Path] | None = self._snapshot_queues.get(camera_id)
+        queue: asyncio.Queue[_SnapshotItem] | None = self._snapshot_queues.get(
+            camera_id
+        )
         if not queue:
             return
 
@@ -912,7 +1081,9 @@ class VideoAnalyzer:
                 )
                 return None
 
-            await put_with_backpressure(queue, path)
+            await put_with_backpressure(
+                queue, _SnapshotItem(path=path, enqueued=monotonic())
+            )
             self._m_inc(camera_id, "enqueued")
             LOGGER.debug(
                 "[%s] Enqueue t=%s %s", camera_id, dt_util.utcnow().isoformat(), path
@@ -1001,6 +1172,22 @@ class VideoAnalyzer:
             LOGGER.warning("VideoAnalyzer already started.")
             return
 
+        # Build the video model semaphore now that runtime_data.options is set.
+        sem_size = max(
+            1,
+            int(
+                self.entry.runtime_data.options.get(
+                    CONF_VIDEO_MODEL_SEMAPHORE, RECOMMENDED_VIDEO_MODEL_SEMAPHORE
+                )
+            ),
+        )
+        self._video_model_sem = asyncio.Semaphore(sem_size)
+        LOGGER.info(
+            "subsystem=video_analyzer video_model_semaphore=%d uncontended=%s",
+            sem_size,
+            self.entry.runtime_data.options.get(CONF_MODEL_PROVIDER_UNCONTENDED, False),
+        )
+
         # Create a reusable httpx client for face API
         if self._httpx_client is None:
             self._httpx_client = httpx.AsyncClient(timeout=_FACE_TIMEOUT_SEC)
@@ -1046,6 +1233,10 @@ class VideoAnalyzer:
             task.cancel()
             tasks_to_await.append(task)
         self._active_queue_tasks.clear()
+
+        # Orphan the semaphore reference; tasks already cancelled above will
+        # absorb CancelledError and exit — not released by this None assignment.
+        self._video_model_sem = None
 
         try:
             self._cancel_track()

--- a/custom_components/home_generative_agent/core/video_helpers.py
+++ b/custom_components/home_generative_agent/core/video_helpers.py
@@ -169,14 +169,14 @@ def order_batch(batch: list[Path]) -> list[tuple[Path, int]]:
     return sorted(((p, epoch_from_path(p)) for p in batch), key=lambda x: x[1])
 
 
-async def put_with_backpressure(q: asyncio.Queue[Path], p: Path) -> None:
+async def put_with_backpressure[T](q: asyncio.Queue[T], item: T) -> None:
     """Put item into queue, dropping oldest if full."""
     if q.full():
         with contextlib.suppress(asyncio.QueueEmpty):
             _ = q.get_nowait()
             q.task_done()
-        _LOGGER.debug("Queue full; dropped oldest to enqueue %s", p)
-    await q.put(p)
+        _LOGGER.debug("Queue full; dropped oldest item.")
+    await q.put(item)
 
 
 def _camera_fs_dir(root: Path, camera_id: str) -> Path:

--- a/tests/custom_components/home_generative_agent/test_video_analyzer_priority.py
+++ b/tests/custom_components/home_generative_agent/test_video_analyzer_priority.py
@@ -1,0 +1,687 @@
+# ruff: noqa: S101, S108, PYI034
+"""
+Tests for video analyzer priority management.
+
+Covers (test plan items):
+- Queue item record preserves path and adds enqueue timestamp
+- Stale-frame backlog policy: frames beyond threshold dropped, newest kept
+- Stale-frame evaluation occurs before semaphore acquisition
+- Semaphore acquisition timeout causes frame drop rather than 90 s wait
+- Semaphore timeout increments the semaphore_timeouts counter
+- VLM calls include bounded num_predict matching VIDEO_VLM_NUM_PREDICT
+- VLM calls pass reasoning=False via configurable
+- Summarization calls include bounded num_predict matching VIDEO_SUMMARY_NUM_PREDICT
+- Summarization calls pass reasoning=False via configurable
+- VLM frame analysis and summary generation share the same semaphore concurrency limit
+- Startup logs video_model_semaphore size and uncontended flag
+- Startup capability probe logs model/memory data when available
+- Startup capability probe falls back silently when probe fails
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import custom_components.home_generative_agent.core.utils as utils_mod
+import custom_components.home_generative_agent.core.video_analyzer as va_mod
+from custom_components.home_generative_agent import NullChat, _log_ollama_server_info
+from custom_components.home_generative_agent.const import (
+    VIDEO_SUMMARY_NUM_PREDICT,
+    VIDEO_VLM_NUM_PREDICT,
+)
+from custom_components.home_generative_agent.core.video_analyzer import (
+    _VIDEO_QUEUE_BACKLOG_THRESHOLD,
+    VideoAnalyzer,
+    _SnapshotItem,
+)
+from custom_components.home_generative_agent.core.video_helpers import (
+    put_with_backpressure,
+)
+
+# ---------------------------------------------------------------------------
+# Override autouse fixtures from pytest-homeassistant-custom-component
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def enable_event_loop_debug() -> None:
+    """No-op override: pure-asyncio tests don't need HA's debug-mode hook."""
+
+
+@pytest.fixture(autouse=True)
+def verify_cleanup() -> None:
+    """No-op override: all tasks explicitly awaited; no HA resources to clean up."""
+
+
+# ---------------------------------------------------------------------------
+# Reset gate primitives that video sessions touch
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+async def _fresh_gate_primitives(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reset admission-control globals before each test."""
+    video_idle = asyncio.Event()
+    video_idle.set()
+    chat_idle = asyncio.Event()
+    chat_idle.set()
+
+    monkeypatch.setattr(utils_mod, "_video_idle", video_idle)
+    monkeypatch.setattr(utils_mod, "_video_active_count", 0)
+    monkeypatch.setattr(utils_mod, "_chat_idle", chat_idle)
+    monkeypatch.setattr(utils_mod, "_chat_active_count", 0)
+
+
+# ---------------------------------------------------------------------------
+# Minimal fake async file for aiofiles.open mocking
+# ---------------------------------------------------------------------------
+
+
+class _FakeImageFile:
+    """Async context manager that mimics an aiofiles file handle."""
+
+    BYTES = b"\xff\xd8\xff\xe0" + b"\x00" * 20  # minimal JPEG-like header
+
+    async def read(self) -> bytes:
+        return self.BYTES
+
+    async def __aenter__(self) -> _FakeImageFile:
+        return self
+
+    async def __aexit__(self, *args: object) -> bool:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: minimal VideoAnalyzer
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def entry() -> MagicMock:
+    """Config entry stub with runtime_data defaults."""
+    e = MagicMock()
+    e.runtime_data.options = {}
+    e.runtime_data.model_deployments.get.return_value = "cloud"
+    e.runtime_data.face_recognition = False
+
+    configured_vlm: Any = MagicMock()
+    configured_vlm.ainvoke = AsyncMock(return_value=MagicMock(content="frame desc"))
+    e.runtime_data.vision_model.with_config.return_value = configured_vlm
+    # Empty existing config so the video override dict is predictable in tests.
+    e.runtime_data.vision_model.config = {}
+
+    configured_sum: Any = MagicMock()
+    configured_sum.ainvoke = AsyncMock(
+        return_value=MagicMock(content="A person walks by.")
+    )
+    e.runtime_data.summarization_model.with_config.return_value = configured_sum
+    e.runtime_data.summarization_model.config = {}
+
+    return e
+
+
+@pytest.fixture
+def hass() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def va(hass: MagicMock, entry: MagicMock) -> VideoAnalyzer:
+    """VideoAnalyzer with a pre-built semaphore (simulates post-start state)."""
+    analyzer = VideoAnalyzer(hass, entry)
+    analyzer._video_model_sem = asyncio.Semaphore(1)  # type: ignore[attr-defined]
+    return analyzer
+
+
+# ---------------------------------------------------------------------------
+# _SnapshotItem: queue item record
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_item_has_path_and_enqueued() -> None:
+    """Queue item record preserves path and adds enqueue timestamp."""
+    item = _SnapshotItem(path=Path("/tmp/snap.jpg"), enqueued=1_234_567.0)
+    assert item.path == Path("/tmp/snap.jpg")
+    assert item.enqueued == pytest.approx(1_234_567.0)
+
+
+def test_snapshot_item_path_remains_a_path() -> None:
+    """Path attribute is a Path, not a str."""
+    item = _SnapshotItem(path=Path("snapshot_20250101_120000.jpg"), enqueued=0.0)
+    assert isinstance(item.path, Path)
+
+
+# ---------------------------------------------------------------------------
+# put_with_backpressure: generic over _SnapshotItem
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_put_with_backpressure_accepts_snapshot_item() -> None:
+    """put_with_backpressure works with the new _SnapshotItem queue type."""
+    q: asyncio.Queue[_SnapshotItem] = asyncio.Queue(maxsize=2)
+    items = [
+        _SnapshotItem(path=Path(f"/tmp/snap_{i}.jpg"), enqueued=float(i))
+        for i in range(3)
+    ]
+    for item in items:
+        await put_with_backpressure(q, item)
+
+    # Queue held 2; the 3rd call should have dropped the oldest (index 0)
+    assert q.qsize() == 2
+    remaining = [q.get_nowait() for _ in range(2)]
+    assert remaining[0].path == Path("/tmp/snap_1.jpg")
+    assert remaining[1].path == Path("/tmp/snap_2.jpg")
+
+
+@pytest.mark.asyncio
+async def test_put_with_backpressure_empty_queue_no_drop() -> None:
+    """When queue is not full no item is dropped."""
+    q: asyncio.Queue[_SnapshotItem] = asyncio.Queue(maxsize=5)
+    item = _SnapshotItem(path=Path("/tmp/snap.jpg"), enqueued=1.0)
+    await put_with_backpressure(q, item)
+    assert q.qsize() == 1
+    assert q.get_nowait().path == Path("/tmp/snap.jpg")
+
+
+# ---------------------------------------------------------------------------
+# _get_batch: backlog policy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_batch_deep_queue_keeps_newest_frame(va: VideoAnalyzer) -> None:
+    """When queue depth exceeds threshold after first get, only newest is kept."""
+    q: asyncio.Queue[_SnapshotItem] = asyncio.Queue(maxsize=50)
+    t = 1_000.0
+    # 4 items: 1 is dequeued first, leaving 3 > _VIDEO_QUEUE_BACKLOG_THRESHOLD (2)
+    for i in range(4):
+        await q.put(_SnapshotItem(path=Path(f"/tmp/snap_{i}.jpg"), enqueued=t + i))
+
+    batch = await va._get_batch(q, "camera.test")  # type: ignore[attr-defined]
+
+    assert len(batch) == 1
+    assert batch[0] == Path("/tmp/snap_3.jpg")  # newest by enqueued time
+    assert va._metrics["camera.test"].dropped_backlog == 3  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_get_batch_shallow_queue_returns_all_frames(va: VideoAnalyzer) -> None:
+    """With queue at or below threshold, all frames are returned normally."""
+    q: asyncio.Queue[_SnapshotItem] = asyncio.Queue(maxsize=50)
+    t = 1_000.0
+    # 3 items: 1 is dequeued first, leaving 2 == threshold — no backlog drop
+    for i in range(3):
+        await q.put(_SnapshotItem(path=Path(f"/tmp/snap_{i}.jpg"), enqueued=t + i))
+
+    batch = await va._get_batch(q, "camera.test")  # type: ignore[attr-defined]
+
+    assert len(batch) == 3
+    assert va._metrics["camera.test"].dropped_backlog == 0  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_get_batch_backlog_threshold_constant_value() -> None:
+    """_VIDEO_QUEUE_BACKLOG_THRESHOLD is 2 (plan spec)."""
+    assert _VIDEO_QUEUE_BACKLOG_THRESHOLD == 2
+
+
+@pytest.mark.asyncio
+async def test_get_batch_single_item_no_backlog(va: VideoAnalyzer) -> None:
+    """Single-item queue is returned as-is without any drop."""
+    q: asyncio.Queue[_SnapshotItem] = asyncio.Queue(maxsize=50)
+    await q.put(_SnapshotItem(path=Path("/tmp/only.jpg"), enqueued=1.0))
+
+    batch = await va._get_batch(q, "camera.test")  # type: ignore[attr-defined]
+
+    assert batch == [Path("/tmp/only.jpg")]
+    assert va._metrics["camera.test"].dropped_backlog == 0  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# _process_snapshot: stale frame check before semaphore
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stale_frame_skips_semaphore(va: VideoAnalyzer) -> None:
+    """Stale frame returns {} immediately without calling semaphore.acquire."""
+    # Use a mock semaphore so we can assert acquire was never called
+    mock_sem = MagicMock()
+    mock_sem.acquire = AsyncMock()
+    va._video_model_sem = mock_sem  # type: ignore[attr-defined]
+    va.entry.runtime_data.model_deployments.get.return_value = "edge"
+
+    # Invalid path name → epoch_from_path raises ValueError → epoch=0 → stale
+    result = await va._process_snapshot(Path("not_a_snapshot.jpg"), "camera.test")  # type: ignore[attr-defined]
+
+    assert result == {}
+    assert va._metrics["camera.test"].dropped_stale == 1  # type: ignore[attr-defined]
+    mock_sem.acquire.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_stale_frame_does_not_open_file(va: VideoAnalyzer) -> None:
+    """Stale-frame path returns before trying to open the snapshot file."""
+    va.entry.runtime_data.model_deployments.get.return_value = "edge"
+
+    with patch("aiofiles.open", return_value=_FakeImageFile()) as mock_open:
+        await va._process_snapshot(Path("not_a_snapshot.jpg"), "camera.test")  # type: ignore[attr-defined]
+
+    mock_open.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _process_snapshot: semaphore timeout causes frame drop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_semaphore_timeout_causes_frame_drop(
+    va: VideoAnalyzer,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Semaphore acquisition timeout causes _process_snapshot to return {}."""
+    # 0-permit semaphore → any acquire blocks
+    va._video_model_sem = asyncio.Semaphore(0)  # type: ignore[attr-defined]
+    va.entry.runtime_data.model_deployments.get.return_value = "edge"
+    monkeypatch.setattr(va_mod, "_VIDEO_MODEL_SEMAPHORE_WAIT_SEC", 0.05)
+
+    with (
+        patch(
+            "custom_components.home_generative_agent.core.video_analyzer.epoch_from_path",
+            return_value=int(time.time()),
+        ),
+        patch("aiofiles.open", return_value=_FakeImageFile()),
+    ):
+        result = await va._process_snapshot(  # type: ignore[attr-defined]
+            Path("snapshot_20250101_120000.jpg"), "camera.test"
+        )
+
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_semaphore_timeout_increments_counter(
+    va: VideoAnalyzer,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Semaphore timeout increments semaphore_timeouts metric."""
+    va._video_model_sem = asyncio.Semaphore(0)  # type: ignore[attr-defined]
+    va.entry.runtime_data.model_deployments.get.return_value = "edge"
+    monkeypatch.setattr(va_mod, "_VIDEO_MODEL_SEMAPHORE_WAIT_SEC", 0.05)
+
+    with (
+        patch(
+            "custom_components.home_generative_agent.core.video_analyzer.epoch_from_path",
+            return_value=int(time.time()),
+        ),
+        patch("aiofiles.open", return_value=_FakeImageFile()),
+    ):
+        await va._process_snapshot(  # type: ignore[attr-defined]
+            Path("snapshot_20250101_120000.jpg"), "camera.test"
+        )
+
+    assert va._metrics["camera.test"].semaphore_timeouts == 1  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# _process_snapshot: VLM num_predict and reasoning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_vlm_call_uses_video_vlm_num_predict(va: VideoAnalyzer) -> None:
+    """VLM frame analysis is configured with VIDEO_VLM_NUM_PREDICT."""
+    # Cloud deployment bypasses the semaphore gate
+    va.entry.runtime_data.model_deployments.get.return_value = "cloud"
+
+    with (
+        patch(
+            "custom_components.home_generative_agent.core.video_analyzer.epoch_from_path",
+            return_value=int(time.time()),
+        ),
+        patch("aiofiles.open", return_value=_FakeImageFile()),
+        patch(
+            "custom_components.home_generative_agent.core.video_analyzer.analyze_image",
+            new=AsyncMock(return_value="a person is at the door"),
+        ),
+    ):
+        await va._process_snapshot(  # type: ignore[attr-defined]
+            Path("snapshot_20250101_120000.jpg"), "camera.test"
+        )
+
+    call_cfg = va.entry.runtime_data.vision_model.with_config.call_args.kwargs["config"]
+    assert call_cfg["configurable"]["num_predict"] == VIDEO_VLM_NUM_PREDICT
+    assert "reasoning" not in call_cfg["configurable"]
+
+
+@pytest.mark.asyncio
+async def test_vlm_call_disables_reasoning(va: VideoAnalyzer) -> None:
+    """Edge VLM frame analysis binds reasoning=False to suppress Ollama thinking."""
+    va.entry.runtime_data.model_deployments.get.return_value = "edge"
+
+    with (
+        patch(
+            "custom_components.home_generative_agent.core.video_analyzer.epoch_from_path",
+            return_value=int(time.time()),
+        ),
+        patch("aiofiles.open", return_value=_FakeImageFile()),
+        patch(
+            "custom_components.home_generative_agent.core.video_analyzer.analyze_image",
+            new=AsyncMock(return_value="desc"),
+        ),
+    ):
+        await va._process_snapshot(  # type: ignore[attr-defined]
+            Path("snapshot_20250101_120000.jpg"), "camera.test"
+        )
+
+    call_cfg = va.entry.runtime_data.vision_model.with_config.call_args.kwargs["config"]
+    assert call_cfg["configurable"]["num_predict"] == VIDEO_VLM_NUM_PREDICT
+    assert call_cfg["configurable"]["reasoning"] is False
+
+
+# ---------------------------------------------------------------------------
+# _generate_summary: summarization num_predict and reasoning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_summary_uses_video_summary_num_predict(va: VideoAnalyzer) -> None:
+    """Multi-frame summary is configured with VIDEO_SUMMARY_NUM_PREDICT."""
+    va.entry.runtime_data.model_deployments.get.return_value = "cloud"
+
+    frame_descs = [
+        {"A person is at the gate. t+0s.": []},
+        {"The person walks away. t+3s.": []},
+    ]
+    result = await va._generate_summary(frame_descs)  # type: ignore[attr-defined]
+
+    call_cfg = va.entry.runtime_data.summarization_model.with_config.call_args.kwargs[
+        "config"
+    ]
+    assert call_cfg["configurable"]["num_predict"] == VIDEO_SUMMARY_NUM_PREDICT
+    assert "reasoning" not in call_cfg["configurable"]
+    assert isinstance(result, str)
+    assert len(result) > 0
+
+
+@pytest.mark.asyncio
+async def test_summary_disables_reasoning(va: VideoAnalyzer) -> None:
+    """Edge summarization passes reasoning=False directly to ainvoke."""
+    va.entry.runtime_data.model_deployments.get.return_value = "edge"
+
+    frame_descs = [
+        {"Scene A.": []},
+        {"Scene B.": []},
+    ]
+    await va._generate_summary(frame_descs)  # type: ignore[attr-defined]
+
+    call_cfg = va.entry.runtime_data.summarization_model.with_config.call_args.kwargs[
+        "config"
+    ]
+    assert call_cfg["configurable"]["num_predict"] == VIDEO_SUMMARY_NUM_PREDICT
+    assert call_cfg["configurable"]["reasoning"] is False
+    # reasoning is in the config, not in ainvoke kwargs
+    configured_sum = va.entry.runtime_data.summarization_model.with_config.return_value
+    assert configured_sum.ainvoke.call_args.kwargs.get("reasoning") is None
+
+
+# ---------------------------------------------------------------------------
+# NullChat fallback: with_config(config=...) must not raise TypeError
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_vlm_null_chat_with_config_does_not_raise(
+    hass: MagicMock, entry: MagicMock
+) -> None:
+    """NullChat.with_config accepts a positional config arg without TypeError."""
+    entry.runtime_data.vision_model = NullChat()
+    entry.runtime_data.model_deployments.get.return_value = "cloud"
+    va = VideoAnalyzer(hass, entry)
+    va._video_model_sem = asyncio.Semaphore(1)  # type: ignore[attr-defined]
+
+    with (
+        patch(
+            "custom_components.home_generative_agent.core.video_analyzer.epoch_from_path",
+            return_value=int(time.time()),
+        ),
+        patch("aiofiles.open", return_value=_FakeImageFile()),
+        patch(
+            "custom_components.home_generative_agent.core.video_analyzer.analyze_image",
+            new=AsyncMock(return_value="desc"),
+        ),
+    ):
+        result = await va._process_snapshot(  # type: ignore[attr-defined]
+            Path("snapshot_20250101_120000.jpg"), "camera.test"
+        )
+
+    assert isinstance(result, dict)
+
+
+@pytest.mark.asyncio
+async def test_summary_null_chat_with_config_does_not_raise(
+    hass: MagicMock, entry: MagicMock
+) -> None:
+    """NullChat.with_config accepts a positional config arg without TypeError."""
+    entry.runtime_data.summarization_model = NullChat()
+    entry.runtime_data.model_deployments.get.return_value = "cloud"
+    va = VideoAnalyzer(hass, entry)
+
+    frame_descs = [{"Scene A.": []}, {"Scene B.": []}]
+    # NullChat.ainvoke returns a str, not an AIMessage, so _generate_summary
+    # raises ValueError (empty content) — the correct fallback path.  A TypeError
+    # from with_config would propagate uncaught and fail this test.
+    with contextlib.suppress(ValueError):
+        await va._generate_summary(frame_descs)  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Shared semaphore: VLM and summary share the same concurrency limit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_semaphore_limits_concurrent_vlm_calls(
+    va: VideoAnalyzer,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Multiple camera workers share one semaphore; max one VLM call at a time."""
+    va.entry.runtime_data.model_deployments.get.return_value = "edge"
+    va._video_model_sem = asyncio.Semaphore(1)  # type: ignore[attr-defined]
+
+    concurrent = 0
+    max_concurrent = 0
+
+    async def _slow_analyze(*_args: object, **_kwargs: object) -> str:
+        nonlocal concurrent, max_concurrent
+        concurrent += 1
+        max_concurrent = max(max_concurrent, concurrent)
+        await asyncio.sleep(0.05)
+        concurrent -= 1
+        return "frame description"
+
+    monkeypatch.setattr(va_mod, "_VIDEO_MODEL_SEMAPHORE_WAIT_SEC", 5)
+
+    with (
+        patch(
+            "custom_components.home_generative_agent.core.video_analyzer.epoch_from_path",
+            return_value=int(time.time()),
+        ),
+        patch("aiofiles.open", return_value=_FakeImageFile()),
+        patch(
+            "custom_components.home_generative_agent.core.video_analyzer.analyze_image",
+            new=AsyncMock(side_effect=_slow_analyze),
+        ),
+    ):
+        tasks = [
+            asyncio.create_task(
+                va._process_snapshot(  # type: ignore[attr-defined]
+                    Path("snapshot_20250101_120000.jpg"), f"camera.test_{i}"
+                )
+            )
+            for i in range(3)
+        ]
+        await asyncio.gather(*tasks)
+
+    assert max_concurrent == 1
+
+
+# ---------------------------------------------------------------------------
+# start(): semaphore size and uncontended flag logged at startup
+# ---------------------------------------------------------------------------
+
+
+def test_start_logs_semaphore_size(
+    va: VideoAnalyzer,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """start() emits an INFO log with video_model_semaphore size and uncontended flag."""
+    va.entry.runtime_data.options = {
+        "video_model_semaphore": 2,
+        "model_provider_uncontended": True,
+    }
+
+    with (
+        patch(
+            "custom_components.home_generative_agent.core.video_analyzer.async_track_time_interval",
+            return_value=MagicMock(),
+        ),
+        caplog.at_level(
+            logging.INFO,
+            logger="custom_components.home_generative_agent.core.video_analyzer",
+        ),
+    ):
+        va.start()
+
+    messages = [r.message for r in caplog.records]
+    assert any("video_model_semaphore=2" in m for m in messages)
+    assert any("uncontended=True" in m for m in messages)
+
+    va.hass.bus.async_listen.assert_called()
+
+
+def test_start_builds_semaphore_from_config(va: VideoAnalyzer) -> None:
+    """start() reads CONF_VIDEO_MODEL_SEMAPHORE from options to size the semaphore."""
+    va.entry.runtime_data.options = {"video_model_semaphore": 3}
+
+    with patch(
+        "custom_components.home_generative_agent.core.video_analyzer.async_track_time_interval",
+        return_value=MagicMock(),
+    ):
+        va.start()
+
+    assert va._video_model_sem is not None  # type: ignore[attr-defined]
+    # Semaphore with 3 permits: internal counter should equal the configured size
+    assert va._video_model_sem._value == 3  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# _log_ollama_server_info: startup capability probe
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_log_ollama_server_info_logs_model_and_vram(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Startup probe logs model name and VRAM info when /api/ps responds."""
+    hass = MagicMock()
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = {
+        "models": [
+            {
+                "name": "qwen3:8b",
+                "size": 5_000_000_000,
+                "size_vram": 4_000_000_000,
+            }
+        ]
+    }
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_resp)
+
+    with (
+        patch(
+            "custom_components.home_generative_agent.get_async_client",
+            return_value=mock_client,
+        ),
+        caplog.at_level(
+            logging.INFO,
+            logger="custom_components.home_generative_agent",
+        ),
+    ):
+        await _log_ollama_server_info(hass, {"vlm": "http://ollama:11434"})
+
+    messages = [r.message for r in caplog.records]
+    assert any("qwen3:8b" in m for m in messages)
+    assert any("vram_mb" in m for m in messages)
+
+
+@pytest.mark.asyncio
+async def test_log_ollama_server_info_falls_back_silently_on_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Startup probe logs a WARNING and does not raise when /api/ps is unreachable."""
+    hass = MagicMock()
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(side_effect=Exception("connection refused"))
+
+    with (
+        patch(
+            "custom_components.home_generative_agent.get_async_client",
+            return_value=mock_client,
+        ),
+        caplog.at_level(
+            logging.WARNING,
+            logger="custom_components.home_generative_agent",
+        ),
+    ):
+        # Must not raise
+        await _log_ollama_server_info(hass, {"vlm": "http://ollama:11434"})
+
+    messages = [r.message for r in caplog.records]
+    assert any("probe_failed" in m for m in messages)
+
+
+@pytest.mark.asyncio
+async def test_log_ollama_server_info_logs_shared_url_swap_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Probe logs a swap-risk note when multiple categories share a URL."""
+    hass = MagicMock()
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = {
+        "models": [{"name": "llama3:8b", "size": 0, "size_vram": 0}]
+    }
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_resp)
+
+    shared_url = "http://ollama:11434"
+    with (
+        patch(
+            "custom_components.home_generative_agent.get_async_client",
+            return_value=mock_client,
+        ),
+        caplog.at_level(
+            logging.INFO,
+            logger="custom_components.home_generative_agent",
+        ),
+    ):
+        await _log_ollama_server_info(
+            hass, {"vlm": shared_url, "summarization": shared_url}
+        )
+
+    messages = [r.message for r in caplog.records]
+    assert any("model_swapping_may_add_latency" in m for m in messages)

--- a/tests/custom_components/home_generative_agent/test_video_priority_gate.py
+++ b/tests/custom_components/home_generative_agent/test_video_priority_gate.py
@@ -1,0 +1,339 @@
+# ruff: noqa: S101
+"""
+Tests for the video-priority admission extensions in core/utils.py.
+
+Covers (test plan items):
+- local_video_session: edge clears _video_idle, cloud is a no-op,
+  reference counting, exception/cancellation safety
+- sentinel_admission defers while a local video session is active
+- chat still outranks video and Sentinel
+- video does not cancel chat
+- video and chat can be simultaneously active without either canceling the other
+- sentinel_admission_counters tracks deferred_video/deferred_chat, resets on read
+- video_is_active reflects live session state
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import custom_components.home_generative_agent.core.utils as utils_mod
+
+# ---------------------------------------------------------------------------
+# Override autouse fixtures from pytest-homeassistant-custom-component
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def enable_event_loop_debug() -> None:
+    """No-op override: pure-asyncio tests don't need HA's debug-mode hook."""
+
+
+@pytest.fixture(autouse=True)
+def verify_cleanup() -> None:
+    """No-op override: all tasks explicitly awaited; no HA resources to clean up."""
+
+
+# ---------------------------------------------------------------------------
+# Fresh gate primitives for each test
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+async def _fresh_gate_primitives(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reset all module-level gate state before each test."""
+    chat_idle = asyncio.Event()
+    chat_idle.set()
+    video_idle = asyncio.Event()
+    video_idle.set()
+
+    monkeypatch.setattr(utils_mod, "_chat_idle", chat_idle)
+    monkeypatch.setattr(utils_mod, "_chat_active_count", 0)
+    monkeypatch.setattr(utils_mod, "_video_idle", video_idle)
+    monkeypatch.setattr(utils_mod, "_video_active_count", 0)
+    monkeypatch.setattr(utils_mod, "_sentinel_last_run", 0.0)
+    monkeypatch.setattr(utils_mod, "_sentinel_first_defer", 0.0)
+    monkeypatch.setattr(utils_mod, "_sentinel_defer_count", 0)
+    monkeypatch.setattr(utils_mod, "_sentinel_admissions_deferred_chat", 0)
+    monkeypatch.setattr(utils_mod, "_sentinel_admissions_deferred_video", 0)
+    monkeypatch.setattr(utils_mod, "_sentinel_llm_tasks", set())
+
+
+def _vid() -> asyncio.Event:
+    return utils_mod._video_idle  # type: ignore[attr-defined]
+
+
+def _chat() -> asyncio.Event:
+    return utils_mod._chat_idle  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# local_video_session: edge deployment
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_local_video_session_edge_clears_idle() -> None:
+    """Edge video session clears _video_idle on entry and restores on exit."""
+    assert _vid().is_set()
+    async with utils_mod.local_video_session("edge"):
+        assert not _vid().is_set()
+    assert _vid().is_set()
+
+
+@pytest.mark.asyncio
+async def test_local_video_session_edge_restores_on_exception() -> None:
+    """_video_idle is restored even when the body raises."""
+    msg = "boom"
+    with pytest.raises(RuntimeError, match=msg):
+        async with utils_mod.local_video_session("edge"):
+            raise RuntimeError(msg)
+    assert _vid().is_set()
+    assert utils_mod._video_active_count == 0  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_local_video_session_edge_restores_on_cancellation() -> None:
+    """_video_idle and ref-count reset when the session task is cancelled."""
+
+    async def _run() -> None:
+        async with utils_mod.local_video_session("edge"):
+            await asyncio.sleep(9999)
+
+    task = asyncio.create_task(_run())
+    await asyncio.sleep(0)
+    assert not _vid().is_set()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert _vid().is_set()
+    assert utils_mod._video_active_count == 0  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_video_sessions_ref_counted() -> None:
+    """_video_idle stays cleared until the last concurrent session exits."""
+    observations: list[bool] = []
+
+    async def _session() -> None:
+        async with utils_mod.local_video_session("edge"):
+            observations.append(_vid().is_set())
+            await asyncio.sleep(0)
+
+    await asyncio.gather(_session(), _session())
+    assert all(obs is False for obs in observations)
+    assert _vid().is_set()
+    assert utils_mod._video_active_count == 0  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_local_video_session_cloud_is_noop() -> None:
+    """Cloud deployment must not touch _video_idle."""
+    assert _vid().is_set()
+    async with utils_mod.local_video_session("cloud"):
+        assert _vid().is_set()
+    assert _vid().is_set()
+    assert utils_mod._video_active_count == 0  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# video_is_active helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_video_is_active_true_during_session() -> None:
+    """video_is_active() reflects the live session state."""
+    assert not utils_mod.video_is_active()
+    async with utils_mod.local_video_session("edge"):
+        assert utils_mod.video_is_active()
+    assert not utils_mod.video_is_active()
+
+
+# ---------------------------------------------------------------------------
+# sentinel_admission: deferred by video
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sentinel_admission_deferred_when_video_active() -> None:
+    """Sentinel is denied when video is active and timeout elapses."""
+    _vid().clear()
+    result = await utils_mod.sentinel_admission(
+        "edge", category="triage", timeout_s=0.05
+    )
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_sentinel_admission_increments_deferred_video_counter() -> None:
+    """Video-active deferral increments the video counter, not the chat counter."""
+    _vid().clear()
+    await utils_mod.sentinel_admission("edge", category="triage", timeout_s=0.05)
+    assert utils_mod._sentinel_admissions_deferred_video == 1  # type: ignore[attr-defined]
+    assert utils_mod._sentinel_admissions_deferred_chat == 0  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_sentinel_admission_increments_deferred_chat_counter() -> None:
+    """Chat-active deferral increments the chat counter, not the video counter."""
+    _chat().clear()
+    await utils_mod.sentinel_admission("edge", category="triage", timeout_s=0.05)
+    assert utils_mod._sentinel_admissions_deferred_chat == 1  # type: ignore[attr-defined]
+    assert utils_mod._sentinel_admissions_deferred_video == 0  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_sentinel_admission_deferred_when_both_active() -> None:
+    """Sentinel is denied when both chat and video are active."""
+    _chat().clear()
+    _vid().clear()
+    result = await utils_mod.sentinel_admission(
+        "edge", category="discovery", timeout_s=0.05
+    )
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_sentinel_admission_admitted_when_both_idle() -> None:
+    """Sentinel is admitted immediately when chat and video are both idle."""
+    result = await utils_mod.sentinel_admission(
+        "edge", category="triage", timeout_s=1.0
+    )
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_sentinel_admission_admitted_after_video_ends() -> None:
+    """Sentinel is admitted once video becomes idle."""
+    _vid().clear()
+    admitted: list[bool] = []
+
+    async def _admit() -> None:
+        result = await utils_mod.sentinel_admission(
+            "edge", category="triage", timeout_s=2.0
+        )
+        admitted.append(result)
+
+    task = asyncio.create_task(_admit())
+    await asyncio.sleep(0.01)
+    assert not admitted
+
+    _vid().set()
+    await asyncio.wait_for(task, timeout=2.0)
+    assert admitted == [True]
+
+
+@pytest.mark.asyncio
+async def test_sentinel_admission_requires_both_idle() -> None:
+    """Sentinel waits for BOTH chat and video before admitting."""
+    _chat().clear()
+    _vid().clear()
+    admitted: list[bool] = []
+
+    async def _admit() -> None:
+        result = await utils_mod.sentinel_admission(
+            "edge", category="triage", timeout_s=2.0
+        )
+        admitted.append(result)
+
+    task = asyncio.create_task(_admit())
+    await asyncio.sleep(0.01)
+
+    # Release video but keep chat busy — still blocked
+    _vid().set()
+    await asyncio.sleep(0.01)
+    assert not admitted
+
+    # Release chat — now both idle, Sentinel is admitted
+    _chat().set()
+    await asyncio.wait_for(task, timeout=2.0)
+    assert admitted == [True]
+
+
+# ---------------------------------------------------------------------------
+# Chat outranks video: video does not cancel chat
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_video_does_not_cancel_chat_session() -> None:
+    """Starting a video session must not interrupt an active chat session."""
+    chat_completed = asyncio.Event()
+
+    async def _chat() -> None:
+        async with utils_mod.local_chat_session("edge"):
+            await asyncio.sleep(0.05)
+        chat_completed.set()
+
+    async def _video() -> None:
+        await asyncio.sleep(0.01)
+        async with utils_mod.local_video_session("edge"):
+            await asyncio.sleep(0)
+
+    await asyncio.gather(_chat(), _video())
+    assert chat_completed.is_set()
+
+
+@pytest.mark.asyncio
+async def test_chat_and_video_simultaneously_active() -> None:
+    """Chat and video can overlap without canceling each other."""
+    video_saw_chat_active: list[bool] = []
+    chat_saw_video_active: list[bool] = []
+
+    async def _chat_work() -> None:
+        async with utils_mod.local_chat_session("edge"):
+            chat_saw_video_active.append(not _vid().is_set())
+            await asyncio.sleep(0.05)
+
+    async def _video_work() -> None:
+        await asyncio.sleep(0.01)  # let chat start first
+        async with utils_mod.local_video_session("edge"):
+            video_saw_chat_active.append(not _chat().is_set())
+            await asyncio.sleep(0)
+
+    await asyncio.gather(_chat_work(), _video_work())
+
+    # Both ran successfully
+    assert len(chat_saw_video_active) == 1
+    assert len(video_saw_chat_active) == 1
+
+    # Gates restored after both finish
+    assert _chat().is_set()
+    assert _vid().is_set()
+
+
+# ---------------------------------------------------------------------------
+# sentinel_admission_counters: read-and-reset
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sentinel_admission_counters_read_and_reset() -> None:
+    """sentinel_admission_counters() returns current values then resets them."""
+    _vid().clear()
+    await utils_mod.sentinel_admission("edge", category="triage", timeout_s=0.05)
+    _vid().set()
+    _chat().clear()
+    await utils_mod.sentinel_admission("edge", category="triage", timeout_s=0.05)
+    _chat().set()
+
+    counters = utils_mod.sentinel_admission_counters()
+    assert counters["deferred_video"] == 1
+    assert counters["deferred_chat"] == 1
+
+    # Second read returns zeros
+    counters2 = utils_mod.sentinel_admission_counters()
+    assert counters2["deferred_video"] == 0
+    assert counters2["deferred_chat"] == 0
+
+
+@pytest.mark.asyncio
+async def test_sentinel_admission_counters_not_incremented_on_success() -> None:
+    """Successful Sentinel admission must not increment deferral counters."""
+    await utils_mod.sentinel_admission("edge", category="triage", timeout_s=1.0)
+    counters = utils_mod.sentinel_admission_counters()
+    assert counters["deferred_video"] == 0
+    assert counters["deferred_chat"] == 0


### PR DESCRIPTION
## Summary

- **Config-merge root cause fix**: `_process_snapshot` and `_generate_summary` previously called `.with_config({"configurable": {"num_predict": N}})`, which *replaced* the entire model config rather than merging, losing the VLM model name, reasoning flag, temperature, and num_ctx. The fix reads the base model's existing `configurable` dict and overlays only the video-specific overrides before calling `with_config(config={...})`.
- **Video model priority system**: Adds `local_video_session` context manager (ref-counted, edge-only) that marks video model calls active so Sentinel admission defers during the entire video window (chat-wait + semaphore-wait + model-call). `wait_for_chat_idle` lets video pipeline yield briefly to in-flight chat before dropping a frame.
- **Token budget constants**: `VIDEO_VLM_NUM_PREDICT=256` and `VIDEO_SUMMARY_NUM_PREDICT=128` cap token spend for the video role without touching the global VLM/summarization defaults.
- **`NullChat.with_config` regression fix**: Widens signature to accept an optional positional arg so cloud-unavailable fallback doesn't raise `TypeError` when called as `with_config({"configurable": ...})`.
- **`put_with_backpressure` generified**: Now `[T]` for use with queue types beyond `Path`.
- **Metrics accuracy fix**: `sentinel_admission` now re-evaluates which events are still blocking *after* the timeout (not before), so `deferred_chat` and `deferred_video` counters correctly accumulate both when both are simultaneously active.

## Test plan

- [x] 41 new tests: `test_video_analyzer_priority.py` (config merge, reasoning disablement, semaphore limiting, NullChat regression) and `test_video_priority_gate.py` (gate semantics, ref counting, counter accuracy, cloud no-op)
- [x] Full suite: 860 passed, 0 failed
- [x] Lint: ruff format + ruff check all pass
- [x] Pre-landing code review passed (P2 issues fixed before PR: defer-reason re-evaluation, misleading stop() comment corrected, policy comment updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)