### PR TITLE
v3.12.6 fix: prevent Qwen3 thinking mode on Sentinel LLM calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.12.6] - 2026-05-03
+
+### Fixed
+
+- **Sentinel LLM timeouts on Qwen3-family models** — Qwen3.5:35b defaults to
+  thinking mode (generating `<think>…</think>` chains) when `ChatOllama.reasoning`
+  is `None`. `reasoning_field()` now passes `{"reasoning": False}` instead of `{}`
+  when reasoning is disabled, explicitly suppressing the default. This was the root
+  cause of repeated 20–60 s timeouts on Sentinel explain and discovery calls.
+- **Discovery prompt token bloat** — `_existing_semantic_context()` could return up
+  to 400 semantic keys (200 proposals + 200 discovery records), adding ~16 K chars
+  of exclusion context on top of the 20 K snapshot budget. Keys sent to the LLM are
+  now capped at 60 (`_MAX_SEMANTIC_KEYS_IN_PROMPT`). The post-hoc
+  `_filter_novel_candidates()` filter catches any duplicates that slip through.
+- **Sentinel explain timeout too tight** — `_EXPLAIN_LLM_TIMEOUT_S` raised 20 → 30 s
+  to give the model headroom over the observed ~20 s inference time.
+- **Discovery timeout too tight** — `_DISCOVERY_LLM_TIMEOUT_S` raised 45 → 60 s.
+- **Opaque timeout log** — `async_explain` now logs
+  `"LLM explanation timed out after 30s; skipping."` instead of the empty-string
+  warning produced when `TimeoutError` was bundled with other exceptions.
+- **Discovery prompt observability** — a new `DEBUG` log line reports prompt char
+  counts (`snapshot=N, keys=M/total`) each discovery cycle.
+
 ## [3.12.5] - 2026-04-29
 
 ### Fixed

--- a/custom_components/home_generative_agent/core/utils.py
+++ b/custom_components/home_generative_agent/core/utils.py
@@ -784,11 +784,16 @@ def reasoning_field(
     model: str,
     enabled: bool,
 ) -> dict[str, ReasoningValue]:
-    """Return {'reasoning': value} if enabled and model likely supports it."""
-    if not enabled:
-        return {}
+    """
+    Return {'reasoning': value} for models that support thinking.
+
+    Explicitly passes False when disabled so ChatOllama does not fall back to
+    the model's default (which for Qwen3-family is thinking-on).
+    """
     supported, value = _guess_ollama_reasoning(model)
-    return {"reasoning": value} if supported else {}
+    if not supported:
+        return {}
+    return {"reasoning": value if enabled else False}
 
 
 def extract_final(raw: str, max_chars: int | None = None) -> str:

--- a/custom_components/home_generative_agent/explain/llm_explain.py
+++ b/custom_components/home_generative_agent/explain/llm_explain.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
 LOGGER = logging.getLogger(__name__)
 MAX_EXPLANATION_CHARS = 220
-_EXPLAIN_LLM_TIMEOUT_S: Final[float] = 20.0
+_EXPLAIN_LLM_TIMEOUT_S: Final[float] = 30.0
 
 
 class LLMExplainer:
@@ -66,7 +66,13 @@ class LLMExplainer:
         except SentinelLLMDeferredError as err:
             LOGGER.debug("LLM explanation deferred: %s", err)
             return None
-        except (TimeoutError, ValueError, TypeError, RuntimeError) as err:
+        except TimeoutError:
+            LOGGER.warning(
+                "LLM explanation timed out after %.0fs; skipping.",
+                _EXPLAIN_LLM_TIMEOUT_S,
+            )
+            return None
+        except (ValueError, TypeError, RuntimeError) as err:
             LOGGER.warning("LLM explanation failed: %s", err)
             return None
 

--- a/custom_components/home_generative_agent/manifest.json
+++ b/custom_components/home_generative_agent/manifest.json
@@ -33,5 +33,5 @@
     "transformers==4.57.1",
     "langchain-google-genai==3.1.0"
   ],
-  "version": "3.12.5"
+  "version": "3.12.6"
 }

--- a/custom_components/home_generative_agent/sentinel/discovery_engine.py
+++ b/custom_components/home_generative_agent/sentinel/discovery_engine.py
@@ -47,7 +47,10 @@ LOGGER = logging.getLogger(__name__)
 
 # Hard cap on discovery LLM calls: prevents the chat model from being
 # monopolised when the snapshot is large (observed 180s+ without a cap).
