### PR TITLE
Fix Home Assistant blocking httpx client setup

### DIFF
--- a/custom_components/home_generative_agent/__init__.py
+++ b/custom_components/home_generative_agent/__init__.py
@@ -39,6 +39,7 @@ from homeassistant.helpers.target import (
     async_extract_referenced_entity_ids,
 )
 from homeassistant.util import dt as dt_util
+from homeassistant.util.ssl import SSL_ALPN_HTTP11, client_context
 from langchain_anthropic import ChatAnthropic
 from langchain_core.runnables import ConfigurableField
 from langchain_google_genai import ChatGoogleGenerativeAI, GoogleGenerativeAIEmbeddings
@@ -1069,6 +1070,11 @@ class NullStore:
         return
 
 
+def _ollama_httpx_client_kwargs() -> dict[str, Any]:
+    """Return httpx kwargs that avoid creating SSL contexts in the event loop."""
+    return {"verify": client_context(alpn_protocols=SSL_ALPN_HTTP11)}
+
+
 def _register_services(hass: HomeAssistant, entry: HGAConfigEntry) -> None:
     """Register integration services."""
 
@@ -1345,9 +1351,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: HGAConfigEntry) -> bool:
     def _build_ollama_provider(
         url: str,
     ) -> RunnableSerializable[LanguageModelInput, BaseMessage]:
+        httpx_kwargs = _ollama_httpx_client_kwargs()
         return ChatOllama(
             model=RECOMMENDED_OLLAMA_CHAT_MODEL,
             base_url=url,
+            sync_client_kwargs=httpx_kwargs,
+            async_client_kwargs=httpx_kwargs,
         ).configurable_fields(
             model=ConfigurableField(id="model"),
             format=ConfigurableField(id="format"),
@@ -1452,6 +1461,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: HGAConfigEntry) -> bool:
                 ),
                 base_url=base_ollama_url,
                 num_ctx=EMBEDDING_MODEL_CTX,
+                sync_client_kwargs=_ollama_httpx_client_kwargs(),
+                async_client_kwargs=_ollama_httpx_client_kwargs(),
             )
         except Exception:
             LOGGER.exception("Ollama embeddings init failed; continuing without them.")

