### PR TITLE
Clarify Home Assistant setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,36 +37,53 @@ This integration will set up the `conversation` platform, allowing users to conv
 
 ### HACS
 
-
-1. Install the [PostgreSQL with pgvector](https://github.com/goruck/addon-postgres-pgvector/tree/main/postgres_pgvector) add-on by clicking the button below and configure it according to [these directions](https://github.com/goruck/addon-postgres-pgvector/blob/main/postgres_pgvector/DOCS.md). This allows for persistence storage of conversations and memories with vector similarity search.
+1. Install the [PostgreSQL with pgvector](https://github.com/goruck/addon-postgres-pgvector/tree/main/postgres_pgvector) add-on by clicking the button below and configure it according to [these directions](https://github.com/goruck/addon-postgres-pgvector/blob/main/postgres_pgvector/DOCS.md). This allows persistent storage of conversations and memories with vector similarity search.
 
 [![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fgoruck%2Faddon-postgres-pgvector)
 
-2. home-generative-agent is available in the default HACS repository. You can install it directly through HACS or click the button below to open it there.
+2. Install Home Generative Agent from HACS. It is available in the default HACS repository, or you can click the button below to open it directly.
 
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=goruck&repository=https%3A%2F%2Fgithub.com%2Fgoruck%2Fhome-generative-agent&category=integration)
 
-3. Add Home Generative Agent as an assistant in your Home Assistant installation by going to Settings → Voice Assistants. Use a configuration similar to the figure below.
+3. Restart Home Assistant.
 
-![Alt text](./assets/hga_assist_config.png)
+4. Add the integration in Home Assistant:
+   - Go to **Settings → Devices & Services**.
+   - Click **Add Integration**.
+   - Search for **Home Generative Agent**.
+   - Complete the initial instruction-only setup screen.
 
-4. Install all the Blueprints in the `blueprints` directory. You can manually create automations using these that converse directly with the Agent (the Agent can also create automations for you from your your conversations with it, see examples below.)
+5. Open the Home Generative Agent integration page and click **Setup**.
+   - Enable the features you want.
+   - Configure the database connection.
+   - If prompted, add a model provider.
 
-5. (Optional) Install `ollama` on your edge device by following the instructions [here](https://ollama.com/download), **or** run any OpenAI-compatible server (vLLM, llama.cpp, LiteLLM, etc.) and add it as an **OpenAI Compatible** edge provider.
+6. Click **Model Provider** on the integration page and add at least one provider, such as OpenAI, Ollama, Gemini, Anthropic, or an OpenAI-compatible endpoint.
 
-- Pull `ollama` models `gpt-oss`, `qwen3:8b`, `qwen3:1.7b`, `qwen2.5vl:7b` and `mxbai-embed-large`.
+7. Add Home Generative Agent as an assistant:
+   - Go to **Settings → Voice Assistants**.
+   - Select Home Generative Agent as the conversation agent.
+   - Use a configuration similar to the figure below.
 
-6. (Optional) Install [face-service](https://github.com/goruck/face-service) on your edge device if you want to use face recognition.
+   ![Alt text](./assets/hga_assist_config.png)
 
-- Go to Developers tools -> Actions -> Enroll Person in the HA UI to enroll a new person into the face database from an image file.
-- If you want the dashboard enrollment card, add the Lovelace resource after installing the integration:
-  - Settings -> Dashboards -> Resources -> Add
-  - URL: `/hga-card/hga-enroll-card.js`
-  - Type: `JavaScript Module`
-- If you want the Sentinel proposals dashboard card, add this resource as well:
-  - Settings -> Dashboards -> Resources -> Add
-  - URL: `/hga-card/hga-proposals-card.js`
-  - Type: `JavaScript Module`
+8. Install all the Blueprints in the `blueprints` directory. You can manually create automations using these that converse directly with the Agent. The Agent can also create automations for you from your conversations with it; see examples below.
+
+9. (Optional) Install `ollama` on your edge device by following the instructions [here](https://ollama.com/download), **or** run any OpenAI-compatible server (vLLM, llama.cpp, LiteLLM, etc.) and add it as an **OpenAI Compatible** edge provider.
+
+   - Pull `ollama` models `gpt-oss`, `qwen3:8b`, `qwen3:1.7b`, `qwen2.5vl:7b` and `mxbai-embed-large`.
+
+10. (Optional) Install [face-service](https://github.com/goruck/face-service) on your edge device if you want to use face recognition.
+
+   - Go to Developers tools -> Actions -> Enroll Person in the HA UI to enroll a new person into the face database from an image file.
+   - If you want the dashboard enrollment card, add the Lovelace resource after installing the integration:
+     - Settings -> Dashboards -> Resources -> Add
+     - URL: `/hga-card/hga-enroll-card.js`
+     - Type: `JavaScript Module`
+   - If you want the Sentinel proposals dashboard card, add this resource as well:
+     - Settings -> Dashboards -> Resources -> Add
+     - URL: `/hga-card/hga-proposals-card.js`
+     - Type: `JavaScript Module`
 
 ### Manual (non-HACS install)
 1. Install PostgreSQL with pgvector as shown above in Step 1.
@@ -76,8 +93,8 @@ This integration will set up the `conversation` platform, allowing users to conv
 5. Download _all_ the files from the `custom_components/home_generative_agent/` directory in this repository.
 6. Place the files you downloaded in the new directory you created.
 7. Restart Home Assistant
-8. In the HA UI, go to "Configuration" -> "Integrations" click "+," and search for "Home Generative Agent"
-9. Follow steps 3 to 6 above.
+8. In the HA UI, go to **Settings → Devices & Services**, click **Add Integration**, and search for **Home Generative Agent**.
+9. Follow steps 4 to 10 above.
 
 ## Configuration
 Configuration is done entirely in the Home Assistant UI using subentry flows.


### PR DESCRIPTION
## Summary
- add explicit restart and Add Integration steps after HACS install
- describe the Setup and Model Provider steps before configuring Voice Assistants
- update manual install instructions to use Settings > Devices & Services

Closes #382

## Testing
- git diff --check