-_DISCOVERY_LLM_TIMEOUT_S: float = 45.0
+_DISCOVERY_LLM_TIMEOUT_S: float = 60.0
+# Max semantic keys sent in the discovery prompt. The post-hoc filter catches
+# any duplicates that slip through, so a generous cap is safe.
+_MAX_SEMANTIC_KEYS_IN_PROMPT: int = 60
 
 # Rule IDs for static built-in rules (deterministic, always active).
 # Included in active_rule_ids so the LLM knows these topics are already covered
@@ -186,13 +189,21 @@ class SentinelDiscoveryEngine:
                     "Discovery TTL cleanup failed; continuing.", exc_info=True
                 )
         active_rule_ids, existing_keys = await self._existing_semantic_context()
+        # Cap keys sent to the LLM to bound prompt token cost. Post-hoc filter
+        # handles duplicates that slip through.
+        capped_keys = sorted(existing_keys)[:_MAX_SEMANTIC_KEYS_IN_PROMPT]
         now = dt_util.utcnow().isoformat()
         prompt = USER_PROMPT_TEMPLATE.format(
             snapshot=compact_snapshot,
             active_rule_ids=json.dumps(sorted(active_rule_ids), separators=(",", ":")),
-            existing_semantic_keys=json.dumps(
-                sorted(existing_keys), separators=(",", ":")
-            ),
+            existing_semantic_keys=json.dumps(capped_keys, separators=(",", ":")),
+        )
+        LOGGER.debug(
+            "Discovery prompt: %d chars (snapshot=%d, keys=%d/%d).",
+            len(prompt),
+            len(compact_snapshot),
+            len(capped_keys),
+            len(existing_keys),
         )
         messages = [SystemMessage(content=SYSTEM_PROMPT), HumanMessage(content=prompt)]
 

--- a/tests/custom_components/home_generative_agent/test_discovery_engine_dedupe.py
+++ b/tests/custom_components/home_generative_agent/test_discovery_engine_dedupe.py
@@ -289,3 +289,94 @@ async def test_existing_context_static_ids_present_alongside_dynamic() -> None:
     active_rule_ids, _ = await engine._existing_semantic_context()
     assert "my_dynamic_rule" in active_rule_ids
     assert _STATIC_RULE_IDS.issubset(active_rule_ids)
+
+
+# ---------------------------------------------------------------------------
+# Semantic key prompt cap tests
+# ---------------------------------------------------------------------------
+
+
+def test_max_semantic_keys_in_prompt_constant() -> None:
+    """_MAX_SEMANTIC_KEYS_IN_PROMPT must be defined and positive."""
+    from custom_components.home_generative_agent.sentinel.discovery_engine import (
+        _MAX_SEMANTIC_KEYS_IN_PROMPT,
+    )
+
+    assert isinstance(_MAX_SEMANTIC_KEYS_IN_PROMPT, int)
+    assert _MAX_SEMANTIC_KEYS_IN_PROMPT > 0
+
+
+@pytest.mark.asyncio
+async def test_discovery_prompt_caps_semantic_keys(hass: HomeAssistant) -> None:
+    """When existing_semantic_keys exceeds the cap, only cap entries reach the prompt."""
+    import json
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, patch
+
+    from custom_components.home_generative_agent.sentinel.discovery_engine import (
+        _MAX_SEMANTIC_KEYS_IN_PROMPT,
+        SentinelDiscoveryEngine,
+    )
+
+    oversized_keys = {f"key_{i}" for i in range(_MAX_SEMANTIC_KEYS_IN_PROMPT + 20)}
+    captured_prompts: list[str] = []
+
+    class _CapturingModel:
+        async def ainvoke(self, messages: list[Any]) -> Any:
+            for msg in messages:
+                if hasattr(msg, "content"):
+                    captured_prompts.append(str(msg.content))
+            return SimpleNamespace(
+                content=json.dumps(
+                    {"schema_version": 1, "generated_at": "2026-01-01T00:00:00Z",
+                     "model": "test", "candidates": []}
+                )
+            )
+
+    class _FullDummyStore:
+        async def async_get_latest(self, _limit: int) -> list[dict[str, Any]]:
+            return []
+
+        async def async_append(self, _payload: Any) -> None:
+            pass
+
+    engine = SentinelDiscoveryEngine(
+        hass=hass,
+        options={},
+        model=_CapturingModel(),
+        store=_FullDummyStore(),  # type: ignore[arg-type]
+    )
+
+    async def _fake_run(call_factory: Any, **_kw: Any) -> Any:
+        return await call_factory()
+
+    with (
+        patch.object(
+            engine,
+            "_existing_semantic_context",
+            new_callable=AsyncMock,
+            return_value=(set(), oversized_keys),
+        ),
+        patch(
+            "custom_components.home_generative_agent.sentinel.discovery_engine.async_build_full_state_snapshot",
+            new_callable=AsyncMock,
+            return_value={
+                "entities": [],
+                "camera_activity": [],
+                "derived": {"is_night": False, "now": "2026-01-01T00:00:00Z"},
+                "generated_at": "2026-01-01T00:00:00Z",
+            },
+        ),
+        patch(
+            "custom_components.home_generative_agent.sentinel.discovery_engine.run_sentinel_llm_call",
+            side_effect=_fake_run,
+        ),
+    ):
+        await engine._run_once()
+
+    assert captured_prompts, "Model was never invoked"
+    prompt_text = " ".join(captured_prompts)
+    key_count_in_prompt = sum(
+        1 for i in range(_MAX_SEMANTIC_KEYS_IN_PROMPT + 20) if f"key_{i}" in prompt_text
+    )
+    assert key_count_in_prompt <= _MAX_SEMANTIC_KEYS_IN_PROMPT

