### PR TITLE
fix: handle llama-server embedding incompatibility and None scores

### DIFF
--- a/README.md
+++ b/README.md
@@ -753,6 +753,7 @@ Normalization fallbacks for common LLM-generated patterns:
   - `Rule registry ignored duplicate rule ...`
   - `... covered_by_existing_rule ...`
 - Existing stored proposal drafts are not auto-migrated; statuses update when proposals are re-processed.
+- **llama-server embedding incompatibility** — If you use llama-server as an OpenAI-compatible provider and see `Memory semantic search failed — embedding endpoint returned an incompatible response` in the logs, the agent has automatically fallen back to recency-based memory retrieval. This happens because llama-server's `/v1/embeddings` response format does not match the OpenAI SDK's expected structure. Semantic search (memory and RAG tool retrieval) will degrade silently. For reliable semantic embeddings, use a dedicated embedding model via Ollama (`mxbai-embed-large` is recommended) and set its provider as the **Embedding** provider in the integration settings. Chat and embedding providers can be different — e.g. llama-server for chat, Ollama for embeddings.
 
 ## Image and Sensor Entities
 

--- a/custom_components/home_generative_agent/agent/graph.py
+++ b/custom_components/home_generative_agent/agent/graph.py
@@ -687,8 +687,8 @@ async def _get_rag_retrieved_tools(
             api_id = item.value.get("api_id")
             if api_id not in allowed_api_ids:
                 continue
-            # score is (1 - distance) for pgvector cosine
-            score = getattr(item, "score", 0.0)
+            # score is (1 - distance) for pgvector cosine; None when no embedding
+            score = getattr(item, "score", None) or 0.0
             if score >= threshold and (name not in best or score > best[name][0]):
                 best[name] = (score, item)
 
@@ -763,7 +763,7 @@ async def _get_actuation_safety_tools(
 
     # Sort by relevance score descending so the merge can cap to the top-N.
     sorted_results = sorted(
-        results, key=lambda i: getattr(i, "score", 0.0), reverse=True
+        results, key=lambda i: getattr(i, "score", None) or 0.0, reverse=True
     )
     safety_tools: list[RawTool] = []
     for item in sorted_results:
@@ -1178,6 +1178,30 @@ def _bind_model_tools(
     return model.bind_tools(selected_tools)
 
 
+async def _search_memories(store: BaseStore, user_id: str, query: str | None) -> list:
+    """Search the memory store, falling back gracefully on embedding errors."""
+    try:
+        return await store.asearch((user_id, "memories"), query=query, limit=10)
+    except AttributeError:
+        # Some OpenAI-compatible servers (e.g. llama-server) return a raw JSON
+        # list from /v1/embeddings instead of {"data": [...]}, which causes the
+        # OpenAI SDK parser to raise AttributeError.  Fall back to recency search.
+        LOGGER.warning(
+            "Memory semantic search failed — embedding endpoint returned an "
+            "incompatible response (not OpenAI-standard). Falling back to "
+            "recency-based memory retrieval. Check the /v1/embeddings response "
+            "format of your OpenAI-compatible server."
+        )
+        try:
+            return await store.asearch((user_id, "memories"), limit=10)
+        except Exception:
+            LOGGER.exception("Memory recency search also failed; no memories injected")
+            return []
+    except Exception:
+        LOGGER.exception("Unexpected memory store search failure; no memories injected")
+        return []
+
+
 async def _call_model(
     state: State, config: RunnableConfig, *, store: BaseStore
 ) -> dict[str, Any]:
@@ -1202,7 +1226,7 @@ async def _call_model(
             query=last_message.content
         )
 
-    mems = await store.asearch((user_id, "memories"), query=query_prompt, limit=10)
+    mems = await _search_memories(store, user_id, query_prompt)
 
     # Recent camera activity.
     camera_activity = await get_recent_camera_activity(hass, store)

--- a/custom_components/home_generative_agent/manifest.json
+++ b/custom_components/home_generative_agent/manifest.json
@@ -34,5 +34,5 @@
     "langchain-google-genai==3.1.0",
     "langchain-anthropic==1.4.3"
   ],
-  "version": "3.14.4"
+  "version": "3.14.5"
 }

--- a/tests/custom_components/home_generative_agent/test_regressions.py
+++ b/tests/custom_components/home_generative_agent/test_regressions.py
@@ -487,9 +487,7 @@ async def test_search_memories_falls_back_to_recency_on_attribute_error(
 
 
 @pytest.mark.asyncio
-async def test_search_memories_returns_empty_when_both_searches_fail(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
+async def test_search_memories_returns_empty_when_both_searches_fail() -> None:
     """Both semantic and recency search failures return [] without propagating."""
     store = MagicMock()
     store.asearch = AsyncMock(
@@ -505,9 +503,7 @@ async def test_search_memories_returns_empty_when_both_searches_fail(
 
 
 @pytest.mark.asyncio
-async def test_search_memories_returns_empty_on_unexpected_error(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
+async def test_search_memories_returns_empty_on_unexpected_error() -> None:
     """Unexpected exceptions are swallowed and return [] so the agent can still respond."""
     store = MagicMock()
     store.asearch = AsyncMock(side_effect=RuntimeError("unexpected failure"))

--- a/tests/custom_components/home_generative_agent/test_regressions.py
+++ b/tests/custom_components/home_generative_agent/test_regressions.py
@@ -19,6 +19,7 @@ from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 import custom_components.home_generative_agent as hga_component
 import custom_components.home_generative_agent.agent.graph as agent_graph
 from custom_components.home_generative_agent.agent import tools as agent_tools
+from custom_components.home_generative_agent.agent.graph import _search_memories
 from custom_components.home_generative_agent.const import SIGNAL_HGA_RECOGNIZED
 from custom_components.home_generative_agent.core.image_entity import LastEventImage
 from custom_components.home_generative_agent.core.person_gallery import PersonGalleryDAO
@@ -434,3 +435,83 @@ async def test_call_model_binds_tools_in_executor(
     assert model.config == {"configurable": {"reasoning": False}}
     assert model.bound_tools == selected_tools
     assert result["messages"].content == "ok"
+
+
+# ---------------------------------------------------------------------------
+# _search_memories — issue #394: llama-server embedding incompatibility
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_memories_returns_semantic_results() -> None:
+    """Happy path: semantic search returns store results unchanged."""
+    store = MagicMock()
+    expected = [MagicMock()]
+    store.asearch = AsyncMock(return_value=expected)
+
+    result = await _search_memories(store, "user-1", "what is the temperature?")
+
+    store.asearch.assert_awaited_once_with(
+        ("user-1", "memories"), query="what is the temperature?", limit=10
+    )
+    assert result is expected
+
+
+@pytest.mark.asyncio
+async def test_search_memories_falls_back_to_recency_on_attribute_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    AttributeError from embedding endpoint falls back to recency search (issue #394).
+
+    llama-server returns a bare JSON list instead of {"data": [...]}, which causes
+    the OpenAI SDK parser to raise AttributeError inside store.asearch.
+    """
+    store = MagicMock()
+    fallback = [MagicMock()]
+    store.asearch = AsyncMock(
+        side_effect=[
+            AttributeError("'list' object has no attribute 'data'"),
+            fallback,
+        ]
+    )
+
+    with caplog.at_level(logging.WARNING):
+        result = await _search_memories(store, "user-1", "some query")
+
+    assert result is fallback
+    assert "incompatible response" in caplog.text
+    # Second call must omit query= (recency-only)
+    _, recency_kwargs = store.asearch.call_args_list[1]
+    assert "query" not in recency_kwargs
+
+
+@pytest.mark.asyncio
+async def test_search_memories_returns_empty_when_both_searches_fail(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Both semantic and recency search failures return [] without propagating."""
+    store = MagicMock()
+    store.asearch = AsyncMock(
+        side_effect=[
+            AttributeError("bad embedding format"),
+            RuntimeError("DB gone"),
+        ]
+    )
+
+    result = await _search_memories(store, "user-1", "query")
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_search_memories_returns_empty_on_unexpected_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Unexpected exceptions are swallowed and return [] so the agent can still respond."""
+    store = MagicMock()
+    store.asearch = AsyncMock(side_effect=RuntimeError("unexpected failure"))
+
+    result = await _search_memories(store, "user-1", "query")
+
+    assert result == []

--- a/tests/custom_components/home_generative_agent/test_tool_retrieval.py
+++ b/tests/custom_components/home_generative_agent/test_tool_retrieval.py
@@ -453,3 +453,73 @@ async def test_retrieve_tools_fallback_when_candidates_filtered_by_api() -> None
     # Disallowed-api item filtered; fallback provides the HA tool
     assert "find_keys" not in result["tool_routing_map"]
     assert "HassSearch" in result["tool_routing_map"]
+
+
+# ---------------------------------------------------------------------------
+# score=None guard — issue #394
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rag_retrieval_none_score_is_treated_as_zero() -> None:
+    """
+    item.score=None must not raise TypeError (issue #394).
+
+    getattr(item, 'score', 0.0) returns None when the attribute exists but is
+    None; the fix normalises it to 0.0 so the threshold comparison is safe.
+    """
+    store = MagicMock()
+    item = MagicMock()
+    item.value = {
+        "name": "some_tool",
+        "api_id": "hga_local",
+        "description": "A tool",
+        "parameters": "{}",
+        "is_actuation": False,
+    }
+    item.score = None
+
+    store.asearch = AsyncMock(return_value=[item])
+
+    config: RunnableConfig = {
+        "configurable": {
+            "options": {"tool_relevance_threshold": 0.15},
+            "tool_index_ready": True,
+        }
+    }
+
+    # Must not raise; None score < threshold so tool is filtered out
+    result = await _get_rag_retrieved_tools(store, config, "query", {"hga_local"})
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_actuation_safety_none_score_does_not_crash() -> None:
+    """
+    item.score=None in actuation safety sort must not raise TypeError (issue #394).
+
+    The lambda key used in sorted() had the same getattr default bug.
+    """
+    store = MagicMock()
+    item = MagicMock()
+    item.value = {
+        "name": "HassTurnOn",
+        "api_id": "assist",
+        "description": "Turn on",
+        "parameters": "{}",
+        "is_actuation": True,
+    }
+    item.score = None
+
+    store.asearch = AsyncMock(return_value=[item])
+
+    config: RunnableConfig = {
+        "configurable": {
+            "options": {},
+            "tool_index_ready": True,
+        }
+    }
+
+    # Must not raise; tool is still returned (actuation safety is not score-gated)
+    result = await _get_actuation_safety_tools(store, config, "turn on the lights", {"assist"})
+    assert any(t["name"] == "HassTurnOn" for t in result)

--- a/tests/custom_components/home_generative_agent/test_tool_retrieval.py
+++ b/tests/custom_components/home_generative_agent/test_tool_retrieval.py
@@ -521,5 +521,7 @@ async def test_actuation_safety_none_score_does_not_crash() -> None:
     }
 
     # Must not raise; tool is still returned (actuation safety is not score-gated)
-    result = await _get_actuation_safety_tools(store, config, "turn on the lights", {"assist"})
+    result = await _get_actuation_safety_tools(
+        store, config, "turn on the lights", {"assist"}
+    )
     assert any(t["name"] == "HassTurnOn" for t in result)


### PR DESCRIPTION
## Summary

- **Bug 1**: llama-server's `/v1/embeddings` returns a bare JSON array instead of the OpenAI-standard `{"data": [...]}` wrapper. The OpenAI SDK parser raises `AttributeError`, which propagated through `store.asearch` and crashed the entire streaming response. Extracted `_search_memories` helper that catches `AttributeError`, logs an actionable warning directing the operator to check their server's embedding format, and falls back to recency-based memory retrieval so the agent can still respond.
- **Bug 2**: `getattr(item, "score", 0.0)` only uses the default when the attribute is *absent*; when the LangGraph store returns `score=None` (item has no embedding vector), the comparison `None >= threshold` raises `TypeError`. Fixed in both `_get_rag_retrieved_tools` and `_get_actuation_safety_tools` using `getattr(item, "score", None) or 0.0`.

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (1038 tests, +6 regression tests)
- [ ] Verify with llama-server that the agent responds instead of returning the timeout error message (unable to test)
- [ ] Confirm the warning log appears when using a llama-server embedding endpoint (unable to test)

Closes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Documentation

- **README.md**: added llama-server embedding incompatibility note to Troubleshooting section — explains the warning log users will see, why semantic search degrades, and recommends Ollama + `mxbai-embed-large` as the embedding provider alongside llama-server for chat.
