### PR TITLE
Fix manifest repository links

### DIFF
--- a/custom_components/home_generative_agent/manifest.json
+++ b/custom_components/home_generative_agent/manifest.json
@@ -13,10 +13,10 @@
     "conversation",
     "recorder"
   ],
-  "documentation": "https://github.com/goruck/home_generative_agent",
+  "documentation": "https://github.com/goruck/home-generative-agent",
   "integration_type": "service",
   "iot_class": "cloud_polling",
-  "issue_tracker": "https://github.com/goruck/home_generative_agent/issues",
+  "issue_tracker": "https://github.com/goruck/home-generative-agent/issues",
   "requirements": [
     "aiofiles==25.1.0",
     "langchain==1.2.12",


### PR DESCRIPTION
## Summary
- Correct manifest documentation and issue tracker URLs to use the hyphenated GitHub repository path

## Verification
- ./hga/bin/python -m json.tool custom_components/home_generative_agent/manifest.json
- git diff --check
- commit hook regenerated/verified requirements_runtime_manifest.txt is unchanged

Closes #400