--- a/tests/custom_components/home_generative_agent/test_discovery_engine_dedupe.py
+++ b/tests/custom_components/home_generative_agent/test_discovery_engine_dedupe.py
@@ -3,11 +3,15 @@
 
 from __future__ import annotations
 
+import json
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from custom_components.home_generative_agent.sentinel.discovery_engine import (
+    _MAX_SEMANTIC_KEYS_IN_PROMPT,
     _STATIC_RULE_IDS,
     SentinelDiscoveryEngine,
     _candidate_identity_hash,
@@ -298,10 +302,6 @@ async def test_existing_context_static_ids_present_alongside_dynamic() -> None:
 
 def test_max_semantic_keys_in_prompt_constant() -> None:
     """_MAX_SEMANTIC_KEYS_IN_PROMPT must be defined and positive."""
-    from custom_components.home_generative_agent.sentinel.discovery_engine import (
-        _MAX_SEMANTIC_KEYS_IN_PROMPT,
-    )
-
     assert isinstance(_MAX_SEMANTIC_KEYS_IN_PROMPT, int)
     assert _MAX_SEMANTIC_KEYS_IN_PROMPT > 0
 
@@ -309,27 +309,22 @@ def test_max_semantic_keys_in_prompt_constant() -> None:
 @pytest.mark.asyncio
 async def test_discovery_prompt_caps_semantic_keys(hass: HomeAssistant) -> None:
     """When existing_semantic_keys exceeds the cap, only cap entries reach the prompt."""
-    import json
-    from types import SimpleNamespace
-    from unittest.mock import AsyncMock, patch
-
-    from custom_components.home_generative_agent.sentinel.discovery_engine import (
-        _MAX_SEMANTIC_KEYS_IN_PROMPT,
-        SentinelDiscoveryEngine,
-    )
-
     oversized_keys = {f"key_{i}" for i in range(_MAX_SEMANTIC_KEYS_IN_PROMPT + 20)}
     captured_prompts: list[str] = []
 
     class _CapturingModel:
         async def ainvoke(self, messages: list[Any]) -> Any:
-            for msg in messages:
-                if hasattr(msg, "content"):
-                    captured_prompts.append(str(msg.content))
+            captured_prompts.extend(
+                str(msg.content) for msg in messages if hasattr(msg, "content")
+            )
             return SimpleNamespace(
                 content=json.dumps(
-                    {"schema_version": 1, "generated_at": "2026-01-01T00:00:00Z",
-                     "model": "test", "candidates": []}
+                    {
+                        "schema_version": 1,
+                        "generated_at": "2026-01-01T00:00:00Z",
+                        "model": "test",
+                        "candidates": [],
+                    }
                 )
             )
 
@@ -375,8 +370,11 @@ async def test_discovery_prompt_caps_semantic_keys(hass: HomeAssistant) -> None:
         await engine._run_once()
 
     assert captured_prompts, "Model was never invoked"
-    prompt_text = " ".join(captured_prompts)
-    key_count_in_prompt = sum(
-        1 for i in range(_MAX_SEMANTIC_KEYS_IN_PROMPT + 20) if f"key_{i}" in prompt_text
-    )
-    assert key_count_in_prompt <= _MAX_SEMANTIC_KEYS_IN_PROMPT
+    # Parse the JSON array from the human message to get an exact key count.
+    human_content = captured_prompts[-1]
+    keys_start = human_content.find("Existing semantic keys (do not duplicate): [")
+    assert keys_start != -1, "Prompt missing existing_semantic_keys section"
+    array_start = human_content.index("[", keys_start)
+    array_end = human_content.index("]", array_start) + 1
+    keys_in_prompt: list[str] = json.loads(human_content[array_start:array_end])
+    assert len(keys_in_prompt) <= _MAX_SEMANTIC_KEYS_IN_PROMPT

--- a/tests/custom_components/home_generative_agent/test_llm_explain.py
+++ b/tests/custom_components/home_generative_agent/test_llm_explain.py
@@ -198,3 +198,27 @@ async def test_async_explain_returns_none_when_deferred() -> None:
     ):
         result = await explainer.async_explain(_finding())
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_async_explain_returns_none_on_timeout() -> None:
+    """async_explain must return None when the LLM call times out."""
+    explainer = LLMExplainer(DummyModel("irrelevant"))
+    with patch(
+        "custom_components.home_generative_agent.explain.llm_explain.run_sentinel_llm_call",
+        side_effect=TimeoutError(),
+    ):
+        result = await explainer.async_explain(_finding())
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_async_explain_returns_none_on_value_error() -> None:
+    """async_explain must return None on unexpected LLM errors."""
+    explainer = LLMExplainer(DummyModel("irrelevant"))
+    with patch(
+        "custom_components.home_generative_agent.explain.llm_explain.run_sentinel_llm_call",
+        side_effect=ValueError("bad response"),
+    ):
+        result = await explainer.async_explain(_finding())
+    assert result is None

