### PR TITLE
v3.14.8 fix: NullChat.ainvoke/astream accept positional config arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.14.8] - 2026-05-16
+
+### Fixed
+
+- **`NullChat` fallback no longer crashes with `TypeError` when a provider is
+  unavailable at startup** — `NullChat.ainvoke` and `NullChat.astream` now
+  accept `config` as an explicit second positional parameter, matching the
+  standard LangChain `BaseChatModel` calling convention
+  (`ainvoke(input, config=None, **kwargs)`). Previously, the fallback model
+  used when a provider health check failed at HA startup (e.g., Ollama not yet
+  responsive) would raise `TypeError: NullChat.ainvoke() takes 2 positional
+  arguments but 3 were given` instead of returning the intended graceful
+  `"LLM unavailable."` response. Two regression tests added. Closes
+  [#410](https://github.com/goruck/home-generative-agent/issues/410).
+
 ## [3.14.7] - 2026-05-15
 
 ### Fixed

--- a/custom_components/home_generative_agent/__init__.py
+++ b/custom_components/home_generative_agent/__init__.py
@@ -1056,11 +1056,13 @@ async def _bootstrap_vectors_once(
 class NullChat:
     """Non-throwing fallback implementing common chat model methods."""
 
-    async def ainvoke(self, _input: Any, **_kw: Any) -> str:
+    async def ainvoke(self, _input: Any, _config: Any = None, **_kw: Any) -> str:
         """Return a placeholder response."""
         return "LLM unavailable."
 
-    async def astream(self, _input: Any, **_kw: Any) -> AsyncGenerator[str, Any]:
+    async def astream(
+        self, _input: Any, _config: Any = None, **_kw: Any
+    ) -> AsyncGenerator[str, Any]:
         """Return a placeholder response."""
         yield "LLM unavailable."
 

--- a/custom_components/home_generative_agent/manifest.json
+++ b/custom_components/home_generative_agent/manifest.json
@@ -34,5 +34,5 @@
     "langchain-google-genai==3.1.0",
     "langchain-anthropic==1.4.3"
   ],
-  "version": "3.14.7"
+  "version": "3.14.8"
 }

--- a/tests/custom_components/home_generative_agent/test_video_analyzer_priority.py
+++ b/tests/custom_components/home_generative_agent/test_video_analyzer_priority.py
@@ -507,6 +507,20 @@ async def test_summary_null_chat_with_config_does_not_raise(
         await va._generate_summary(frame_descs)  # type: ignore[attr-defined]
 
 
+@pytest.mark.asyncio
+async def test_null_chat_ainvoke_accepts_positional_config() -> None:
+    """NullChat.ainvoke accepts config as a positional arg (LangChain convention)."""
+    result = await NullChat().ainvoke([], {"configurable": {}})
+    assert result == "LLM unavailable."
+
+
+@pytest.mark.asyncio
+async def test_null_chat_astream_accepts_positional_config() -> None:
+    """NullChat.astream accepts config as a positional arg (LangChain convention)."""
+    chunks = [chunk async for chunk in NullChat().astream([], {"configurable": {}})]
+    assert chunks == ["LLM unavailable."]
+
+
 # ---------------------------------------------------------------------------
 # Shared semaphore: VLM and summary share the same concurrency limit
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes `NullChat`, the fallback model used when a provider health check fails at HA startup.

**Bug:** `NullChat.ainvoke` and `NullChat.astream` only accepted `_input` as a positional argument. `_invoke_model` in `graph.py` calls `model.ainvoke(messages, config)` — passing `config` positionally, which is the standard LangChain `BaseChatModel` convention. This raised `TypeError: NullChat.ainvoke() takes 2 positional arguments but 3 were given` instead of the intended graceful `"LLM unavailable."` response. Surfaced in issue #394 when a user's Ollama health check failed at startup.

**Fix:** Both methods now declare `_config: Any = None` as an explicit second positional parameter, matching the LangChain interface. Two regression tests added.

Closes #410. Surfaced by #394.

## Test Coverage

| Method | Changed? | Direct test | Covered? |
|---|---|---|---|
| `ainvoke` | YES (`_config` added) | `test_null_chat_ainvoke_accepts_positional_config` (new) | ✅ |
| `astream` | YES (`_config` added) | `test_null_chat_astream_accepts_positional_config` (new) | ✅ |
| `with_config` | No | pre-existing integration tests | ✅ |
| `bind_tools` | No | — | pre-existing gap, out of scope |

Tests: 1069 → 1071 (+2 new regression tests)
Coverage gate: PASS (100% of changed paths)

## Pre-Landing Review

No issues found. 0 errors, 0 warnings from pyright. Lint clean.

## Adversarial Review

6 findings, all informational — none blocking:
- Silent empty response when NullChat is active (pre-existing behavior, not introduced here)
- No `_invoke_model`-level integration test (future work, tracked in #410)
- `_config` naming vs LangChain `config` keyword (harmless — NullChat discards all args)
- `astream` return type annotation pre-existing mismatch (pre-existing)
- `contextlib.suppress` coupling in existing test (correct behavior per reviewer)
- No LangGraph pipeline integration test for NullChat (future work, tracked in #410)

## Plan Completion

No plan file for this branch.

## Test plan

- [x] 1071 tests pass (0 failures)
- [x] Pyright: 0 errors, 0 warnings
- [x] Ruff lint: all checks passed
- [x] `test_null_chat_ainvoke_accepts_positional_config` — ainvoke with positional config returns "LLM unavailable."
- [x] `test_null_chat_astream_accepts_positional_config` — astream with positional config yields "LLM unavailable."

🤖 Generated with [Claude Code](https://claude.com/claude-code)