### PR TITLE
v3.14.1 fix: inject type:object into Anthropic tool input_schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.14.1] - 2026-05-10
+
+### Fixed
+
+- **Anthropic API rejects tools with missing `input_schema.type`** — Tools whose
+  parameters schema had no top-level `type` field (e.g. tools with no parameters,
+  returning `{}`) caused a `400 invalid_request_error` from the Anthropic API on
+  every chat query. `_format_and_dedupe_tools` now injects `"type": "object"` when
+  the field is absent, and replaces non-dict parameter values (null, array) with
+  `{"type": "object"}` to prevent a downstream `AttributeError`.
+
 ## [3.14.0] - 2026-05-10
 
 ### Added

--- a/custom_components/home_generative_agent/agent/graph.py
+++ b/custom_components/home_generative_agent/agent/graph.py
@@ -851,13 +851,18 @@ def _format_and_dedupe_tools(
             continue
 
         routing_map[name] = tool["api_id"]
+        parameters = json.loads(tool["parameters"])
+        if not isinstance(parameters, dict):
+            parameters = {"type": "object"}
+        elif not parameters.get("type"):
+            parameters["type"] = "object"
         selected_tools.append(
             {
                 "type": "function",
                 "function": {
                     "name": name,
                     "description": tool["description"],
-                    "parameters": json.loads(tool["parameters"]),
+                    "parameters": parameters,
                 },
             }
         )

--- a/custom_components/home_generative_agent/manifest.json
+++ b/custom_components/home_generative_agent/manifest.json
@@ -34,5 +34,5 @@
     "langchain-google-genai==3.1.0",
     "langchain-anthropic==1.4.3"
   ],
-  "version": "3.14.0"
+  "version": "3.14.1"
 }

--- a/tests/custom_components/home_generative_agent/test_discovery_quality_metrics.py
+++ b/tests/custom_components/home_generative_agent/test_discovery_quality_metrics.py
@@ -135,8 +135,8 @@ def test_discovery_cycle_stats_property_returns_copy() -> None:
 async def test_unsupported_ttl_expired_incremented() -> None:
     """unsupported_ttl_expired accumulates the value returned by cleanup."""
     proposal_store = _DummyProposalStore(ttl_expired=5)
-    model = AsyncMock()
-    model.ainvoke = AsyncMock(return_value=MagicMock(content=""))
+    model = MagicMock()
+    model.invoke = MagicMock(return_value=MagicMock(content=""))
     engine = _make_engine(model=model, proposal_store=proposal_store)
     with _SNAPSHOT_PATCH, _REDUCER_PATCH:
         await engine._run_once()
@@ -147,8 +147,8 @@ async def test_unsupported_ttl_expired_incremented() -> None:
 async def test_unsupported_ttl_expired_zero_when_no_cleanup() -> None:
     """unsupported_ttl_expired stays 0 when cleanup returns 0."""
     proposal_store = _DummyProposalStore(ttl_expired=0)
-    model = AsyncMock()
-    model.ainvoke = AsyncMock(return_value=MagicMock(content=""))
+    model = MagicMock()
+    model.invoke = MagicMock(return_value=MagicMock(content=""))
     engine = _make_engine(model=model, proposal_store=proposal_store)
     with _SNAPSHOT_PATCH, _REDUCER_PATCH:
         await engine._run_once()
@@ -187,8 +187,8 @@ async def test_candidates_generated_counts_all_returned() -> None:
         }
         for i in range(3)
     ]
-    model = AsyncMock()
-    model.ainvoke = AsyncMock(return_value=_valid_llm_response(candidates))
+    model = MagicMock()
+    model.invoke = MagicMock(return_value=_valid_llm_response(candidates))
     engine = _make_engine(model=model)
     with _SNAPSHOT_PATCH, _REDUCER_PATCH:
         await engine._run_once()
@@ -218,8 +218,8 @@ async def test_candidates_novel_vs_deduplicated_counts() -> None:
             "evidence_paths": ["entities[entity_ids contains lock.front_door].state"],
         },
     ]
-    model = AsyncMock()
-    model.ainvoke = AsyncMock(return_value=_valid_llm_response(raw))
+    model = MagicMock()
+    model.invoke = MagicMock(return_value=_valid_llm_response(raw))
     engine = _make_engine(model=model)
     with _SNAPSHOT_PATCH, _REDUCER_PATCH:
         await engine._run_once()
@@ -256,8 +256,8 @@ async def test_derived_only_paths_candidate_is_dropped() -> None:
             "evidence_paths": ["entities[entity_ids contains lock.front_door].state"],
         },
     ]
-    model = AsyncMock()
-    model.ainvoke = AsyncMock(return_value=_valid_llm_response(raw))
+    model = MagicMock()
+    model.invoke = MagicMock(return_value=_valid_llm_response(raw))
     engine = _make_engine(model=model)
     with _SNAPSHOT_PATCH, _REDUCER_PATCH:
         await engine._run_once()