--- a/tests/custom_components/home_generative_agent/test_utils.py
+++ b/tests/custom_components/home_generative_agent/test_utils.py
@@ -284,11 +284,7 @@ def test_reasoning_field_qwen3_enabled_returns_true() -> None:
 
 
 def test_reasoning_field_qwen3_disabled_returns_false() -> None:
-    """Qwen3-family models return {'reasoning': False} when disabled.
-
-    Previously returned {}, which caused ChatOllama to default to thinking-on
-    for Qwen3 models. Explicit False is required to suppress the default.
-    """
+    """Qwen3-family models return {'reasoning': False} when disabled."""
     result = reasoning_field(model="qwen3.5:35b", enabled=False)
     assert result == {"reasoning": False}
 
@@ -301,5 +297,7 @@ def test_reasoning_field_gpt_oss_disabled_returns_false() -> None:
 
 def test_reasoning_field_qwen3_disabled_returns_false_registry_url() -> None:
     """Registry-prefixed model names are stripped before matching."""
-    result = reasoning_field(model="registry.ollama.ai/library/qwen3.5:35b", enabled=False)
+    result = reasoning_field(
+        model="registry.ollama.ai/library/qwen3.5:35b", enabled=False
+    )
     assert result == {"reasoning": False}

--- a/tests/custom_components/home_generative_agent/test_utils.py
+++ b/tests/custom_components/home_generative_agent/test_utils.py
@@ -13,6 +13,7 @@ from custom_components.home_generative_agent.core.utils import (
     InvalidAuthError,
     extract_final,
     openai_compatible_healthy,
+    reasoning_field,
     validate_openai_compatible_url,
 )
 
