### PR TITLE
fix: name appliance in power-duration notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- **Appliance duration alerts now name the actual appliance** — Notifications for
+  `appliance_power_duration` findings previously fell back to the generic phrase
+  "An appliance" because the LLM explanation lacked a display name. The rule now
+  includes `friendly_name` in finding evidence, and a new deterministic message
+  builder formats the mobile copy directly — e.g. `Washer drew about 296 W for
+  633 min, above the 60 min threshold. Check it.` — bypassing the LLM path
+  entirely for this finding type. Power-sensor suffixes (`Power`, `Energy`, etc.)
+  are stripped case-insensitively so user-set names like `EV Charger Power` render
+  as `EV Charger`. When no friendly name is present the entity ID is used as
+  fallback. The same formatter is reused for persistent notifications. Closes
+  [#391](https://github.com/goruck/home-generative-agent/issues/391).
+
 ## [3.14.2] - 2026-05-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [3.14.3] - 2026-05-11
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Security / presence:
 
 Appliances / sensors:
 
-- `appliance_power_duration` — appliance drawing power beyond a configurable duration threshold
+- `appliance_power_duration` — appliance drawing power beyond a configurable duration threshold; notification names the actual appliance (e.g. `Washer drew about 296 W for 633 min, above the 60 min threshold. Check it.`)
 
 Cameras:
 
@@ -256,7 +256,8 @@ When Sentinel notifications are enabled:
 
 - Mobile push explanation text is compact and plain-language (targeted for small screens).
 - Explanation text is normalized before send (markdown/backticks removed, whitespace collapsed).
-- If explanation text is missing or too long, Sentinel uses a deterministic fallback message.
+- Some finding types use a dedicated deterministic message builder regardless of LLM explanation availability — `appliance_power_duration` and `alarm_disarmed_during_external_threat` always produce deterministic mobile copy that names the relevant entity.
+- For all other finding types, if explanation text is missing or too long, Sentinel uses a deterministic fallback message.
 - Fallback urgency wording depends on severity:
   - `high`: `Urgent: check and secure it now.`
   - `medium`: `Check soon and secure it if unexpected.`

--- a/custom_components/home_generative_agent/manifest.json
+++ b/custom_components/home_generative_agent/manifest.json
@@ -34,5 +34,5 @@
     "langchain-google-genai==3.1.0",
     "langchain-anthropic==1.4.3"
   ],
-  "version": "3.14.2"
+  "version": "3.14.3"
 }

--- a/custom_components/home_generative_agent/sentinel/notifier.py
+++ b/custom_components/home_generative_agent/sentinel/notifier.py
@@ -764,7 +764,7 @@ def _appliance_power_duration_mobile_message(finding: AnomalyFinding) -> str:
             ev.get("entity_id")
             or (finding.triggering_entities[0] if finding.triggering_entities else "")
         )
-        appliance = _friendly_entity(entity_id)
+        appliance = _strip_power_suffix(_friendly_entity(entity_id))
 
     power_w = ev.get("power_w")
     duration_min = ev.get("duration_min")

