### PR TITLE
Reduce Sentinel log noise

### DIFF
--- a/custom_components/home_generative_agent/core/utils.py
+++ b/custom_components/home_generative_agent/core/utils.py
@@ -336,11 +336,6 @@ async def sentinel_admission(
         # Re-evaluate after timeout: both could still be blocking.
         chat_blocking = not _chat_idle.is_set()
         video_blocking = not _video_idle.is_set()
-        defer_reason = (
-            "chat_and_video_active"
-            if chat_blocking and video_blocking
-            else ("chat_active" if chat_blocking else "video_active")
-        )
         _sentinel_defer_count += 1
         if chat_blocking:
             _sentinel_admissions_deferred_chat += 1
@@ -370,14 +365,6 @@ async def sentinel_admission(
                 _sentinel_defer_count,
                 starved_for_s,
             )
-        else:
-            LOGGER.debug(
-                "sentinel_admission category=%s decision=deferred reason=%s "
-                "consecutive_deferrals=%d",
-                category,
-                defer_reason,
-                _sentinel_defer_count,
-            )
         return False
     _sentinel_last_run = time.monotonic()
     _sentinel_first_defer = 0.0
@@ -387,7 +374,6 @@ async def sentinel_admission(
         health_stats["sentinel_admission_degraded_category"] = None
         health_stats["sentinel_admission_consecutive_deferrals"] = 0
         health_stats["sentinel_admission_starved_for_s"] = 0
-    LOGGER.debug("sentinel_admission category=%s decision=admitted", category)
     return True
 
 
@@ -431,6 +417,67 @@ async def run_sentinel_llm_call(  # noqa: PLR0913
         ) from err
     finally:
         _sentinel_llm_tasks.discard(task)
+
+
+async def run_sentinel_llm_call_in_executor(  # noqa: PLR0913
+    call_factory: Callable[[], Any],
+    *,
+    deployment: str,
+    category: str,
+    admission_timeout_s: float,
+    call_timeout_s: float,
+    health_stats: MutableMapping[str, Any] | None = None,
+) -> Any:
+    """Run a blocking Sentinel LLM call off the event loop."""
+    if not await sentinel_admission(
+        deployment,
+        category=category,
+        timeout_s=admission_timeout_s,
+        health_stats=health_stats,
+    ):
+        raise SentinelLLMDeferredError(category, "deferred; chat is active")
+
+    task = asyncio.create_task(asyncio.to_thread(call_factory))
+    _sentinel_llm_tasks.add(task)
+    try:
+        return await asyncio.wait_for(task, timeout=call_timeout_s)
+    except asyncio.CancelledError as err:
+        raise SentinelLLMDeferredError(
+            category, "interrupted by foreground chat"
+        ) from err
+    finally:
+        _sentinel_llm_tasks.discard(task)
+
+
+async def run_sentinel_model_call(  # noqa: PLR0913
+    model: Any,
+    messages: Any,
+    *,
+    deployment: str,
+    category: str,
+    admission_timeout_s: float,
+    call_timeout_s: float,
+    health_stats: MutableMapping[str, Any] | None = None,
+) -> Any:
+    """Run a Sentinel model call, preferring sync ``invoke`` off the event loop."""
+    invoke = getattr(model, "invoke", None)
+    if callable(invoke):
+        return await run_sentinel_llm_call_in_executor(
+            lambda: invoke(messages),
+            deployment=deployment,
+            category=category,
+            admission_timeout_s=admission_timeout_s,
+            call_timeout_s=call_timeout_s,
+            health_stats=health_stats,
+        )
+    return await run_sentinel_llm_call(
+        lambda: model.ainvoke(messages),
+        deployment=deployment,
+        category=category,
+        admission_timeout_s=admission_timeout_s,
+        call_timeout_s=call_timeout_s,
+        health_stats=health_stats,
+    )
 
 
 async def generate_embeddings(

--- a/custom_components/home_generative_agent/explain/llm_explain.py
+++ b/custom_components/home_generative_agent/explain/llm_explain.py
@@ -13,7 +13,7 @@ from custom_components.home_generative_agent.core.utils import (
     SENTINEL_ADMISSION_TIMEOUT_S,
     SentinelLLMDeferredError,
     extract_final,
-    run_sentinel_llm_call,
+    run_sentinel_model_call,
 )
 
 from .prompts import SYSTEM_PROMPT, USER_PROMPT_TEMPLATE
@@ -55,8 +55,9 @@ class LLMExplainer:
         messages = [SystemMessage(content=SYSTEM_PROMPT), HumanMessage(content=prompt)]
 
         try:
-            result = await run_sentinel_llm_call(
-                lambda: self._model.ainvoke(messages),
+            result = await run_sentinel_model_call(
+                self._model,
+                messages,
                 deployment=self._deployment,
                 category="explain",
                 admission_timeout_s=SENTINEL_ADMISSION_TIMEOUT_S,

--- a/custom_components/home_generative_agent/sentinel/baseline.py
+++ b/custom_components/home_generative_agent/sentinel/baseline.py
@@ -422,7 +422,6 @@ class SentinelBaselineUpdater:
             return
         self._stop_event.clear()
         self._task = self._hass.async_create_task(self._run_loop())
-        LOGGER.debug("SentinelBaselineUpdater started.")
 
     async def stop(self) -> None:
         """Stop the background update loop."""
@@ -433,7 +432,6 @@ class SentinelBaselineUpdater:
         with contextlib.suppress(asyncio.CancelledError):
             await self._task
         self._task = None
-        LOGGER.debug("SentinelBaselineUpdater stopped.")
 
     # ---------------------------------------------------------------------- #
     # Run loop
@@ -445,7 +443,6 @@ class SentinelBaselineUpdater:
             default=RECOMMENDED_SENTINEL_BASELINE_UPDATE_INTERVAL_MINUTES,
         )
         interval_seconds = interval_minutes * 60
-        LOGGER.info("Baseline update loop started (interval=%d min).", interval_minutes)
         while not self._stop_event.is_set():
             try:
                 from custom_components.home_generative_agent.snapshot.builder import (  # noqa: PLC0415
@@ -637,11 +634,6 @@ class SentinelBaselineUpdater:
                         await self._fire_establishment_notification(
                             entity_id, entity_values[entity_id], snapshot
                         )
-
-            LOGGER.debug(
-                "Baseline upsert completed for %d entities.", len(entity_values)
-            )
-
             # Fire drift notifications after commit (outside the conn context).
             # Only fire for established entities — skip entities still in build-up.
             for entity_id, value in entity_values.items():
@@ -678,7 +670,7 @@ class SentinelBaselineUpdater:
         message = (
             f"Baseline established for {friendly_name}: normal \u2248 {value:.2f}."
         )
-        LOGGER.info("Baseline established for %s (value=%.2f).", entity_id, value)
+        LOGGER.debug("Baseline established for %s (value=%.2f).", entity_id, value)
         try:
             await self._hass.services.async_call(
                 "persistent_notification",
@@ -712,7 +704,7 @@ class SentinelBaselineUpdater:
             f"was {reference_value:.2f}, now {current_value:.2f} "
             f"({drift_pct:.1f}% change). Reference updated."
         )
-        LOGGER.info(
+        LOGGER.debug(
             "Baseline drift for %s: %.2f -> %.2f (%.1f%%).",
             entity_id,
             reference_value,
@@ -897,11 +889,6 @@ class SentinelBaselineUpdater:
                 continue
             result.setdefault(entity_id, {})[metric] = float(value)
 
-        LOGGER.debug(
-            "Fetched baselines for %d entities (min_samples=%d).",
-            len(result),
-            min_samples,
-        )
         return result
 
     async def async_fetch_full_baselines(self) -> dict[str, dict[str, Any]] | None:

--- a/custom_components/home_generative_agent/sentinel/correlator.py
+++ b/custom_components/home_generative_agent/sentinel/correlator.py
@@ -236,13 +236,6 @@ class SentinelCorrelator:
                 output.append(group[0])
             else:
                 compound = CompoundFinding.from_findings(group)
-                LOGGER.info(
-                    "Sentinel correlator grouped %d findings into compound %s "
-                    "(types=%s).",
-                    len(group),
-                    compound.compound_id,
-                    [f.type for f in group],
-                )
                 output.append(compound)
 
         return output

--- a/custom_components/home_generative_agent/sentinel/discovery_engine.py
+++ b/custom_components/home_generative_agent/sentinel/discovery_engine.py
@@ -20,7 +20,7 @@ from custom_components.home_generative_agent.core.utils import (
     SENTINEL_ADMISSION_TIMEOUT_S,
     SentinelLLMDeferredError,
     extract_final,
-    run_sentinel_llm_call,
+    run_sentinel_model_call,
 )
 from custom_components.home_generative_agent.explain.discovery_prompts import (
     SYSTEM_PROMPT,
@@ -35,6 +35,7 @@ from custom_components.home_generative_agent.snapshot.discovery_reducer import (
 
 from .discovery_schema import DISCOVERY_OUTPUT_SCHEMA, DISCOVERY_SCHEMA_VERSION
 from .discovery_semantic import candidate_semantic_key, rule_semantic_key
+from .logging_utils import RepeatingLogLimiter
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -101,6 +102,7 @@ class SentinelDiscoveryEngine:
         self._stop_event = asyncio.Event()
         self._run_lock = asyncio.Lock()
         self._discovery_cycle_stats: dict[str, int] = {}
+        self._log_limiter = RepeatingLogLimiter(LOGGER)
 
     def start(self) -> None:
         """Start the discovery loop."""
@@ -123,7 +125,6 @@ class SentinelDiscoveryEngine:
         interval = _coerce_int(
             self._options.get(CONF_SENTINEL_DISCOVERY_INTERVAL_SECONDS), default=3600
         )
-        LOGGER.info("Sentinel discovery loop started (interval=%ss).", interval)
         while not self._stop_event.is_set():
             await self._run_once_guarded()
             try:
@@ -162,8 +163,15 @@ class SentinelDiscoveryEngine:
         try:
             snapshot = await async_build_full_state_snapshot(self._hass)
         except (ValueError, TypeError, KeyError):
-            LOGGER.warning("Failed to build snapshot for discovery.")
+            self._log_limiter.warning(
+                "snapshot_build",
+                "Failed to build snapshot for discovery.",
+            )
             return
+        self._log_limiter.recovered(
+            "snapshot_build",
+            "Discovery snapshot build recovered after %d failed cycle(s).",
+        )
 
         if self._baseline_updater is not None:
             ready_ids = await self._baseline_updater.async_fetch_ready_entity_ids()
@@ -180,14 +188,16 @@ class SentinelDiscoveryEngine:
             try:
                 expired = await self._proposal_store.cleanup_unsupported_ttl()
                 if expired:
-                    LOGGER.info(
+                    LOGGER.debug(
                         "Discovery TTL cleanup: expired %d unsupported proposal(s).",
                         expired,
                     )
                     self._discovery_cycle_stats["unsupported_ttl_expired"] += expired
             except Exception:  # noqa: BLE001
-                LOGGER.warning(
-                    "Discovery TTL cleanup failed; continuing.", exc_info=True
+                self._log_limiter.warning(
+                    "ttl_cleanup",
+                    "Discovery TTL cleanup failed; continuing.",
+                    exc_info=True,
                 )
         active_rule_ids, existing_keys = await self._existing_semantic_context()
         # Cap keys sent to the LLM to bound prompt token cost. Post-hoc filter
@@ -199,18 +209,12 @@ class SentinelDiscoveryEngine:
             active_rule_ids=json.dumps(sorted(active_rule_ids), separators=(",", ":")),
             existing_semantic_keys=json.dumps(capped_keys, separators=(",", ":")),
         )
-        LOGGER.debug(
-            "Discovery prompt: %d chars (snapshot=%d, keys=%d/%d).",
-            len(prompt),
-            len(compact_snapshot),
-            len(capped_keys),
-            len(existing_keys),
-        )
         messages = [SystemMessage(content=SYSTEM_PROMPT), HumanMessage(content=prompt)]
 
         try:
-            result = await run_sentinel_llm_call(
-                lambda: self._model.ainvoke(messages),
+            result = await run_sentinel_model_call(
+                self._model,
+                messages,
                 deployment=self._deployment,
                 category="discovery",
                 admission_timeout_s=SENTINEL_ADMISSION_TIMEOUT_S,
@@ -221,14 +225,23 @@ class SentinelDiscoveryEngine:
             LOGGER.debug("Discovery LLM call deferred: %s", err)
             return
         except TimeoutError:
-            LOGGER.warning(
+            self._log_limiter.warning(
+                "llm_call",
                 "Discovery LLM call timed out after %.0fs; skipping cycle.",
                 _DISCOVERY_LLM_TIMEOUT_S,
             )
             return
         except (ValueError, TypeError, RuntimeError) as err:
-            LOGGER.warning("Discovery LLM call failed: %s", err)
+            self._log_limiter.warning(
+                "llm_call",
+                "Discovery LLM call failed: %s",
+                err,
+            )
             return
+        self._log_limiter.recovered(
+            "llm_call",
+            "Discovery LLM call recovered after %d failed cycle(s).",
+        )
 
         content = extract_final(getattr(result, "content", None) or "")
         if not content:
@@ -238,7 +251,10 @@ class SentinelDiscoveryEngine:
         try:
             payload = json.loads(content)
         except (json.JSONDecodeError, TypeError):
-            LOGGER.warning("Discovery output was not valid JSON.")
+            self._log_limiter.warning(
+                "invalid_output",
+                "Discovery output was not valid JSON.",
+            )
             return
 
         payload.setdefault("schema_version", DISCOVERY_SCHEMA_VERSION)
@@ -248,13 +264,27 @@ class SentinelDiscoveryEngine:
         try:
             validated = cast("dict[str, Any]", DISCOVERY_OUTPUT_SCHEMA(payload))
         except vol.Invalid:
-            LOGGER.warning("Discovery output failed schema validation.")
+            self._log_limiter.warning(
+                "invalid_output",
+                "Discovery output failed schema validation.",
+            )
             return
+        self._log_limiter.recovered(
+            "invalid_output",
+            "Discovery output recovered after %d invalid response(s).",
+        )
 
         raw_candidates = validated.get("candidates", [])
         if not isinstance(raw_candidates, list):
-            LOGGER.warning("Discovery output candidates were not a list.")
+            self._log_limiter.warning(
+                "invalid_candidates",
+                "Discovery output candidates were not a list.",
+            )
             return
+        self._log_limiter.recovered(
+            "invalid_candidates",
+            "Discovery candidates recovered after %d invalid response(s).",
+        )
         candidates = [item for item in raw_candidates if isinstance(item, dict)]
         self._discovery_cycle_stats["candidates_generated"] = len(candidates)
         filtered, filtered_candidates = self._filter_novel_candidates(
@@ -267,22 +297,7 @@ class SentinelDiscoveryEngine:
         )
         validated["candidates"] = filtered
         validated["filtered_candidates"] = filtered_candidates
-        if not filtered:
-            LOGGER.info(
-                "Discovery produced no novel candidates after dedupe (filtered=%s).",
-                len(filtered_candidates),
-            )
-        else:
-            LOGGER.debug(
-                "Discovery kept %s novel candidate(s) and filtered %s candidate(s).",
-                len(filtered),
-                len(filtered_candidates),
-            )
-
         await self._store.async_append(validated)
-        LOGGER.info(
-            "Discovery stored %s candidate(s).", len(validated.get("candidates", []))
-        )
 
     async def _existing_semantic_context(  # noqa: PLR0912
         self,
@@ -364,10 +379,6 @@ class SentinelDiscoveryEngine:
                         "dedupe_reason": "derived_only_paths",
                     }
                 )
-                LOGGER.debug(
-                    "Discovery dropped candidate %s (derived_only_paths).",
-                    candidate.get("candidate_id"),
-                )
                 continue
 
             dedupe_reason: str | None = None
@@ -378,12 +389,6 @@ class SentinelDiscoveryEngine:
             elif identity_key in seen_batch:
                 dedupe_reason = "batch_duplicate"
             if dedupe_reason is not None:
-                LOGGER.debug(
-                    "Discovery dropped candidate %s with key %s (%s).",
-                    candidate.get("candidate_id"),
-                    identity_key,
-                    dedupe_reason,
-                )
                 dropped_entry: dict[str, str] = {
                     "candidate_id": str(candidate.get("candidate_id", "")),
                     "dedupe_reason": dedupe_reason,

--- a/custom_components/home_generative_agent/sentinel/engine.py
+++ b/custom_components/home_generative_agent/sentinel/engine.py
@@ -62,6 +62,7 @@ from .dynamic_rules import evaluate_dynamic_rules
 from .execution import (
     SentinelExecutionService,
 )
+from .logging_utils import RepeatingLogLimiter
 from .models import AnomalyFinding, CompoundFinding
 from .rules.alarm_disarmed_external_threat import AlarmDisarmedDuringExternalThreatRule
 from .rules.appliance_power_duration import AppliancePowerDurationRule
@@ -198,6 +199,7 @@ class SentinelEngine:
         self._correlator = SentinelCorrelator()
         self._trigger_scheduler = SentinelTriggerScheduler()
         self._execution_service = SentinelExecutionService(dict(options))
+        self._log_limiter = RepeatingLogLimiter(LOGGER)
         self._rules = [
             UnlockedLockAtNightRule(),
             OpenEntryWhileAwayRule(),
@@ -343,8 +345,6 @@ class SentinelEngine:
         if self._baseline_updater is not None:
             self._baseline_updater.start()
 
-        LOGGER.debug("Sentinel engine started (event-driven triggering active).")
-
     async def stop(self) -> None:
         """Stop the sentinel loop and unsubscribe from HA events."""
         if self._task is None:
@@ -386,11 +386,6 @@ class SentinelEngine:
         if anomaly_type is None:
             return
 
-        LOGGER.debug(
-            "State change on %s → anomaly type %s; enqueueing trigger.",
-            entity_id,
-            anomaly_type,
-        )
         self._trigger_scheduler.enqueue(TriggerRecord(anomaly_type=anomaly_type))
 
     # ---------------------------------------------------------------------- #
@@ -401,7 +396,6 @@ class SentinelEngine:
         interval = _coerce_int(
             self._options.get(CONF_SENTINEL_INTERVAL_SECONDS), default=300
         )
-        LOGGER.info("Sentinel loop started (interval=%ss).", interval)
         while not self._stop_event.is_set():
             # Check the trigger scheduler first.  If a queued trigger is ready
             # the single-flight lock inside the scheduler wraps _run_once().
@@ -453,21 +447,34 @@ class SentinelEngine:
             self.run_stats["scheduler"] = self._trigger_scheduler.stats
             async_dispatcher_send(self._hass, SIGNAL_SENTINEL_RUN_COMPLETE)
 
-    async def _run_once(self, trigger_source: str = "poll") -> None:  # noqa: PLR0912, PLR0915
+    async def _run_once(self, trigger_source: str = "poll") -> None:  # noqa: PLR0912
         try:
             snapshot = await async_build_full_state_snapshot(self._hass)
         except (ValueError, TypeError, KeyError):
-            LOGGER.warning("Failed to build snapshot for sentinel.")
+            self._log_limiter.warning(
+                "snapshot_build",
+                "Failed to build snapshot for sentinel.",
+            )
             return
+        self._log_limiter.recovered(
+            "snapshot_build",
+            "Sentinel snapshot build recovered after %d failed cycle(s).",
+        )
 
         # Force Level 0 when suppression state is in read-only mode (version
         # mismatch after a downgrade).
         if self._suppression.is_read_only:
-            LOGGER.warning(
+            self._log_limiter.warning(
+                "suppression_read_only",
                 "Suppression state is read-only (schema version mismatch); "
-                "sentinel forced to Level 0 (notify-only)."
+                "sentinel forced to Level 0 (notify-only).",
             )
             # Continue but will not dispatch (autonomy level effectively 0).
+        else:
+            self._log_limiter.recovered(
+                "suppression_read_only",
+                "Suppression state left read-only mode after %d cycle(s).",
+            )
 
         now = dt_util.utcnow()
         cooldown_type = timedelta(
@@ -510,22 +517,21 @@ class SentinelEngine:
             try:
                 findings = rule.evaluate(snapshot)
             except (KeyError, ValueError, TypeError):
-                LOGGER.warning("Sentinel rule %s failed to evaluate.", rule.rule_id)
-                continue
-            if findings:
-                LOGGER.info(
-                    "Sentinel rule %s produced %s finding(s).",
+                self._log_limiter.warning(
+                    f"rule_eval:{rule.rule_id}",
+                    "Sentinel rule %s failed to evaluate.",
                     rule.rule_id,
-                    len(findings),
                 )
+                continue
+            self._log_limiter.recovered(
+                f"rule_eval:{rule.rule_id}",
+                "Sentinel rule %s recovered after %d failed evaluation(s).",
+                rule.rule_id,
+            )
             all_findings.extend(findings)
 
         if self._rule_registry is not None:
             dynamic_rules = self._rule_registry.list_rules()
-            LOGGER.debug(
-                "Sentinel dynamic registry has %s rule(s).",
-                len(dynamic_rules),
-            )
             if dynamic_rules:
                 baselines: dict[str, dict[str, float]] = {}
                 dow_data: dict[str, dict[str, tuple[float, int]]] | None = None
@@ -562,11 +568,6 @@ class SentinelEngine:
                     dow_min_samples=dow_min_samples,
                     global_drift_pct=global_drift_pct,
                 )
-                LOGGER.debug(
-                    "Sentinel evaluated %s dynamic rule(s), produced %s finding(s).",
-                    len(dynamic_rules),
-                    len(dynamic_findings),
-                )
                 sustained_minutes = _coerce_int(
                     self._options.get(CONF_SENTINEL_BASELINE_SUSTAINED_MINUTES),
                     RECOMMENDED_SENTINEL_BASELINE_SUSTAINED_MINUTES,
@@ -575,15 +576,9 @@ class SentinelEngine:
                     dynamic_findings = self._apply_sustained_gate(
                         dynamic_findings, now, sustained_minutes
                     )
-                if dynamic_findings:
-                    LOGGER.info(
-                        "Sentinel dynamic rules produced %s finding(s).",
-                        len(dynamic_findings),
-                    )
                 all_findings.extend(dynamic_findings)
 
         if not all_findings:
-            LOGGER.debug("Sentinel cycle completed with no findings.")
             return
 
         # Correlation pass: group related findings from this single cycle.
@@ -600,7 +595,6 @@ class SentinelEngine:
                 explain_enabled,
                 trigger_source=trigger_source,
             )
-        LOGGER.debug("Sentinel cycle completed with %s finding(s).", len(all_findings))
 
     # ---------------------------------------------------------------------- #
     # Cyclical load sustained deviation gate
@@ -681,7 +675,8 @@ class SentinelEngine:
             # unchanged — tokenising the anomaly_id would be unreliable and
             # could produce false positive or false negative gate matches.
             if not finding.triggering_entities:
-                LOGGER.warning(
+                self._log_limiter.warning(
+                    "cyclical_gate_missing_entities",
                     "Cyclical gate: finding %s has no triggering_entities; "
                     "skipping gate for this finding.",
                     finding.anomaly_id,
@@ -701,11 +696,6 @@ class SentinelEngine:
             if first_seen is None:
                 # First time above threshold — start the clock, suppress.
                 self._cyclical_deviation_above_since[entity_id] = now
-                LOGGER.debug(
-                    "Cyclical gate started for %s (sustained_minutes=%d).",
-                    entity_id,
-                    sustained_minutes,
-                )
                 continue
 
             elapsed = (now - first_seen).total_seconds() / 60.0
@@ -722,20 +712,9 @@ class SentinelEngine:
                 continue
             if elapsed < sustained_minutes:
                 # Still within the gate window — suppress.
-                LOGGER.debug(
-                    "Cyclical gate suppressing %s (%.1f / %d min elapsed).",
-                    entity_id,
-                    elapsed,
-                    sustained_minutes,
-                )
                 continue
 
             # Gate exceeded — fire and reset clock.
-            LOGGER.info(
-                "Cyclical gate exceeded for %s (%.1f min); firing finding.",
-                entity_id,
-                elapsed,
-            )
             self._cyclical_deviation_above_since[entity_id] = now
             passed.append(finding)
 
@@ -743,9 +722,6 @@ class SentinelEngine:
         # (Not in seen_cyclical means no cyclical finding appeared for them.)
         stale = set(self._cyclical_deviation_above_since) - seen_cyclical
         for entity_id in stale:
-            LOGGER.debug(
-                "Cyclical gate cleared for %s (no finding this run).", entity_id
-            )
             del self._cyclical_deviation_above_since[entity_id]
 
         return passed
@@ -830,12 +806,6 @@ class SentinelEngine:
             **suppress_kwargs,
         )
         if suppression_decision.suppress:
-            LOGGER.debug(
-                "Suppressed finding %s for %s (%s).",
-                finding.anomaly_id,
-                finding.type,
-                suppression_decision.reason_code,
-            )
             await _append_finding_audit(
                 self._audit_store,
                 snapshot,
@@ -865,12 +835,6 @@ class SentinelEngine:
             triage_reason_code_value = triage_result.reason_code
             triage_confidence_value = triage_result.triage_confidence
             if triage_result.decision == TRIAGE_SUPPRESS:
-                LOGGER.info(
-                    "Triage suppressed finding %s (%s): reason=%s.",
-                    finding.anomaly_id,
-                    finding.type,
-                    triage_result.reason_code,
-                )
                 await _append_finding_audit(
                     self._audit_store,
                     snapshot,
@@ -904,12 +868,6 @@ class SentinelEngine:
             canary_would_execute = (
                 exec_result.action_policy_path == ACTION_POLICY_AUTO_EXECUTE
             )
-            if canary_would_execute:
-                LOGGER.info(
-                    "Canary: would auto-execute finding %s (execution_id=%s).",
-                    finding.anomaly_id,
-                    exec_result.execution_id,
-                )
 
         # Live auto-execute: call HA services when policy approves and canary is off.
         action_outcome: dict[str, Any] | None = None
@@ -934,10 +892,6 @@ class SentinelEngine:
         # BLOCKED findings: audit and skip notification — no pending user action.
         if exec_result.action_policy_path == ACTION_POLICY_BLOCKED:
             await self._suppression.async_save()
-            LOGGER.debug(
-                "Finding %s blocked by execution policy; no notification dispatched.",
-                finding.anomaly_id,
-            )
             await _append_finding_audit(
                 self._audit_store,
                 snapshot,
@@ -956,12 +910,6 @@ class SentinelEngine:
 
         register_prompt(self._suppression.state, finding, now)
         await self._suppression.async_save()
-        LOGGER.info(
-            "Dispatching finding %s (%s) → policy=%s.",
-            finding.anomaly_id,
-            finding.type,
-            exec_result.action_policy_path,
-        )
 
         explanation = None
         if explain_enabled and self._explainer is not None:
@@ -1028,11 +976,6 @@ class SentinelEngine:
                 passing.append((constituent, decision.reason_code))
 
         if not passing:
-            LOGGER.debug(
-                "Suppressed compound finding %s (all %d constituents suppressed).",
-                compound.compound_id,
-                len(compound.constituent_findings),
-            )
             await _append_finding_audit(
                 self._audit_store,
                 snapshot,
@@ -1064,11 +1007,6 @@ class SentinelEngine:
         # BLOCKED findings: audit and skip notification — no pending user action.
         if exec_result.action_policy_path == ACTION_POLICY_BLOCKED:
             await self._suppression.async_save()
-            LOGGER.debug(
-                "Compound finding %s blocked by execution policy; "
-                "no notification dispatched.",
-                compound.compound_id,
-            )
             await _append_finding_audit(
                 self._audit_store,
                 snapshot,
@@ -1085,13 +1023,6 @@ class SentinelEngine:
         for constituent, _reason in passing:
             register_prompt(self._suppression.state, constituent, now)
         await self._suppression.async_save()
-
-        LOGGER.info(
-            "Dispatching compound finding %s (%d constituents, %d passed suppression).",
-            compound.compound_id,
-            len(compound.constituent_findings),
-            len(passing),
-        )
 
         canary_would_execute: bool | None = None
         if canary_mode:

--- a/custom_components/home_generative_agent/sentinel/execution.py
+++ b/custom_components/home_generative_agent/sentinel/execution.py
@@ -261,7 +261,7 @@ class SentinelExecutionService:
         # All guardrails passed — approve auto-execute.
         self._recent_action_times.append(now)
         self._idempotency_seen.add(execution_id)
-        LOGGER.info(
+        LOGGER.debug(
             "Auto-execute approved for finding %s (execution_id=%s).",
             finding.anomaly_id,
             execution_id,
@@ -417,11 +417,6 @@ class SentinelExecutionService:
             )
 
         # All guardrails pass — hypothetical auto-execute (no state mutation).
-        LOGGER.debug(
-            "Canary: would auto-execute finding %s (execution_id=%s).",
-            finding.anomaly_id,
-            execution_id,
-        )
         return ActionPolicyResult(
             action_policy_path=ACTION_POLICY_AUTO_EXECUTE,
             data_quality=dq,

--- a/custom_components/home_generative_agent/sentinel/logging_utils.py
+++ b/custom_components/home_generative_agent/sentinel/logging_utils.py
@@ -1,0 +1,45 @@
+"""Small logging helpers for Sentinel runtime loops."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+
+class RepeatingLogLimiter:
+    """Limit repeated operational warnings while preserving recovery signal."""
+
+    def __init__(
+        self,
+        logger: logging.Logger,
+        *,
+        every: int = 10,
+        recovery_level: int = logging.DEBUG,
+    ) -> None:
+        """Initialize the limiter for a logger."""
+        self._logger = logger
+        self._every = every
+        self._recovery_level = recovery_level
+        self._counts: dict[str, int] = {}
+
+    def warning(
+        self,
+        key: str,
+        msg: str,
+        *args: Any,
+        exc_info: bool | BaseException | tuple[Any, Any, Any] | None = None,
+    ) -> None:
+        """Log the first warning, then every Nth repeat for the same key."""
+        count = self._counts.get(key, 0) + 1
+        self._counts[key] = count
+        if count != 1 and count % self._every != 0:
+            return
+        if count > 1:
+            msg = f"{msg.rstrip('.')} (occurrence={count})."
+        self._logger.warning(msg, *args, exc_info=exc_info)
+
+    def recovered(self, key: str, msg: str, *args: Any) -> None:
+        """Log once when a previously repeating condition has recovered."""
+        count = self._counts.pop(key, 0)
+        if count:
+            self._logger.log(self._recovery_level, msg, *args, count)

--- a/custom_components/home_generative_agent/sentinel/notifier.py
+++ b/custom_components/home_generative_agent/sentinel/notifier.py
@@ -306,10 +306,10 @@ class SentinelNotifier:
                     "push": {"interruption-level": interrupt_level},
                 },
             }
-            LOGGER.info("Sending sentinel notification via %s.", target_service)
+            LOGGER.debug("Sending sentinel notification via %s.", target_service)
             await self._hass.services.async_call(domain, service, data, blocking=False)
         else:
-            LOGGER.info("Sending sentinel notification via persistent_notification.")
+            LOGGER.debug("Sending sentinel notification via persistent_notification.")
             await self._hass.services.async_call(
                 "persistent_notification",
                 "create",
@@ -364,7 +364,9 @@ class SentinelNotifier:
                         self._suppression.state, _entity_id, finding.type
                     )
                 await self._suppression.async_save()
-                LOGGER.info("Snooze 24 h registered for finding type %s.", finding.type)
+                LOGGER.debug(
+                    "Snooze 24 h registered for finding type %s.", finding.type
+                )
 
         elif verb == ACT_SNOOZE_ALWAYS:
             # Guard: send confirmation notification; do NOT write snooze yet.
@@ -380,7 +382,7 @@ class SentinelNotifier:
                     self._suppression.state, finding_type, SNOOZE_PERMANENT, now
                 )
                 await self._suppression.async_save()
-                LOGGER.info(
+                LOGGER.debug(
                     "Permanent snooze confirmed for finding type %s.", finding_type
                 )
             else:
@@ -513,7 +515,7 @@ class SentinelNotifier:
                 },
                 blocking=False,
             )
-        LOGGER.info("Daily digest sent: %s.", message)
+        LOGGER.debug("Daily digest sent: %s.", message)
 
     async def _send_always_confirmation(self, finding: AnomalyFinding) -> None:
         """

--- a/custom_components/home_generative_agent/sentinel/rule_registry.py
+++ b/custom_components/home_generative_agent/sentinel/rule_registry.py
@@ -64,7 +64,7 @@ class RuleRegistry:
             LOGGER.debug("Skipping rule registry add: missing rule_id.")
             return False
         if self.find_rule(str(rule_id)):
-            LOGGER.info("Rule registry ignored duplicate rule %s.", rule_id)
+            LOGGER.debug("Rule registry ignored duplicate rule %s.", rule_id)
             return False
         stored_rule = dict(rule)
         stored_rule.setdefault("enabled", True)

--- a/custom_components/home_generative_agent/sentinel/rules/camera_entry_unsecured.py
+++ b/custom_components/home_generative_agent/sentinel/rules/camera_entry_unsecured.py
@@ -77,11 +77,19 @@ class CameraEntryUnsecuredRule:
             e["entity_id"]: e["last_changed"] for e in snapshot["entities"]
         }
 
+        skip_counts = {
+            "no_area": 0,
+            "no_activity": 0,
+            "parse_error": 0,
+            "outside_window": 0,
+            "missing_linked_entry": 0,
+        }
+        fallback_sensor_candidates = 0
         for activity in snapshot["camera_activity"]:
             cam = activity["camera_entity_id"]
             area = activity.get("area")
             if not area:
-                LOGGER.debug("%s: skipped — no area assigned in snapshot.", cam)
+                skip_counts["no_area"] += 1
                 continue
             last_activity = activity.get("last_activity")
             if not last_activity:
@@ -107,31 +115,17 @@ class CameraEntryUnsecuredRule:
                         for e in snapshot["entities"]
                         if e.get("area") == area and e["domain"] == "binary_sensor"
                     ]
-                    LOGGER.debug(
-                        "%s: area=%s area_binary_sensor_candidates=%s",
-                        cam,
-                        area,
-                        candidates,
-                    )
+                    fallback_sensor_candidates += len(candidates)
                 last_activity = max(candidates) if candidates else None
             if not last_activity:
-                LOGGER.debug("%s: skipped — no activity timestamp resolved.", cam)
+                skip_counts["no_activity"] += 1
                 continue
             last_dt = dt_util.parse_datetime(last_activity)
             if last_dt is None:
-                LOGGER.debug(
-                    "%s: skipped — could not parse last_activity=%s.",
-                    cam,
-                    last_activity,
-                )
+                skip_counts["parse_error"] += 1
                 continue
             if now - last_dt > window:
-                LOGGER.debug(
-                    "%s: skipped — last_activity=%s is outside %d-min window.",
-                    cam,
-                    last_activity,
-                    ACTIVITY_WINDOW_MIN,
-                )
+                skip_counts["outside_window"] += 1
                 continue
             # Same-area unsecured entries (primary spatial relationship).
             unsecured_same_area: list[str] = list(unsecured_by_area.get(area) or [])
@@ -144,11 +138,7 @@ class CameraEntryUnsecuredRule:
             for linked_eid in self._camera_entry_links.get(cam, []):
                 entity = entity_by_id.get(linked_eid)
                 if entity is None:
-                    LOGGER.debug(
-                        "%s: linked entry entity %s not in snapshot, skipping.",
-                        cam,
-                        linked_eid,
-                    )
+                    skip_counts["missing_linked_entry"] += 1
                     continue
                 domain = entity["domain"]
                 state = entity["state"]
@@ -204,5 +194,16 @@ class CameraEntryUnsecuredRule:
                     suggested_actions=["check_entry"],
                     is_sensitive=True,
                 ),
+            )
+        if LOGGER.isEnabledFor(logging.DEBUG) and (
+            findings or any(skip_counts.values())
+        ):
+            LOGGER.debug(
+                "Camera-entry rule evaluated %d camera(s): findings=%d "
+                "skips=%s fallback_sensor_candidates=%d.",
+                len(snapshot["camera_activity"]),
+                len(findings),
+                skip_counts,
+                fallback_sensor_candidates,
             )
         return findings

--- a/custom_components/home_generative_agent/sentinel/suppression.py
+++ b/custom_components/home_generative_agent/sentinel/suppression.py
@@ -153,6 +153,7 @@ def _migrate_suppression_state(data: dict[str, Any]) -> dict[str, Any]:
     Returns the same dict object (mutations are in-place).
     """
     stored_version = int(data.get("version", 1))
+    original_version = stored_version
     if stored_version >= SUPPRESSION_STATE_VERSION:
         return data
 
@@ -162,7 +163,6 @@ def _migrate_suppression_state(data: dict[str, Any]) -> dict[str, Any]:
         data.setdefault("presence_grace_until", {})
         data["version"] = 2
         stored_version = 2
-        LOGGER.info("Suppression state migrated from v1 to v2.")
 
     # v2 → v3: presence_grace_until keys must be person entity IDs
     if stored_version < 3:  # noqa: PLR2004
@@ -180,14 +180,12 @@ def _migrate_suppression_state(data: dict[str, Any]) -> dict[str, Any]:
             del data["presence_grace_until"][key]
         data["version"] = 3
         stored_version = 3
-        LOGGER.info("Suppression state migrated from v2 to v3.")
 
     # v3 → v4: learned per-entity cooldown multipliers
     if stored_version < 4:  # noqa: PLR2004
         data.setdefault("learned_cooldown_multipliers", {})
         data["version"] = 4
         stored_version = 4
-        LOGGER.info("Suppression state migrated from v3 to v4.")
 
     # v4 → v5: fix key scheme (entity_id only → {rule_type}:{entity_id})
     if stored_version < 5:  # noqa: PLR2004
@@ -202,14 +200,18 @@ def _migrate_suppression_state(data: dict[str, Any]) -> dict[str, Any]:
             LOGGER.warning(
                 "Suppression state v4→v5: discarded %d bare entity_id key(s) "
                 "from learned_cooldown_multipliers (wrong key scheme; "
-                "expected '{rule_type}:{entity_id}'). "
-                "Discarded keys: %s",
+                "expected '{rule_type}:{entity_id}').",
                 len(stale),
-                sorted(stale),
             )
+            LOGGER.debug("Discarded learned cooldown keys: %s", sorted(stale))
         data["version"] = 5
         stored_version = 5
-        LOGGER.info("Suppression state migrated from v4 to v5.")
+
+    LOGGER.info(
+        "Suppression state migrated from v%d to v%d.",
+        original_version,
+        stored_version,
+    )
 
     return data
 
@@ -265,11 +267,6 @@ def _check_pending_prompt(
         del state.pending_prompts[finding.anomaly_id]
         return None
 
-    LOGGER.debug(
-        "Suppressing %s (%s): pending prompt exists.",
-        finding.anomaly_id,
-        finding.type,
-    )
     return SuppressionDecision(
         suppress=True,
         reason_code=SUPPRESSION_REASON_PENDING_PROMPT,
@@ -442,12 +439,6 @@ def should_suppress(  # noqa: PLR0911, PLR0913
     # 2. Snooze
     snooze_code = _check_snooze(state, finding, now)
     if snooze_code is not None:
-        LOGGER.debug(
-            "Suppressing %s (%s): snooze active (%s).",
-            finding.anomaly_id,
-            finding.type,
-            snooze_code,
-        )
         return SuppressionDecision(
             suppress=True,
             reason_code=snooze_code,
@@ -456,11 +447,6 @@ def should_suppress(  # noqa: PLR0911, PLR0913
 
     # 3. Presence grace
     if _check_presence_grace(state, finding, now):
-        LOGGER.debug(
-            "Suppressing %s (%s): presence grace window active.",
-            finding.anomaly_id,
-            finding.type,
-        )
         return SuppressionDecision(
             suppress=True,
             reason_code=SUPPRESSION_REASON_PRESENCE_GRACE,
@@ -476,12 +462,6 @@ def should_suppress(  # noqa: PLR0911, PLR0913
         severity=finding.severity,
         quiet_severities=quiet_hours_severities or [],
     ):
-        LOGGER.debug(
-            "Suppressing %s (%s): quiet hours active for severity=%s.",
-            finding.anomaly_id,
-            finding.type,
-            finding.severity,
-        )
         return SuppressionDecision(
             suppress=True,
             reason_code=SUPPRESSION_REASON_QUIET_HOURS,
@@ -491,12 +471,6 @@ def should_suppress(  # noqa: PLR0911, PLR0913
     # 5. Type cooldown
     last_type = _parse_dt(state.last_by_type.get(finding.type))
     if last_type is not None and now - last_type < cooldown_type:
-        LOGGER.debug(
-            "Suppressing %s (%s): type cooldown active (last=%s).",
-            finding.anomaly_id,
-            finding.type,
-            state.last_by_type.get(finding.type),
-        )
         return SuppressionDecision(
             suppress=True,
             reason_code=SUPPRESSION_REASON_TYPE_COOLDOWN,
@@ -517,15 +491,6 @@ def should_suppress(  # noqa: PLR0911, PLR0913
             state.last_by_entity.get(entity_id, {}).get(finding.type)
         )
         if last_entity is not None and now - last_entity < effective_cooldown:
-            LOGGER.debug(
-                "Suppressing %s (%s): entity cooldown active for %s "
-                "(last=%s, multiplier=%d).",
-                finding.anomaly_id,
-                finding.type,
-                entity_id,
-                state.last_by_entity.get(entity_id, {}).get(finding.type),
-                multiplier,
-            )
             return SuppressionDecision(
                 suppress=True,
                 reason_code=SUPPRESSION_REASON_ENTITY_COOLDOWN,
@@ -653,11 +618,6 @@ def register_presence_grace(
     """
     expiry = dt_util.as_utc(now + timedelta(minutes=grace_minutes)).isoformat()
     state.presence_grace_until[person_entity_id] = expiry
-    LOGGER.debug(
-        "Presence grace opened for %s (expires %s).",
-        person_entity_id,
-        expiry,
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/custom_components/home_generative_agent/sentinel/triage.py
+++ b/custom_components/home_generative_agent/sentinel/triage.py
@@ -38,7 +38,10 @@ from custom_components.home_generative_agent.core.utils import (
     SENTINEL_ADMISSION_TIMEOUT_S,
     SentinelLLMDeferredError,
     extract_final,
-    run_sentinel_llm_call,
+    run_sentinel_model_call,
+)
+from custom_components.home_generative_agent.sentinel.logging_utils import (
+    RepeatingLogLimiter,
 )
 
 if TYPE_CHECKING:
@@ -48,6 +51,7 @@ if TYPE_CHECKING:
     )
 
 LOGGER = logging.getLogger(__name__)
+_PARSE_LOG_LIMITER = RepeatingLogLimiter(LOGGER)
 
 _THINK_BLOCK = re.compile(r"<think>.*?(?:</think>|$)", re.IGNORECASE | re.DOTALL)
 
@@ -139,6 +143,7 @@ class SentinelTriageService:
         self._timeout_seconds = timeout_seconds
         self._deployment = deployment
         self._health_stats = health_stats
+        self._log_limiter = RepeatingLogLimiter(LOGGER)
 
     async def triage(
         self,
@@ -167,8 +172,9 @@ class SentinelTriageService:
             HumanMessage(content=prompt),
         ]
         try:
-            result = await run_sentinel_llm_call(
-                lambda: self._model.ainvoke(messages),
+            result = await run_sentinel_model_call(
+                self._model,
+                messages,
                 deployment=self._deployment,
                 category="triage",
                 admission_timeout_s=SENTINEL_ADMISSION_TIMEOUT_S,
@@ -185,7 +191,8 @@ class SentinelTriageService:
             )
         except TimeoutError:
             elapsed_ms = int((time.monotonic() - start) * 1000)
-            LOGGER.warning(
+            self._log_limiter.warning(
+                "llm_call",
                 "Triage LLM call timed out after %d ms; failing open to notify.",
                 elapsed_ms,
             )
@@ -196,7 +203,11 @@ class SentinelTriageService:
                 summary="Triage timed out; defaulting to notify.",
             )
         except (ValueError, TypeError, RuntimeError, OSError) as err:
-            LOGGER.warning("Triage LLM call failed: %s; failing open to notify.", err)
+            self._log_limiter.warning(
+                "llm_call",
+                "Triage LLM call failed: %s; failing open to notify.",
+                err,
+            )
             return TriageDecision(
                 decision=TRIAGE_NOTIFY,
                 reason_code=TRIAGE_REASON_ERROR,
@@ -205,6 +216,10 @@ class SentinelTriageService:
             )
 
         elapsed_ms = int((time.monotonic() - start) * 1000)
+        self._log_limiter.recovered(
+            "llm_call",
+            "Triage LLM call recovered after %d failed attempt(s).",
+        )
         return _parse_response(result, elapsed_ms)
 
 
@@ -282,7 +297,8 @@ def _parse_response(result: Any, elapsed_ms: int) -> TriageDecision:  # noqa: AR
     try:
         parsed: dict[str, Any] = json.loads(content)
     except (json.JSONDecodeError, ValueError):
-        LOGGER.warning(
+        _PARSE_LOG_LIMITER.warning(
+            "non_json",
             "Triage LLM returned non-JSON response (%d chars); failing open.",
             len(content),
         )
@@ -300,6 +316,10 @@ def _parse_response(result: Any, elapsed_ms: int) -> TriageDecision:  # noqa: AR
         TRIAGE_REASON_LLM_SUPPRESS
         if decision == TRIAGE_SUPPRESS
         else TRIAGE_REASON_LLM_NOTIFY
+    )
+    _PARSE_LOG_LIMITER.recovered(
+        "non_json",
+        "Triage JSON parsing recovered after %d invalid response(s).",
     )
 
     raw_conf = parsed.get("triage_confidence")

--- a/custom_components/home_generative_agent/sentinel/trigger_scheduler.py
+++ b/custom_components/home_generative_agent/sentinel/trigger_scheduler.py
@@ -178,11 +178,6 @@ class SentinelTriggerScheduler:
                 pending.anomaly_type == record.anomaly_type
                 and pending.age(now) < COALESCE_WINDOW_SECONDS
             ):
-                LOGGER.debug(
-                    "Trigger coalesced: type=%s age=%.1fs",
-                    record.anomaly_type,
-                    pending.age(now),
-                )
                 self._stats["triggers_coalesced"] += 1
                 return
 
@@ -211,11 +206,6 @@ class SentinelTriggerScheduler:
         # --- 3. Enqueue ---
         self._queue.append(record)
         self._trigger_available.set()
-        LOGGER.debug(
-            "Trigger enqueued: type=%s queue_depth=%d",
-            record.anomaly_type,
-            len(self._queue),
-        )
 
     async def run_once_if_triggered(
         self,
@@ -242,19 +232,11 @@ class SentinelTriggerScheduler:
             return False
 
         if self._lock.locked():
-            LOGGER.debug(
-                "Single-flight lock held; skipping trigger-driven run for type=%s.",
-                record.anomaly_type,
-            )
             # Re-queue so the trigger is not lost permanently.
             self._queue.insert(0, record)
             return False
 
         async with self._lock:
-            LOGGER.debug(
-                "Executing trigger-driven _run_once for type=%s.",
-                record.anomaly_type,
-            )
             await run_once()
 
         return True
@@ -265,10 +247,8 @@ class SentinelTriggerScheduler:
     ) -> bool:
         """Execute *run_once* immediately under the single-flight lock."""
         if self._lock.locked():
-            LOGGER.debug("Single-flight lock held; skipping immediate run request.")
             return False
         async with self._lock:
-            LOGGER.debug("Executing immediate _run_once request.")
             await run_once()
         return True
 
@@ -296,7 +276,6 @@ class SentinelTriggerScheduler:
         execute concurrently.
         """
         async with self._lock:
-            LOGGER.debug("Executing polling-driven _run_once.")
             await run_once()
 
     @property
@@ -324,11 +303,6 @@ class SentinelTriggerScheduler:
         while self._queue:
             candidate = self._queue.pop(0)
             if candidate.is_expired(now):
-                LOGGER.debug(
-                    "Trigger TTL expired; discarding type=%s age=%.1fs.",
-                    candidate.anomaly_type,
-                    candidate.age(now),
-                )
                 self._stats["triggers_ttl_expired"] += 1
                 continue
             return candidate

--- a/tests/custom_components/home_generative_agent/test_chat_priority_gate.py
+++ b/tests/custom_components/home_generative_agent/test_chat_priority_gate.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 import time
 from unittest.mock import AsyncMock, MagicMock
 
@@ -392,3 +393,38 @@ async def test_run_sentinel_llm_call_timeout_raises_timeout_error() -> None:
             admission_timeout_s=0.1,
             call_timeout_s=0.05,
         )
+
+
+@pytest.mark.asyncio
+async def test_run_sentinel_model_call_uses_sync_invoke_off_event_loop() -> None:
+    """Models with sync invoke should run in an executor, not on the event loop."""
+    loop_thread_id = threading.get_ident()
+
+    class SyncModel:
+        def __init__(self) -> None:
+            self.invoke_thread_id: int | None = None
+            self.ainvoke_called = False
+
+        def invoke(self, _messages: list[str]) -> str:
+            self.invoke_thread_id = threading.get_ident()
+            return "ok"
+
+        async def ainvoke(self, _messages: list[str]) -> str:
+            self.ainvoke_called = True
+            return "async"
+
+    model = SyncModel()
+
+    result = await utils_mod.run_sentinel_model_call(
+        model,
+        ["message"],
+        deployment="cloud",
+        category="triage",
+        admission_timeout_s=0.1,
+        call_timeout_s=1.0,
+    )
+
+    assert result == "ok"
+    assert model.invoke_thread_id is not None
+    assert model.invoke_thread_id != loop_thread_id
+    assert model.ainvoke_called is False

--- a/tests/custom_components/home_generative_agent/test_discovery_engine_dedupe.py
+++ b/tests/custom_components/home_generative_agent/test_discovery_engine_dedupe.py
@@ -342,8 +342,8 @@ async def test_discovery_prompt_caps_semantic_keys(hass: HomeAssistant) -> None:
         store=_FullDummyStore(),  # type: ignore[arg-type]
     )
 
-    async def _fake_run(call_factory: Any, **_kw: Any) -> Any:
-        return await call_factory()
+    async def _fake_run(model: Any, messages: Any, **_kw: Any) -> Any:
+        return await model.ainvoke(messages)
 
     with (
         patch.object(
@@ -363,7 +363,7 @@ async def test_discovery_prompt_caps_semantic_keys(hass: HomeAssistant) -> None:
             },
         ),
         patch(
-            "custom_components.home_generative_agent.sentinel.discovery_engine.run_sentinel_llm_call",
+            "custom_components.home_generative_agent.sentinel.discovery_engine.run_sentinel_model_call",
             side_effect=_fake_run,
         ),
     ):

--- a/tests/custom_components/home_generative_agent/test_llm_explain.py
+++ b/tests/custom_components/home_generative_agent/test_llm_explain.py
@@ -190,10 +190,10 @@ async def test_async_explain_does_not_pass_raw_timestamps() -> None:
 
 @pytest.mark.asyncio
 async def test_async_explain_returns_none_when_deferred() -> None:
-    """async_explain must return None when run_sentinel_llm_call raises SentinelLLMDeferredError."""
+    """async_explain must return None when the model call is deferred."""
     explainer = LLMExplainer(DummyModel("some content"))
     with patch(
-        "custom_components.home_generative_agent.explain.llm_explain.run_sentinel_llm_call",
+        "custom_components.home_generative_agent.explain.llm_explain.run_sentinel_model_call",
         side_effect=SentinelLLMDeferredError("explain", "chat is active"),
     ):
         result = await explainer.async_explain(_finding())
@@ -205,7 +205,7 @@ async def test_async_explain_returns_none_on_timeout() -> None:
     """async_explain must return None when the LLM call times out."""
     explainer = LLMExplainer(DummyModel("irrelevant"))
     with patch(
-        "custom_components.home_generative_agent.explain.llm_explain.run_sentinel_llm_call",
+        "custom_components.home_generative_agent.explain.llm_explain.run_sentinel_model_call",
         side_effect=TimeoutError(),
     ):
         result = await explainer.async_explain(_finding())
@@ -217,7 +217,7 @@ async def test_async_explain_returns_none_on_value_error() -> None:
     """async_explain must return None on unexpected LLM errors."""
     explainer = LLMExplainer(DummyModel("irrelevant"))
     with patch(
-        "custom_components.home_generative_agent.explain.llm_explain.run_sentinel_llm_call",
+        "custom_components.home_generative_agent.explain.llm_explain.run_sentinel_model_call",
         side_effect=ValueError("bad response"),
     ):
         result = await explainer.async_explain(_finding())

--- a/tests/custom_components/home_generative_agent/test_sentinel_logging_utils.py
+++ b/tests/custom_components/home_generative_agent/test_sentinel_logging_utils.py
@@ -1,0 +1,42 @@
+# ruff: noqa: S101
+"""Tests for Sentinel logging helpers."""
+
+from __future__ import annotations
+
+import logging
+
+from custom_components.home_generative_agent.sentinel.logging_utils import (
+    RepeatingLogLimiter,
+)
+
+
+def test_repeating_log_limiter_warns_first_then_every_n(caplog) -> None:
+    logger = logging.getLogger("tests.hga.sentinel.logging_limiter")
+    limiter = RepeatingLogLimiter(logger, every=3)
+
+    with caplog.at_level(logging.WARNING, logger=logger.name):
+        for _ in range(5):
+            limiter.warning("snapshot", "Snapshot failed.")
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert messages == [
+        "Snapshot failed.",
+        "Snapshot failed (occurrence=3).",
+    ]
+
+
+def test_repeating_log_limiter_logs_recovery_once(caplog) -> None:
+    logger = logging.getLogger("tests.hga.sentinel.logging_recovery")
+    limiter = RepeatingLogLimiter(logger, every=3, recovery_level=logging.INFO)
+
+    with caplog.at_level(logging.INFO, logger=logger.name):
+        limiter.warning("llm", "LLM failed.")
+        limiter.warning("llm", "LLM failed.")
+        limiter.recovered("llm", "LLM recovered after %d failed attempt(s).")
+        limiter.recovered("llm", "LLM recovered after %d failed attempt(s).")
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert messages == [
+        "LLM failed.",
+        "LLM recovered after 2 failed attempt(s).",
+    ]

--- a/tests/custom_components/home_generative_agent/test_sentinel_triage.py
+++ b/tests/custom_components/home_generative_agent/test_sentinel_triage.py
@@ -588,13 +588,13 @@ async def test_llm_receives_system_and_human_messages() -> None:
 
 @pytest.mark.asyncio
 async def test_triage_deferred_when_chat_active() -> None:
-    """SentinelLLMDeferredError from run_sentinel_llm_call must produce decision=notify, reason_code=triage_deferred."""
+    """SentinelLLMDeferredError from the model call must produce a deferred decision."""
     finding = _finding()
     snapshot = _snapshot()
 
     svc = SentinelTriageService(MockLLM())
     with patch(
-        "custom_components.home_generative_agent.sentinel.triage.run_sentinel_llm_call",
+        "custom_components.home_generative_agent.sentinel.triage.run_sentinel_model_call",
         side_effect=SentinelLLMDeferredError("triage", "chat is active"),
     ):
         result = await svc.triage(finding, snapshot)


### PR DESCRIPTION
## Summary
- demote or remove routine Sentinel debug/info logging for lifecycle, suppression, discovery, baseline, scheduler, and notifier paths
- add a small repeating-warning limiter for repeated Sentinel operational failures with recovery logging
- run Sentinel model calls through a helper that uses sync invoke in an executor when available to avoid Home Assistant event-loop blocking during model setup

## Tests
- hga/bin/ruff check custom_components/home_generative_agent/core/utils.py custom_components/home_generative_agent/sentinel/discovery_engine.py custom_components/home_generative_agent/sentinel/triage.py custom_components/home_generative_agent/explain/llm_explain.py custom_components/home_generative_agent/sentinel/baseline.py custom_components/home_generative_agent/sentinel/engine.py custom_components/home_generative_agent/sentinel/suppression.py custom_components/home_generative_agent/sentinel/rules/camera_entry_unsecured.py tests/custom_components/home_generative_agent/test_chat_priority_gate.py tests/custom_components/home_generative_agent/test_sentinel_triage.py tests/custom_components/home_generative_agent/test_llm_explain.py tests/custom_components/home_generative_agent/test_discovery_engine_dedupe.py
- ./hga/bin/pytest tests/custom_components/home_generative_agent/test_trigger_scheduler.py tests/custom_components/home_generative_agent/test_sentinel_triage.py tests/custom_components/home_generative_agent/test_discovery_engine_dedupe.py tests/custom_components/home_generative_agent/test_rules_sentinel.py tests/custom_components/home_generative_agent/test_sentinel_auto_execute.py tests/custom_components/home_generative_agent/test_suppression_upgrades.py tests/custom_components/home_generative_agent/test_sentinel_logging_utils.py tests/custom_components/home_generative_agent/test_suppression.py tests/custom_components/home_generative_agent/test_sentinel_correlator.py tests/custom_components/home_generative_agent/test_sentinel_end_to_end.py tests/custom_components/home_generative_agent/test_chat_priority_gate.py tests/custom_components/home_generative_agent/test_llm_explain.py
- hga/bin/pyright
- git diff --check