--- a/tests/custom_components/home_generative_agent/test_graph_helpers.py
+++ b/tests/custom_components/home_generative_agent/test_graph_helpers.py
@@ -3,8 +3,62 @@
 
 from __future__ import annotations
 
-from custom_components.home_generative_agent.agent.graph import _determine_model_name
+from custom_components.home_generative_agent.agent.graph import (
+    _determine_model_name,
+    _format_and_dedupe_tools,
+)
 from custom_components.home_generative_agent.const import CONF_ANTHROPIC_CHAT_MODEL
+
+
+def test_format_and_dedupe_tools_injects_type_object_when_missing() -> None:
+    """Tools with empty parameters get type:object injected for Anthropic API."""
+    raw: list = [
+        {
+            "name": "no_params_tool",
+            "api_id": "test",
+            "description": "A tool with no parameters",
+            "parameters": "{}",
+            "is_actuation": False,
+        }
+    ]
+    selected, _routing = _format_and_dedupe_tools(raw)
+    assert len(selected) == 1
+    params = selected[0]["function"]["parameters"]
+    assert params.get("type") == "object", "missing type must be filled with 'object'"
+
+
+def test_format_and_dedupe_tools_handles_non_dict_parameters() -> None:
+    """Non-dict parameters (null, array) are replaced with {type: object}."""
+    for bad_params in ["null", "[]", '"string"']:
+        raw: list = [
+            {
+                "name": f"tool_{bad_params}",
+                "api_id": "test",
+                "description": "broken schema",
+                "parameters": bad_params,
+                "is_actuation": False,
+            }
+        ]
+        selected, _ = _format_and_dedupe_tools(raw)
+        params = selected[0]["function"]["parameters"]
+        assert params == {"type": "object"}, f"bad params {bad_params!r} not normalized"
+
+
+def test_format_and_dedupe_tools_preserves_existing_type() -> None:
+    """Tools that already declare type:object are not modified."""
+    raw: list = [
+        {
+            "name": "typed_tool",
+            "api_id": "test",
+            "description": "Tool with explicit schema",
+            "parameters": '{"type": "object", "properties": {"x": {"type": "string"}}}',
+            "is_actuation": False,
+        }
+    ]
+    selected, _ = _format_and_dedupe_tools(raw)
+    params = selected[0]["function"]["parameters"]
+    assert params["type"] == "object"
+    assert "x" in params["properties"]
 
 
 def test_determine_model_name_anthropic_returns_configured_model() -> None:

--- a/tests/custom_components/home_generative_agent/test_sentinel_baseline.py
+++ b/tests/custom_components/home_generative_agent/test_sentinel_baseline.py
@@ -1991,6 +1991,7 @@ def _make_gate_engine() -> SentinelEngine:
     """Return a minimal SentinelEngine with only gate-relevant state populated."""
     engine = object.__new__(SentinelEngine)
     engine._cyclical_deviation_above_since = {}
+    engine._log_limiter = MagicMock()
     return engine
 
 


### PR DESCRIPTION
## Summary

**Bug fix** — Anthropic API rejects chat queries with `400 invalid_request_error: tools.N.custom.input_schema.type: Field required` when any tool lacks a `type` field in its parameters schema.

**Root cause:** `_format_and_dedupe_tools` passed `json.loads(tool["parameters"])` directly into the tool dict. Tools with no parameters produce `{}` — a valid empty dict, but the Anthropic API requires `input_schema.type` to be explicitly set on every custom tool.

**Fix:** Normalize the parameters dict in `_format_and_dedupe_tools` before `bind_tools` forwards it:
- `{}` or dict missing `type` → inject `"type": "object"`
- Non-dict values (`null`, array, bare string from a corrupted store row) → replace with `{"type": "object"}` instead of crashing with `AttributeError`
- Dict with `type` already set → unchanged

**Pre-existing test fixes (separate commit):**
- `test_discovery_quality_metrics.py`: 5 tests used `AsyncMock` for the model, but `run_sentinel_model_call` prefers `model.invoke` (sync, run in executor). Calling an `AsyncMock` from a thread returns an unawaited coroutine — `result.content` was always `None`. Changed to `MagicMock` + `invoke`.
- `test_sentinel_baseline.py`: `_make_gate_engine()` bypasses `__init__` but `_apply_sustained_gate` now calls `self._log_limiter`. Added `MagicMock` `_log_limiter` to the fixture.

## Test Coverage

```
CODE PATHS                                           
[+] agent/graph.py — _format_and_dedupe_tools        
  ├── [★★★ TESTED] empty parameters {} → type injected
  ├── [★★★ TESTED] non-dict (null/array/string) → replaced with {type: object}
  └── [★★★ TESTED] existing type preserved unchanged
```

Tests: 1013 → 1016 (+3 new regression tests)

## Pre-Landing Review

No issues found. Change is pure schema normalization — no SQL, no LLM output handling, no async/sync mixing.

Adversarial review found one FIXABLE issue (non-dict parameters causing `AttributeError`) — fixed before commit.

## Test plan
- [x] All 1016 pytest tests pass
- [x] `make lint` passes
- [x] Adversarial review findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)