--- a/custom_components/home_generative_agent/sentinel/notifier.py
+++ b/custom_components/home_generative_agent/sentinel/notifier.py
@@ -746,10 +746,45 @@ _POWER_SUFFIXES: tuple[str, ...] = (
 
 def _strip_power_suffix(name: str) -> str:
     """Remove trailing power-sensor label words from an appliance display name."""
+    name_lower = name.lower()
     for suffix in _POWER_SUFFIXES:
-        if name.endswith(suffix):
+        if name_lower.endswith(suffix.lower()):
             return name[: -len(suffix)].strip()
     return name
+
+
+def _appliance_power_duration_mobile_message(finding: AnomalyFinding) -> str:
+    """Deterministic mobile copy for appliance_power_duration."""
+    ev = finding.evidence
+    raw_name = (ev.get("friendly_name") or "").strip()
+    if raw_name:
+        appliance = _strip_power_suffix(raw_name)
+    else:
+        entity_id = str(
+            ev.get("entity_id")
+            or (finding.triggering_entities[0] if finding.triggering_entities else "")
+        )
+        appliance = _friendly_entity(entity_id)
+
+    power_w = ev.get("power_w")
+    duration_min = ev.get("duration_min")
+    threshold_min = ev.get("threshold_min")
+
+    power_str = (
+        f"about {round(float(power_w))} W" if power_w is not None else "high power"
+    )
+    dur_str = (
+        f"{int(duration_min)} min" if duration_min is not None else "an extended period"
+    )
+    thr_str = (
+        f"{int(threshold_min)} min" if threshold_min is not None else "the configured"
+    )
+
+    msg = (
+        f"{appliance} drew {power_str} for {dur_str},"
+        f" above the {thr_str} threshold. Check it."
+    )
+    return msg[:MAX_MOBILE_MESSAGE_CHARS].rstrip()
 
 
 def _fallback_message(finding: AnomalyFinding) -> str:
@@ -802,6 +837,8 @@ def _alarm_disarmed_mobile_message(finding: AnomalyFinding) -> str:
 def _mobile_message(explanation: str | None, finding: AnomalyFinding) -> str:
     if finding.type == "alarm_disarmed_during_external_threat":
         return _alarm_disarmed_mobile_message(finding)
+    if finding.type == "appliance_power_duration":
+        return _appliance_power_duration_mobile_message(finding)
     if explanation:
         text = _normalize_text(explanation)
         if text and len(text) <= MAX_MOBILE_MESSAGE_CHARS:
@@ -814,6 +851,9 @@ def _persistent_message(explanation: str | None, finding: AnomalyFinding) -> str
         text = _normalize_text(explanation)
         if text:
             return text
+
+    if finding.type == "appliance_power_duration":
+        return _appliance_power_duration_mobile_message(finding)
 
     entities = ", ".join(
         _friendly_entity(entity) for entity in finding.triggering_entities

--- a/custom_components/home_generative_agent/sentinel/rules/appliance_power_duration.py
+++ b/custom_components/home_generative_agent/sentinel/rules/appliance_power_duration.py
@@ -68,8 +68,14 @@ class AppliancePowerDurationRule:
                 "power_w": power_val,
                 "duration_min": int((now - last_changed).total_seconds() / 60),
                 "threshold_min": self._duration_min,
+                "friendly_name": entity["friendly_name"] or None,
             }
-            anomaly_id = build_anomaly_id(self.rule_id, [entity["entity_id"]], evidence)
+            hash_evidence = {
+                k: v for k, v in evidence.items() if k != "friendly_name"
+            }
+            anomaly_id = build_anomaly_id(
+                self.rule_id, [entity["entity_id"]], hash_evidence
+            )
             findings.append(
                 AnomalyFinding(
                     anomaly_id=anomaly_id,

--- a/custom_components/home_generative_agent/sentinel/rules/appliance_power_duration.py
+++ b/custom_components/home_generative_agent/sentinel/rules/appliance_power_duration.py
@@ -70,9 +70,7 @@ class AppliancePowerDurationRule:
                 "threshold_min": self._duration_min,
                 "friendly_name": entity["friendly_name"] or None,
             }
-            hash_evidence = {
-                k: v for k, v in evidence.items() if k != "friendly_name"
-            }
+            hash_evidence = {k: v for k, v in evidence.items() if k != "friendly_name"}
             anomaly_id = build_anomaly_id(
                 self.rule_id, [entity["entity_id"]], hash_evidence
             )

--- a/docs/appliance-duration-message-plan.md
+++ b/docs/appliance-duration-message-plan.md
@@ -1,0 +1,153 @@
+# Appliance Duration Message Plan
+
+Originating issue: [#391 Improve Message](https://github.com/goruck/home-generative-agent/issues/391)
+
+## Problem Statement
+
+The `appliance_power_duration` Sentinel notification can describe a specific
+power sensor as the generic phrase "An appliance". A reported example was:
+
+`An appliance in Room-A recently drew about 296 W for 633 minutes, exceeding the 60-minute threshold. Check the appliance.`
+
+The user expectation is that the message names the actual Home Assistant entity
+or appliance, not only the category. For example, a washer power sensor should
+produce copy that starts with "Washer" rather than "An appliance".
+
+## Current Behavior
+
+`AppliancePowerDurationRule` builds finding evidence with `entity_id`, `area`,
+`power_w`, `duration_min`, and `threshold_min`, but does not include the
+snapshot entity's `friendly_name`.
+
+When LLM explanations are enabled, the explainer is instructed to use only the
+provided evidence. Without a friendly display name, the model can legitimately
+fall back to generic wording such as "An appliance". The notifier also currently
+prefers a valid LLM explanation over its generic fallback message, so adding a
+better fallback alone would not reliably fix this issue.
+
+## Goals
+
+- Name the relevant appliance or power sensor in appliance-duration alerts.
+- Keep the message short enough for mobile notifications.
+- Avoid raw entity IDs when a useful display name is available.
+- Keep the change scoped to `appliance_power_duration`.
+
+## Non-Goals
+
+- Do not redesign all Sentinel message generation.
+- Do not add a user-facing message-template setting.
+- Do not change anomaly detection thresholds or sustained-duration behavior.
+- Do not add a separate persistent-notification code path. The deterministic
+  appliance-duration formatter introduced here is reused by `_persistent_message()`
+  (see Change 5), but no other persistent-notification behavior is changed.
+
+## Proposed Changes
+
+1. Add `friendly_name` to appliance-duration finding evidence.
+
+   In `custom_components/home_generative_agent/sentinel/rules/appliance_power_duration.py`,
+   copy `entity["friendly_name"]` into the evidence payload. Use `or None` so
+   that an empty string is stored as `None` rather than `""`, keeping the
+   fallback logic simple.
+
+   Exclude `friendly_name` from the evidence passed to `build_anomaly_id()`.
+   `friendly_name` is display-only and can change independently of the actual
+   anomaly. Concretely: build the full evidence dict first, then pass a filtered
+   copy — `{k: v for k, v in evidence.items() if k != "friendly_name"}` — to
+   `build_anomaly_id()`, and pass the full dict to `AnomalyFinding`. No change
+   to `build_anomaly_id()` itself is required.
+
+2. Add deterministic mobile copy for `appliance_power_duration`.
+
+   In `custom_components/home_generative_agent/sentinel/notifier.py`, add a
+   helper that formats appliance-duration notifications from finding evidence.
+   `_mobile_message()` should use this helper for `appliance_power_duration`
+   before considering an LLM explanation. The LLM explanation is still generated
+   upstream by the triage/explain pipeline when enabled; the helper simply
+   bypasses it for the mobile message, so there is no change to inference cost
+   or audit records.
+
+3. Prefer friendly display names.
+
+   Message construction should use the pattern
+   `(evidence.get("friendly_name") or "").strip()` so that both `None` and `""`
+   trigger the fallback. Strip common power-sensor suffixes with the existing
+   `_strip_power_suffix()` helper. Preserve the original casing of user-provided
+   friendly names so values like `EV Charger Power` do not become `Ev Charger`.
+   Fall back to `_friendly_entity(entity_id)` when no friendly name is present.
+
+   Note: `_strip_power_suffix()` currently matches title-case suffixes (e.g.
+   `" Power"`, `" Energy"`). Update `_strip_power_suffix()` itself to do a
+   case-insensitive suffix comparison (e.g. `name.lower().endswith(suffix.lower())`)
+   while preserving the original casing of the returned string. This is safe to
+   apply to both the appliance-duration path and the existing `is_completion` path
+   in `async_notify()`, which already applies `.title()` after stripping. The
+   entity-ID fallback can remain title-cased because it is generated from an
+   identifier, not user-authored display text.
+
+   Target copy:
+
+   `Washer drew about 296 W for 633 min, above the 60 min threshold. Check it.`
+
+4. Preserve existing behavior for other finding types.
+
+   Other notification types should keep the current LLM-first behavior, except
+   for existing deterministic paths such as `alarm_disarmed_during_external_threat`.
+
+5. Reuse the deterministic formatter for persistent fallback copy.
+
+   `_persistent_message()` should use the same appliance-duration formatter when
+   no usable explanation is available. This prevents no-mobile-service installs
+   from falling back to a generic "Appliance power duration" message while still
+   preserving the existing LLM-first behavior for persistent notifications.
+
+## Known Limitation: `anomaly_id` Instability
+
+`build_anomaly_id()` currently hashes the full evidence dict including
+`duration_min`, which increases each evaluation cycle as the appliance keeps
+running. The `anomaly_id` for `appliance_power_duration` findings is therefore
+already unstable across runs, and the per-finding cooldown in the notifier is
+ineffective for this type.
+
+This plan should not add a second, display-only source of churn. Add
+`friendly_name` to the stored finding evidence, but build the anomaly ID from a
+hash evidence dict that excludes `friendly_name`.
+
+Fixing the existing `duration_min` instability, for example by excluding
+time-varying fields from the hash, is a separate issue and is out of scope here.
+
+## Test Plan
+
+- Update `test_appliance_power_duration_triggers()` to assert that
+  `friendly_name` is present in the finding evidence.
+- Add notifier coverage showing `Washer Power` is rendered as `Washer`.
+- Add notifier coverage for a lowercase `friendly_name` (e.g. `"washer power"`)
+  rendering correctly as `Washer`.
+- Add notifier coverage showing user-provided casing is preserved, for example
+  `EV Charger Power` rendering as `EV Charger`.
+- Add notifier coverage for fallback to the entity ID display name when
+  `friendly_name` is missing (`None` or `""`).
+- Add notifier coverage showing deterministic appliance-duration copy wins even
+  when the LLM explanation says "An appliance".
+- Add coverage showing `friendly_name` is not included in the anomaly ID hash
+  input, so changing only the display name does not change the ID.
+
+## Verification
+
+Run focused tests:
+
+```bash
+./hga/bin/pytest tests/custom_components/home_generative_agent/test_rules_sentinel.py tests/custom_components/home_generative_agent/test_sentinel_notifier.py
+```
+
+Run targeted lint:
+
+```bash
+hga/bin/ruff check custom_components/home_generative_agent/sentinel/rules/appliance_power_duration.py custom_components/home_generative_agent/sentinel/notifier.py tests/custom_components/home_generative_agent/test_rules_sentinel.py tests/custom_components/home_generative_agent/test_sentinel_notifier.py
+```
+
+Run type checking:
+
+```bash
+hga/bin/pyright custom_components/home_generative_agent/sentinel/rules/appliance_power_duration.py custom_components/home_generative_agent/sentinel/notifier.py
+```

--- a/tests/custom_components/home_generative_agent/test_rules_sentinel.py
+++ b/tests/custom_components/home_generative_agent/test_rules_sentinel.py
@@ -150,7 +150,7 @@ def test_open_entry_while_away_triggers() -> None:
 
 
 def test_appliance_power_duration_triggers() -> None:
-    """High power draw over duration should trigger."""
+    """High power draw over duration should trigger and expose friendly_name."""
     snapshot = _base_snapshot()
     snapshot["derived"]["now"] = "2025-01-01T02:00:00+00:00"
     snapshot["entities"] = [
@@ -168,6 +168,30 @@ def test_appliance_power_duration_triggers() -> None:
 
     findings = AppliancePowerDurationRule(duration_min=30).evaluate(snapshot)
     assert len(findings) == 1
+    assert findings[0].evidence["friendly_name"] == "Washer Power"
+
+
+def test_appliance_power_duration_friendly_name_excluded_from_anomaly_id() -> None:
+    """Changing friendly_name must not change the anomaly_id hash."""
+    snapshot = _base_snapshot()
+    snapshot["derived"]["now"] = "2025-01-01T02:00:00+00:00"
+    base_entity: dict[str, Any] = {
+        "entity_id": "sensor.washer_power",
+        "domain": "sensor",
+        "state": "250",
+        "area": "Laundry",
+        "attributes": {"device_class": "power", "unit_of_measurement": "W"},
+        "last_changed": "2025-01-01T00:00:00+00:00",
+        "last_updated": "2025-01-01T00:00:00+00:00",
+    }
+
+    snapshot["entities"] = [{**base_entity, "friendly_name": "Washer Power"}]
+    findings_a = AppliancePowerDurationRule(duration_min=30).evaluate(snapshot)
+
+    snapshot["entities"] = [{**base_entity, "friendly_name": "My Washing Machine Power"}]
+    findings_b = AppliancePowerDurationRule(duration_min=30).evaluate(snapshot)
+
+    assert findings_a[0].anomaly_id == findings_b[0].anomaly_id
 
 
 def test_camera_entry_unsecured_triggers() -> None:

--- a/tests/custom_components/home_generative_agent/test_rules_sentinel.py
+++ b/tests/custom_components/home_generative_agent/test_rules_sentinel.py
@@ -175,21 +175,31 @@ def test_appliance_power_duration_friendly_name_excluded_from_anomaly_id() -> No
     """Changing friendly_name must not change the anomaly_id hash."""
     snapshot = _base_snapshot()
     snapshot["derived"]["now"] = "2025-01-01T02:00:00+00:00"
-    base_entity: dict[str, Any] = {
-        "entity_id": "sensor.washer_power",
-        "domain": "sensor",
-        "state": "250",
-        "area": "Laundry",
-        "attributes": {"device_class": "power", "unit_of_measurement": "W"},
-        "last_changed": "2025-01-01T00:00:00+00:00",
-        "last_updated": "2025-01-01T00:00:00+00:00",
-    }
-
-    snapshot["entities"] = [{**base_entity, "friendly_name": "Washer Power"}]
+    snapshot["entities"] = [
+        {
+            "entity_id": "sensor.washer_power",
+            "domain": "sensor",
+            "state": "250",
+            "friendly_name": "Washer Power",
+            "area": "Laundry",
+            "attributes": {"device_class": "power", "unit_of_measurement": "W"},
+            "last_changed": "2025-01-01T00:00:00+00:00",
+            "last_updated": "2025-01-01T00:00:00+00:00",
+        }
+    ]
     findings_a = AppliancePowerDurationRule(duration_min=30).evaluate(snapshot)
 
     snapshot["entities"] = [
-        {**base_entity, "friendly_name": "My Washing Machine Power"}
+        {
+            "entity_id": "sensor.washer_power",
+            "domain": "sensor",
+            "state": "250",
+            "friendly_name": "My Washing Machine Power",
+            "area": "Laundry",
+            "attributes": {"device_class": "power", "unit_of_measurement": "W"},
+            "last_changed": "2025-01-01T00:00:00+00:00",
+            "last_updated": "2025-01-01T00:00:00+00:00",
+        }
     ]
     findings_b = AppliancePowerDurationRule(duration_min=30).evaluate(snapshot)
 

--- a/tests/custom_components/home_generative_agent/test_rules_sentinel.py
+++ b/tests/custom_components/home_generative_agent/test_rules_sentinel.py
@@ -188,7 +188,9 @@ def test_appliance_power_duration_friendly_name_excluded_from_anomaly_id() -> No
     snapshot["entities"] = [{**base_entity, "friendly_name": "Washer Power"}]
     findings_a = AppliancePowerDurationRule(duration_min=30).evaluate(snapshot)
 
-    snapshot["entities"] = [{**base_entity, "friendly_name": "My Washing Machine Power"}]
+    snapshot["entities"] = [
+        {**base_entity, "friendly_name": "My Washing Machine Power"}
+    ]
     findings_b = AppliancePowerDurationRule(duration_min=30).evaluate(snapshot)
 
     assert findings_a[0].anomaly_id == findings_b[0].anomaly_id

--- a/tests/custom_components/home_generative_agent/test_sentinel_notifier.py
+++ b/tests/custom_components/home_generative_agent/test_sentinel_notifier.py
@@ -1207,7 +1207,7 @@ def test_appliance_power_duration_fallback_to_entity_id() -> None:
             "friendly_name": name_val,
         }
         msg = _appliance_power_duration_mobile_message(_appliance_finding(evidence=ev))
-        assert "Washer" in msg
+        assert msg.startswith("Washer drew ")
         assert len(msg) <= MAX_MOBILE_MESSAGE_CHARS
 
 

--- a/tests/custom_components/home_generative_agent/test_sentinel_notifier.py
+++ b/tests/custom_components/home_generative_agent/test_sentinel_notifier.py
@@ -24,6 +24,7 @@ from custom_components.home_generative_agent.sentinel.notifier import (
     MAX_MOBILE_MESSAGE_CHARS,
     SentinelNotifier,
     _alarm_disarmed_mobile_message,
+    _appliance_power_duration_mobile_message,
     _build_actions,
     _friendly_type,
     _mobile_message,
@@ -1123,6 +1124,103 @@ async def test_async_notify_non_completion_subtitle_uses_friendly_type() -> None
     subtitle = hass.services.calls[0]["data"]["data"]["subtitle"]
     # "candidate_" stripped → "Appliance power spike away"
     assert subtitle == "Appliance power spike away"
+
+
+# ---------------------------------------------------------------------------
+# 15. Appliance power duration deterministic message
+# ---------------------------------------------------------------------------
+
+
+def _appliance_finding(
+    anomaly_id: str = "apd1",
+    evidence: dict[str, Any] | None = None,
+) -> AnomalyFinding:
+    return AnomalyFinding(
+        anomaly_id=anomaly_id,
+        type="appliance_power_duration",
+        severity="medium",
+        confidence=0.6,
+        triggering_entities=["sensor.washer_power"],
+        evidence=evidence
+        or {
+            "entity_id": "sensor.washer_power",
+            "area": "Laundry",
+            "power_w": 296.0,
+            "duration_min": 633,
+            "threshold_min": 60,
+            "friendly_name": "Washer Power",
+        },
+        suggested_actions=["check_appliance"],
+        is_sensitive=False,
+    )
+
+
+def test_appliance_power_duration_strips_power_suffix() -> None:
+    """'Washer Power' friendly_name should render as 'Washer' in the message."""
+    msg = _appliance_power_duration_mobile_message(_appliance_finding())
+    assert msg.startswith("Washer ")
+    assert "Power" not in msg.split()[0]
+    assert "296" in msg
+    assert "633 min" in msg
+    assert "60 min" in msg
+    assert len(msg) <= MAX_MOBILE_MESSAGE_CHARS
+
+
+def test_appliance_power_duration_preserves_casing() -> None:
+    """User-authored casing (e.g. 'EV Charger') must not be title-cased away."""
+    ev: dict[str, Any] = {
+        "entity_id": "sensor.ev_charger_power",
+        "area": "Garage",
+        "power_w": 7200.0,
+        "duration_min": 120,
+        "threshold_min": 60,
+        "friendly_name": "EV Charger Power",
+    }
+    msg = _appliance_power_duration_mobile_message(_appliance_finding(evidence=ev))
+    assert msg.startswith("EV Charger ")
+
+
+def test_appliance_power_duration_lowercase_friendly_name() -> None:
+    """Lowercase friendly_name suffix should still be stripped correctly."""
+    ev: dict[str, Any] = {
+        "entity_id": "sensor.washer_power",
+        "area": "Laundry",
+        "power_w": 250.0,
+        "duration_min": 90,
+        "threshold_min": 60,
+        "friendly_name": "washer power",
+    }
+    msg = _appliance_power_duration_mobile_message(_appliance_finding(evidence=ev))
+    assert msg.startswith("washer ")
+    assert "power" not in msg.split()[0].lower() or msg.startswith("washer ")
+
+
+def test_appliance_power_duration_fallback_to_entity_id() -> None:
+    """None and empty-string friendly_name both fall back to the entity ID display name."""
+    for name_val in (None, ""):
+        ev: dict[str, Any] = {
+            "entity_id": "sensor.washer_power",
+            "area": "Laundry",
+            "power_w": 250.0,
+            "duration_min": 90,
+            "threshold_min": 60,
+            "friendly_name": name_val,
+        }
+        msg = _appliance_power_duration_mobile_message(_appliance_finding(evidence=ev))
+        assert "Washer" in msg
+        assert len(msg) <= MAX_MOBILE_MESSAGE_CHARS
+
+
+def test_appliance_power_duration_mobile_message_wins_over_llm() -> None:
+    """Deterministic copy is used even when the LLM explanation mentions 'An appliance'."""
+    finding = _appliance_finding()
+    llm_explanation = (
+        "An appliance in Laundry recently drew about 296 W for 633 minutes,"
+        " exceeding the 60-minute threshold. Check the appliance."
+    )
+    msg = _mobile_message(llm_explanation, finding)
+    assert msg.startswith("Washer ")
+    assert "An appliance" not in msg
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION

## Documentation

- **README.md**: updated `appliance_power_duration` rule description to show the named-appliance notification format; added a note that `appliance_power_duration` and `alarm_disarmed_during_external_threat` use dedicated deterministic message builders that bypass the LLM path
- **CHANGELOG.md**: added `[Unreleased]` entry describing the fix, example output, and fallback behavior