--- a/custom_components/home_generative_agent/agent/graph.py
+++ b/custom_components/home_generative_agent/agent/graph.py
@@ -1161,6 +1161,15 @@ async def _invoke_model(
         raise HomeAssistantError(msg) from err
 
 
+def _bind_model_tools(
+    model: Any, selected_tools: list[Any], *, disable_reasoning: bool
+) -> Any:
+    """Bind tools to a model in a worker thread."""
+    if disable_reasoning:
+        model = model.with_config(config={"configurable": {"reasoning": False}})
+    return model.bind_tools(selected_tools)
+
+
 async def _call_model(
     state: State, config: RunnableConfig, *, store: BaseStore
 ) -> dict[str, Any]:
@@ -1210,9 +1219,14 @@ async def _call_model(
         # Disable reasoning/thinking before binding tools: Qwen3's <think> tokens
         # interleave with tool call JSON output and break Ollama's qwen3.go parser
         # (ResponseError: "invalid character 'g' looking for beginning of value").
-        if chat_model_options.get("reasoning"):
-            model = model.with_config(config={"configurable": {"reasoning": False}})
-        model = model.bind_tools(selected_tools)
+        model = await hass.async_add_executor_job(
+            partial(
+                _bind_model_tools,
+                model,
+                selected_tools,
+                disable_reasoning=bool(chat_model_options.get("reasoning")),
+            )
+        )
 
     # Pass routing map to MultiLLMAPI
     routing_map = state.get("tool_routing_map", {})

--- a/custom_components/home_generative_agent/core/video_analyzer.py
+++ b/custom_components/home_generative_agent/core/video_analyzer.py
@@ -22,6 +22,7 @@ from homeassistant.components.camera.const import DOMAIN as CAMERA_DOMAIN
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.httpx_client import get_async_client
 from langchain_core.messages import HumanMessage, SystemMessage
 from PIL import Image
 
@@ -625,13 +626,14 @@ class VideoAnalyzer:
         client = self._httpx_client
         if client is None:
             # fallback if start() wasn't called yet
-            client = httpx.AsyncClient(timeout=_FACE_TIMEOUT_SEC)
+            client = get_async_client(self.hass)
 
         # Call face API with timeout & specific exception handling
         try:
             resp = await client.post(
                 urljoin(base_url.rstrip("/") + "/", "analyze"),
                 files={"file": ("snapshot.jpg", data, "image/jpeg")},
+                timeout=_FACE_TIMEOUT_SEC,
             )
             resp.raise_for_status()
             face_res = resp.json()
@@ -1190,7 +1192,7 @@ class VideoAnalyzer:
 
         # Create a reusable httpx client for face API
         if self._httpx_client is None:
-            self._httpx_client = httpx.AsyncClient(timeout=_FACE_TIMEOUT_SEC)
+            self._httpx_client = get_async_client(self.hass)
 
         self._cancel_track = async_track_time_interval(
             self.hass,
@@ -1216,7 +1218,7 @@ class VideoAnalyzer:
 
         LOGGER.info("Video analyzer started.")
 
-    async def stop(self) -> None:  # noqa: PLR0912
+    async def stop(self) -> None:
         """Stop the video analyzer."""
         if not hasattr(self, "_cancel_track"):
             LOGGER.warning("VideoAnalyzer not started.")
@@ -1263,12 +1265,8 @@ class VideoAnalyzer:
             for task in pending:
                 LOGGER.warning("Task did not cancel in time: %s", task)
 
-        # close reusable httpx client
-        if self._httpx_client is not None:
-            try:
-                await self._httpx_client.aclose()
-            finally:
-                self._httpx_client = None
+        # Shared Home Assistant httpx client is closed by Home Assistant.
+        self._httpx_client = None
 
         # cancel hourly metrics reporting
         if self._metrics_job_cancel is not None:

--- a/tests/custom_components/home_generative_agent/test_regressions.py
+++ b/tests/custom_components/home_generative_agent/test_regressions.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import ssl
 from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
@@ -15,6 +16,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
+import custom_components.home_generative_agent as hga_component
 import custom_components.home_generative_agent.agent.graph as agent_graph
 from custom_components.home_generative_agent.agent import tools as agent_tools
 from custom_components.home_generative_agent.const import SIGNAL_HGA_RECOGNIZED
@@ -270,6 +272,13 @@ def test_make_transient_tool_error_content_instructs_no_retry() -> None:
     assert "Do not retry" in content or "transient" in content.lower()
 
 
+def test_ollama_httpx_client_kwargs_use_prebuilt_ssl_context() -> None:
+    """Ollama chat and embedding clients must not build SSL contexts on-loop."""
+    kwargs = cast("Any", hga_component)._ollama_httpx_client_kwargs()
+
+    assert isinstance(kwargs["verify"], ssl.SSLContext)
+
+
 # ---------------------------------------------------------------------------
 # _call_model — fallback "Done." when Qwen3 thinking strips all content
 # ---------------------------------------------------------------------------
@@ -349,3 +358,79 @@ async def test_call_model_injects_done_fallback_after_empty_tool_response(
     assert isinstance(ai_msg, AIMessage)
     assert ai_msg.content == "Done.", f"expected 'Done.' but got {ai_msg.content!r}"
     assert not ai_msg.tool_calls
+
+
+@pytest.mark.asyncio
+async def test_call_model_binds_tools_in_executor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tool binding can lazily import LangChain modules, so keep it off-loop."""
+
+    async def _fake_invoke_model(*_args: object, **_kwargs: object) -> AIMessage:
+        return AIMessage(content="ok")
+
+    async def _fake_camera(*_args: object, **_kwargs: object) -> list[object]:
+        return []
+
+    async def _fake_trim(
+        messages: list[object], *_args: object, **_kwargs: object
+    ) -> list[object]:
+        return messages
+
+    class FakeHass:
+        executor_calls = 0
+
+        async def async_add_executor_job(self, target: Any) -> Any:
+            self.executor_calls += 1
+            return target()
+
+    class FakeModel:
+        bound_tools: list[object] | None = None
+        config: dict[str, object] | None = None
+
+        def with_config(self, *, config: dict[str, object]) -> FakeModel:
+            self.config = config
+            return self
+
+        def bind_tools(self, tools: list[object]) -> FakeModel:
+            self.bound_tools = tools
+            return self
+
+    fake_hass = FakeHass()
+    model = FakeModel()
+    selected_tools: list[object] = [object()]
+    mock_store = MagicMock()
+    mock_store.asearch = AsyncMock(return_value=[])
+
+    monkeypatch.setattr(agent_graph, "_invoke_model", _fake_invoke_model)
+    monkeypatch.setattr(agent_graph, "get_recent_camera_activity", _fake_camera)
+    monkeypatch.setattr(agent_graph, "_trim_messages_for_model", _fake_trim)
+
+    state: dict[str, object] = {
+        "messages": [HumanMessage(content="turn on the lamp")],
+        "selected_tools": selected_tools,
+        "summary": "",
+        "tool_routing_map": {},
+        "messages_to_remove": [],
+        "chat_model_usage_metadata": {},
+    }
+    config: dict[str, object] = {
+        "configurable": {
+            "chat_model": model,
+            "user_id": "user-test",
+            "hass": fake_hass,
+            "options": {},
+            "chat_model_options": {"reasoning": True},
+            "prompt": "You are a helpful assistant.",
+            "langchain_tools": {},
+            "ha_llm_api": None,
+            "pending_actions": {},
+        }
+    }
+
+    result = await agent_graph._call_model(state, config, store=mock_store)  # type: ignore[arg-type]
+
+    assert fake_hass.executor_calls == 1
+    assert model.config == {"configurable": {"reasoning": False}}
+    assert model.bound_tools == selected_tools
+    assert result["messages"].content == "ok"

--- a/tests/custom_components/home_generative_agent/test_video_analyzer_priority.py
+++ b/tests/custom_components/home_generative_agent/test_video_analyzer_priority.py
@@ -578,6 +578,10 @@ def test_start_logs_semaphore_size(
             "custom_components.home_generative_agent.core.video_analyzer.async_track_time_interval",
             return_value=MagicMock(),
         ),
+        patch(
+            "custom_components.home_generative_agent.core.video_analyzer.get_async_client",
+            return_value=MagicMock(),
+        ),
         caplog.at_level(
             logging.INFO,
             logger="custom_components.home_generative_agent.core.video_analyzer",
@@ -596,15 +600,41 @@ def test_start_builds_semaphore_from_config(va: VideoAnalyzer) -> None:
     """start() reads CONF_VIDEO_MODEL_SEMAPHORE from options to size the semaphore."""
     va.entry.runtime_data.options = {"video_model_semaphore": 3}
 
-    with patch(
-        "custom_components.home_generative_agent.core.video_analyzer.async_track_time_interval",
-        return_value=MagicMock(),
+    with (
+        patch(
+            "custom_components.home_generative_agent.core.video_analyzer.async_track_time_interval",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "custom_components.home_generative_agent.core.video_analyzer.get_async_client",
+            return_value=MagicMock(),
+        ),
     ):
         va.start()
 
     assert va._video_model_sem is not None  # type: ignore[attr-defined]
     # Semaphore with 3 permits: internal counter should equal the configured size
     assert va._video_model_sem._value == 3  # type: ignore[attr-defined]
+
+
+def test_start_uses_home_assistant_shared_httpx_client(va: VideoAnalyzer) -> None:
+    """start() must not create a private httpx client in the event loop."""
+    client = MagicMock()
+
+    with (
+        patch(
+            "custom_components.home_generative_agent.core.video_analyzer.async_track_time_interval",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "custom_components.home_generative_agent.core.video_analyzer.get_async_client",
+            return_value=client,
+        ) as get_client,
+    ):
+        va.start()
+
+    get_client.assert_called_once_with(va.hass)
+    assert va._httpx_client is client  # type: ignore[attr-defined]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- pass prebuilt HA SSL contexts into Ollama chat and embedding clients
- run LangChain tool binding in the executor to avoid lazy import blocking
- reuse Home Assistant's shared httpx client for the video analyzer face API

## Tests
- ./hga/bin/pytest tests/custom_components/home_generative_agent/test_video_analyzer_priority.py tests/custom_components/home_generative_agent/test_regressions.py -q
- hga/bin/ruff check custom_components/home_generative_agent/__init__.py custom_components/home_generative_agent/agent/graph.py custom_components/home_generative_agent/core/video_analyzer.py tests/custom_components/home_generative_agent/test_video_analyzer_priority.py tests/custom_components/home_generative_agent/test_regressions.py
- hga/bin/pyright custom_components/home_generative_agent/__init__.py custom_components/home_generative_agent/agent/graph.py custom_components/home_generative_agent/core/video_analyzer.py tests/custom_components/home_generative_agent/test_video_analyzer_priority.py tests/custom_components/home_generative_agent/test_regressions.py

Closes #110 