@@ -263,3 +264,42 @@ async def test_openai_compatible_healthy_returns_false_on_auth_error(
 
     result = await openai_compatible_healthy(hass, "http://localhost:8000", "bad-key")
     assert result is False
+
+
+# ---------------------------------------------------------------------------
+# reasoning_field tests
+# ---------------------------------------------------------------------------
+
+
+def test_reasoning_field_unsupported_model_returns_empty() -> None:
+    """Non-thinking models always return {} regardless of enabled flag."""
+    assert reasoning_field(model="llama3:8b", enabled=True) == {}
+    assert reasoning_field(model="llama3:8b", enabled=False) == {}
+
+
+def test_reasoning_field_qwen3_enabled_returns_true() -> None:
+    """Qwen3-family models return {'reasoning': True} when enabled."""
+    result = reasoning_field(model="qwen3:32b", enabled=True)
+    assert result == {"reasoning": True}
+
+
+def test_reasoning_field_qwen3_disabled_returns_false() -> None:
+    """Qwen3-family models return {'reasoning': False} when disabled.
+
+    Previously returned {}, which caused ChatOllama to default to thinking-on
+    for Qwen3 models. Explicit False is required to suppress the default.
+    """
+    result = reasoning_field(model="qwen3.5:35b", enabled=False)
+    assert result == {"reasoning": False}
+
+
+def test_reasoning_field_gpt_oss_disabled_returns_false() -> None:
+    """gpt-oss models return {'reasoning': False} when disabled."""
+    result = reasoning_field(model="gpt-oss", enabled=False)
+    assert result == {"reasoning": False}
+
+
+def test_reasoning_field_qwen3_disabled_returns_false_registry_url() -> None:
+    """Registry-prefixed model names are stripped before matching."""
+    result = reasoning_field(model="registry.ollama.ai/library/qwen3.5:35b", enabled=False)
+    assert result == {"reasoning": False}


### PR DESCRIPTION
## Summary

**Root cause**: Qwen3.5:35b defaults to thinking mode when `ChatOllama.reasoning` is `None`. Every Sentinel LLM call (explain, discovery, triage) was silently generating a full `<think>…</think>` chain before the JSON answer, consuming 20–60 s of the timeout budget.

- **`core/utils.py`** — `reasoning_field()` now passes `{"reasoning": False}` for thinking-capable models when disabled, instead of omitting the field. This is the root cause fix.
- **`explain/llm_explain.py`** — `_EXPLAIN_LLM_TIMEOUT_S` 20 → 30 s; `TimeoutError` split into its own `except` clause with an informative log message (previously produced an empty-string warning).
- **`sentinel/discovery_engine.py`** — `_DISCOVERY_LLM_TIMEOUT_S` 45 → 60 s; `existing_semantic_keys` capped at 60 entries in the prompt (was up to 400 entries / ~16 K chars); new `DEBUG` log showing prompt char counts per cycle.

## Test Coverage

```
CODE PATHS                                            
[+] core/utils.py — reasoning_field()
  ├── [★★★ TESTED] unsupported model → {}           test_reasoning_field_unsupported_model_returns_empty
  ├── [★★★ TESTED] supported + enabled → value      test_reasoning_field_qwen3_enabled_returns_true
  ├── [★★★ TESTED] supported + disabled → False     test_reasoning_field_qwen3_disabled_returns_false (NEW BEHAVIOR)
  ├── [★★★ TESTED] gpt-oss disabled → False         test_reasoning_field_gpt_oss_disabled_returns_false
  └── [★★★ TESTED] registry-URL model name          test_reasoning_field_qwen3_disabled_returns_false_registry_url

[+] explain/llm_explain.py — async_explain()
  ├── [★★★ TESTED] TimeoutError path                test_async_explain_returns_none_on_timeout (NEW)
  ├── [★★★ TESTED] ValueError path                  test_async_explain_returns_none_on_value_error (NEW)
  └── [★★★ TESTED] SentinelLLMDeferredError         test_async_explain_returns_none_when_deferred (existing)

[+] sentinel/discovery_engine.py — prompt building
  ├── [★★★ TESTED] _MAX_SEMANTIC_KEYS_IN_PROMPT > 0 test_max_semantic_keys_in_prompt_constant
  └── [★★★ TESTED] >60 keys truncated in prompt     test_discovery_prompt_caps_semantic_keys

COVERAGE: 869 tests passing (860 pre-existing + 9 new)
```

## Pre-Landing Review

No issues found. Lint: clean (`make lint` passes). All 869 tests pass.

## Plan Completion

No plan file — fixes diagnosed from live HA + Ollama logs across this session.

## Test plan
- [x] All 869 pytest tests pass
- [x] `make lint` passes (ruff format + check)
- [x] Restart HA and confirm Sentinel discovery and explain calls complete without timeout warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)