### PR TITLE
Fix read-only open-state live context queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.14.9] - 2026-05-17
+
+### Fixed
+
+- **Read-only open-state queries are more reliable across local tool-calling
+  models** — HGA now force-binds and promotes `GetLiveContext` for read-only
+  queries such as "list all open windows" and "list the open doors in my house",
+  even when semantic tool retrieval misses it or ranks less relevant tools
+  higher. The first `GetLiveContext` call for these queries is normalized to a
+  broad `binary_sensor` live-context request so local models that emit brittle
+  filters like `name: "Window"` or list-valued domains still get the needed
+  state. Broad live-context results are then filtered back to the requested
+  entity type, preventing door queries from volunteering open windows. Focused
+  regression tests cover retrieval, argument normalization, retry handling, and
+  scoped result filtering.
+
 ## [3.14.8] - 2026-05-16
 
 ### Fixed

--- a/custom_components/home_generative_agent/agent/graph.py
+++ b/custom_components/home_generative_agent/agent/graph.py
@@ -575,6 +575,89 @@ def _parse_open_entries_from_live_context(raw: str) -> list[str]:
     return open_entries
 
 
+def _open_state_name_matches_query(name: str, query: str) -> bool:
+    """Return whether an open entry name is in scope for the user's query."""
+    name_lc = name.lower()
+    query_lc = query.lower()
+    if "window" in query_lc:
+        return "window" in name_lc
+    if "door" in query_lc:
+        return "door" in name_lc
+    if "gate" in query_lc:
+        return "gate" in name_lc
+    return True
+
+
+def _open_state_empty_result(query: str) -> str:
+    """Return a scoped empty live-context result for the user's query."""
+    query_lc = query.lower()
+    if "window" in query_lc:
+        return "Live Context: No open windows were found."
+    if "door" in query_lc:
+        return "Live Context: No open doors were found."
+    if "gate" in query_lc:
+        return "Live Context: No open gates were found."
+    return "Live Context: No open entries were found."
+
+
+def _filter_open_state_live_context_content(content: str, query: str) -> str:
+    """Filter broad live context down to the open entries requested by the user."""
+    if not _query_is_read_only_open_state(query):
+        return content
+
+    parsed: dict[str, Any] | None = None
+    try:
+        maybe_parsed = json.loads(content)
+    except json.JSONDecodeError:
+        maybe_parsed = None
+    if isinstance(maybe_parsed, dict):
+        parsed = maybe_parsed
+        raw_result = str(parsed.get("result") or parsed.get("response") or "")
+    else:
+        raw_result = content
+
+    open_entries = [
+        name
+        for name in _parse_open_entries_from_live_context(raw_result)
+        if _open_state_name_matches_query(name, query)
+    ]
+    if open_entries:
+        result = "Live Context: Open entries matching the request:\n" + "\n".join(
+            f"- names: {name}\n  state: 'on'\n  attributes:\n    device_class: opening"
+            for name in open_entries
+        )
+    else:
+        result = _open_state_empty_result(query)
+
+    if parsed is None:
+        return result
+
+    filtered = dict(parsed)
+    filtered["result"] = result
+    return json.dumps(filtered)
+
+
+def _maybe_filter_open_state_tool_response(
+    tool_response: ToolMessage,
+    tool_call: dict[str, Any],
+    first_open_state_live_context_call: dict[str, Any] | None,
+    tool_name: str,
+    query: str,
+) -> ToolMessage:
+    """Filter broad live context before returning it to the model."""
+    if (
+        tool_call is not first_open_state_live_context_call
+        or tool_name != "GetLiveContext"
+        or not isinstance(tool_response.content, str)
+    ):
+        return tool_response
+
+    tool_response.content = _filter_open_state_live_context_content(
+        tool_response.content, query
+    )
+    return tool_response
+
+
 async def _find_open_entries(
     hass: HomeAssistant, messages: list[AnyMessage]
 ) -> list[str]:
@@ -719,16 +802,76 @@ async def _get_rag_retrieved_tools(
 _MAX_ACTION_ROUNDS = 3
 
 
-def _query_needs_actuation_safety(query: str) -> bool:
-    """Return True when the query warrants force-injection of actuation tools."""
-    if not re.search(ACTUATION_KEYWORDS_REGEX, query):
-        return False
-    return not (
-        re.search(READ_ONLY_STATE_QUERY_REGEX, query)
+def _query_is_read_only_open_state(query: str) -> bool:
+    """Return True when open/opened describes state instead of an action."""
+    return bool(
+        re.search(ACTUATION_KEYWORDS_REGEX, query)
+        and re.search(READ_ONLY_STATE_QUERY_REGEX, query)
         and re.search(OPEN_AS_STATE_REGEX, query)
         and not re.search(NON_OPEN_ACTUATION_KEYWORDS_REGEX, query)
         and not re.search(OPEN_COMMAND_CLAUSE_REGEX, query)
     )
+
+
+def _latest_open_state_query(messages: Sequence[BaseMessage]) -> str:
+    """Return the active read-only open-state query, including short retries."""
+    latest_human = ""
+    for msg in reversed(messages):
+        if isinstance(msg, HumanMessage):
+            latest_human = str(msg.content)
+            break
+
+    if _query_is_read_only_open_state(latest_human):
+        return latest_human
+
+    if latest_human.strip().lower() not in {"yes", "y", "try again", "again"}:
+        return ""
+
+    for msg in reversed(messages):
+        if not isinstance(msg, HumanMessage):
+            continue
+        query = str(msg.content)
+        if _query_is_read_only_open_state(query):
+            return query
+    return ""
+
+
+def _normalize_live_context_args_for_open_state(
+    tool_name: str,
+    tool_args: dict[str, Any],
+    query: str,
+    *,
+    force_broad: bool = True,
+) -> dict[str, Any]:
+    """Normalize brittle GetLiveContext calls for read-only open-state queries."""
+    if (
+        not force_broad
+        or tool_name != "GetLiveContext"
+        or not _query_is_read_only_open_state(query)
+    ):
+        return tool_args
+    return {"domain": "binary_sensor"}
+
+
+def _open_state_live_context_normalization_context(
+    messages: Sequence[BaseMessage], tool_calls: list[dict[str, Any]]
+) -> tuple[str, dict[str, Any] | None]:
+    """Return the open-state query and first live-context call to widen."""
+    query = _latest_open_state_query(messages)
+    if not query:
+        return "", None
+    first_call = next(
+        (tc for tc in tool_calls if tc.get("name", "") == "GetLiveContext"),
+        None,
+    )
+    return query, first_call
+
+
+def _query_needs_actuation_safety(query: str) -> bool:
+    """Return True when the query warrants force-injection of actuation tools."""
+    if not re.search(ACTUATION_KEYWORDS_REGEX, query):
+        return False
+    return not _query_is_read_only_open_state(query)
 
 
 async def _get_actuation_safety_tools(
@@ -1012,6 +1155,50 @@ async def _get_pending_pin_tools(
     ]
 
 
+async def _get_tool_by_name(
+    store: BaseStore,
+    config: RunnableConfig,
+    name: str,
+    allowed_api_ids: set[str],
+) -> RawTool | None:
+    """Fetch a specific tool by name from the index, falling back to config tools."""
+    for api_id in sorted(allowed_api_ids):
+        try:
+            item = await store.aget(("system", "tools"), key=f"{api_id}::{name}")
+        except (
+            InvalidNamespaceError,
+            psycopg.OperationalError,
+            psycopg.ProgrammingError,
+            ValueError,
+        ) as err:
+            LOGGER.debug("Could not fetch %s from tool index: %s", name, err)
+            break
+        except Exception:
+            LOGGER.exception("Unexpected failure fetching %s from tool index", name)
+            break
+
+        if item is None:
+            continue
+
+        val = item.value
+        if val.get("name") != name or val.get("api_id") not in allowed_api_ids:
+            continue
+
+        return RawTool(
+            name=val["name"],
+            api_id=val["api_id"],
+            description=val["description"],
+            parameters=val["parameters"],
+            is_actuation=val.get("is_actuation", False),
+        )
+
+    for tool in _get_fallback_tools(config, allowed_api_ids):
+        if tool["name"] == name and tool["api_id"] in allowed_api_ids:
+            return tool
+
+    return None
+
+
 async def _retrieve_tools(
     state: State,
     config: RunnableConfig,
@@ -1089,10 +1276,21 @@ async def _retrieve_tools(
             fallback = live_context + non_actuation + actuation
         all_candidates = fallback[:limit]
 
-    # 3b. For read-only open-state queries, promote GetLiveContext to the front
-    # of the normal-path candidate list so it is not displaced by other RAG tools
-    # that may score nearby despite being less relevant.
-    if not _query_needs_actuation_safety(query):
+    # 3b. For read-only open-state queries, force-bind GetLiveContext and promote
+    # it to the front. RAG can otherwise miss it, leaving the prompt to require a
+    # tool that was not actually included in the model schema.
+    if _query_is_read_only_open_state(query):
+        all_candidates = [
+            t
+            for t in all_candidates
+            if not t["is_actuation"] or t["name"] == "GetLiveContext"
+        ]
+        if not any(t["name"] == "GetLiveContext" for t in all_candidates):
+            live_context = await _get_tool_by_name(
+                store, config, "GetLiveContext", allowed_api_ids
+            )
+            if live_context is not None:
+                all_candidates = [live_context, *all_candidates]
         live_ctx = [t for t in all_candidates if t["name"] == "GetLiveContext"]
         rest = [t for t in all_candidates if t["name"] != "GetLiveContext"]
         all_candidates = live_ctx + rest
@@ -1526,9 +1724,11 @@ async def _call_tools(
     tool_calls: list[dict[str, Any]] = (
         raw_tool_calls if isinstance(raw_tool_calls, list) else []
     )
-    tool_responses: list[ToolMessage] = []
 
     tool_routing_map: dict[str, str] = state.get("tool_routing_map", {})
+    open_state_query, first_open_state_live_context_call = (
+        _open_state_live_context_normalization_context(state["messages"], tool_calls)
+    )
 
     # Execute all tool calls concurrently.
     # asyncio.gather preserves submission order: results[i] matches tool_calls[i].
@@ -1538,6 +1738,20 @@ async def _call_tools(
         """Execute a single tool call and return its ToolMessage."""
         tool_name = tool_call.get("name", "")
         tool_args = tool_call.get("args", {}) or {}
+        normalized_args = _normalize_live_context_args_for_open_state(
+            tool_name,
+            tool_args,
+            open_state_query,
+            force_broad=tool_call is first_open_state_live_context_call,
+        )
+        if normalized_args != tool_args:
+            LOGGER.debug(
+                "Normalized GetLiveContext args for read-only open-state query: "
+                "%s -> %s",
+                tool_args,
+                normalized_args,
+            )
+            tool_args = normalized_args
         LOGGER.debug("Tool call: %s(%s)", tool_name, tool_args)
 
         # Enforce the retrieved tool set: reject calls for tools that were not
@@ -1587,6 +1801,13 @@ async def _call_tools(
                 ctx=ctx,
                 tool_call=tool_call,
             )
+        tool_response = _maybe_filter_open_state_tool_response(
+            tool_response,
+            tool_call,
+            first_open_state_live_context_call,
+            tool_name,
+            open_state_query,
+        )
         LOGGER.debug("Tool response: %s", tool_response)
         return tool_response
 

--- a/custom_components/home_generative_agent/agent/graph.py
+++ b/custom_components/home_generative_agent/agent/graph.py
@@ -108,6 +108,9 @@ _LLM_INVOKE_TIMEOUT_S: float = 180.0
 
 _PIN_LOOKBACK = 20  # messages to scan for an unresolved requires_pin
 _ROUTING_REJECTION_MARKER = "is not available for this request"
+_OPEN_STATE_RETRY_PHRASES: frozenset[str] = frozenset(
+    {"yes", "y", "try again", "again"}
+)
 
 
 class State(MessagesState):
@@ -191,7 +194,7 @@ async def _precheck_alarm_open_entries(
     if is_disarm:
         return None
 
-    open_entries = await _find_open_entries(ctx.hass, ctx.state["messages"])
+    open_entries = await _find_open_entries(ctx.hass, [])
     if not open_entries:
         return None
 
@@ -575,29 +578,29 @@ def _parse_open_entries_from_live_context(raw: str) -> list[str]:
     return open_entries
 
 
+_OPEN_ENTITY_KEYWORDS: tuple[str, ...] = ("window", "door", "gate")
+
+
 def _open_state_name_matches_query(name: str, query: str) -> bool:
     """Return whether an open entry name is in scope for the user's query."""
     name_lc = name.lower()
     query_lc = query.lower()
-    if "window" in query_lc:
-        return "window" in name_lc
-    if "door" in query_lc:
-        return "door" in name_lc
-    if "gate" in query_lc:
-        return "gate" in name_lc
-    return True
+    present = [kw for kw in _OPEN_ENTITY_KEYWORDS if kw in query_lc]
+    if not present:
+        return True
+    return any(kw in name_lc for kw in present)
 
 
 def _open_state_empty_result(query: str) -> str:
     """Return a scoped empty live-context result for the user's query."""
     query_lc = query.lower()
-    if "window" in query_lc:
-        return "Live Context: No open windows were found."
-    if "door" in query_lc:
-        return "Live Context: No open doors were found."
-    if "gate" in query_lc:
-        return "Live Context: No open gates were found."
-    return "Live Context: No open entries were found."
+    present = [kw for kw in _OPEN_ENTITY_KEYWORDS if kw in query_lc]
+    if not present:
+        return "Live Context: No open entries were found."
+    if len(present) == 1:
+        return f"Live Context: No open {present[0]}s were found."
+    entity_list = ", ".join(f"{kw}s" for kw in present[:-1]) + f" or {present[-1]}s"
+    return f"Live Context: No open {entity_list} were found."
 
 
 def _filter_open_state_live_context_content(content: str, query: str) -> str:
@@ -612,12 +615,14 @@ def _filter_open_state_live_context_content(content: str, query: str) -> str:
         maybe_parsed = None
     if isinstance(maybe_parsed, dict):
         parsed = maybe_parsed
+        if parsed.get("success") is False or parsed.get("error"):
+            return content
         raw_result = str(parsed.get("result") or parsed.get("response") or "")
     else:
         raw_result = content
 
     open_entries = [
-        name
+        name.replace("\n", " ").replace("\r", " ")[:128]
         for name in _parse_open_entries_from_live_context(raw_result)
         if _open_state_name_matches_query(name, query)
     ]
@@ -824,15 +829,16 @@ def _latest_open_state_query(messages: Sequence[BaseMessage]) -> str:
     if _query_is_read_only_open_state(latest_human):
         return latest_human
 
-    if latest_human.strip().lower() not in {"yes", "y", "try again", "again"}:
+    if latest_human.strip().lower() not in _OPEN_STATE_RETRY_PHRASES:
         return ""
 
     for msg in reversed(messages):
         if not isinstance(msg, HumanMessage):
             continue
         query = str(msg.content)
-        if _query_is_read_only_open_state(query):
-            return query
+        if query.strip().lower() in _OPEN_STATE_RETRY_PHRASES:
+            continue
+        return query if _query_is_read_only_open_state(query) else ""
     return ""
 
 
@@ -1187,8 +1193,8 @@ async def _get_tool_by_name(
         return RawTool(
             name=val["name"],
             api_id=val["api_id"],
-            description=val["description"],
-            parameters=val["parameters"],
+            description=val.get("description", ""),
+            parameters=val.get("parameters", "{}"),
             is_actuation=val.get("is_actuation", False),
         )
 
@@ -1286,14 +1292,14 @@ async def _retrieve_tools(
             if not t["is_actuation"] or t["name"] == "GetLiveContext"
         ]
         if not any(t["name"] == "GetLiveContext" for t in all_candidates):
-            live_context = await _get_tool_by_name(
+            fetched_live_ctx = await _get_tool_by_name(
                 store, config, "GetLiveContext", allowed_api_ids
             )
-            if live_context is not None:
-                all_candidates = [live_context, *all_candidates]
+            if fetched_live_ctx is not None:
+                all_candidates = [fetched_live_ctx, *all_candidates]
         live_ctx = [t for t in all_candidates if t["name"] == "GetLiveContext"]
         rest = [t for t in all_candidates if t["name"] != "GetLiveContext"]
-        all_candidates = live_ctx + rest
+        all_candidates = (live_ctx + rest)[: limit + 1]
 
     # 4. Format and deduplicate
     selected_tools, routing_map = _format_and_dedupe_tools(all_candidates)

--- a/custom_components/home_generative_agent/const.py
+++ b/custom_components/home_generative_agent/const.py
@@ -934,9 +934,13 @@ NON_OPEN_ACTUATION_KEYWORDS_REGEX = (
 
 # Compound state-then-command forms where "open" is used as a command verb
 # despite the query also containing read-only state language.
-# Covers: "show me open windows and then open the garage door".
+# Covers: "show me open windows and then open the garage door",
+#         "list open windows and open the garage door" (via article anchor).
 # Known gap: comma- or period-separated compound forms are not detected.
-OPEN_COMMAND_CLAUSE_REGEX = r"(?i)\b(?:then|and then|after that)\s+open\b"
+OPEN_COMMAND_CLAUSE_REGEX = (
+    r"(?i)\b(?:then|and then|after that)\s+open\b"
+    r"|\band\s+open\s+(?:the|a|an)\b"
+)
 
 # Tool prefixes/names for actuation safety net
 ACTUATION_TOOL_PREFIXES = (

--- a/custom_components/home_generative_agent/manifest.json
+++ b/custom_components/home_generative_agent/manifest.json
@@ -34,5 +34,5 @@
     "langchain-google-genai==3.1.0",
     "langchain-anthropic==1.4.3"
   ],
-  "version": "3.14.8"
+  "version": "3.14.9"
 }

--- a/docs/issue-394-openai-compatible-e2e-test-plan.md
+++ b/docs/issue-394-openai-compatible-e2e-test-plan.md
@@ -30,6 +30,9 @@ All three bugs are already fixed in the codebase. This plan is about
 | `AttributeError` on bare embedding list | `_search_memories()` in `agent/graph.py` catches `AttributeError` and falls back to recency search |
 | `score=None` TypeError | `_get_rag_retrieved_tools()` and `_get_actuation_safety_tools()` both guard with `getattr(item, "score", None) or 0.0` |
 | Tool-selection loop | `_tool_loop_guard()` fires after `_MAX_ACTION_ROUNDS = 3` rounds via the `action_rounds` state counter |
+| Read-only open-state tool selection | `_retrieve_tools()` force-binds and promotes `GetLiveContext` for read-only open-state queries, even when RAG misses it |
+| Brittle local-model `GetLiveContext` args | `_call_tools()` normalizes the first read-only open-state `GetLiveContext` call to broad `{"domain": "binary_sensor"}` |
+| Broad open-state result pollution | `_filter_open_state_live_context_content()` filters broad binary-sensor results back to the requested type, such as doors or windows |
 
 Existing coverage should be preserved and extended only where a real assertion
 gap remains:
@@ -38,7 +41,11 @@ gap remains:
 |----------|---------------|-----|
 | llama-server embedding `AttributeError` fallback | `test_search_memories_falls_back_to_recency_on_attribute_error` in `test_regressions.py` | None — verified |
 | `score=None` retrieval guard | `test_rag_retrieval_none_score_is_treated_as_zero` and `test_actuation_safety_none_score_does_not_crash` in `test_tool_retrieval.py` | None — verified |
-| Read-only `open` query avoids actuation injection | `test_retrieve_tools_no_actuation_safety_for_read_only_open` in `test_tool_retrieval.py` | Asserts `tool_routing_map` presence only; does not assert `GetLiveContext` is first in `selected_tools` |
+| Read-only `open` query avoids actuation injection and promotes `GetLiveContext` | `test_retrieve_tools_no_actuation_safety_for_read_only_open` in `test_tool_retrieval.py` | None — verified |
+| Read-only open-door query force-binds `GetLiveContext` when RAG misses it | `test_retrieve_tools_force_injects_live_context_for_open_doors` in `test_tool_retrieval.py` | None — verified |
+| Open commands keep actuation behavior | `test_retrieve_tools_open_command_does_not_force_live_context` in `test_tool_retrieval.py` | None — verified |
+| Local-model live-context args are widened only for the first read-only open-state call | `test_normalize_live_context_args_for_read_only_open_state`, `test_normalize_live_context_args_does_not_touch_open_command`, and `test_normalize_live_context_args_can_leave_subsequent_calls_alone` in `test_tool_retrieval.py` | None — verified |
+| Broad live-context results are scoped to the requested open entity type | `test_filter_open_state_live_context_scopes_door_query` and `test_filter_open_state_live_context_keeps_requested_open_windows` in `test_tool_retrieval.py` | None — verified |
 | `action_rounds` reset at turn start | `test_retrieve_tools_action_rounds_reset` in `test_tool_retrieval.py` | None — verified |
 | Repeated unproductive tool calls return a friendly message | Not covered | Add direct `_should_continue()` / `_tool_loop_guard()` regression test |
 
@@ -57,9 +64,15 @@ The manual smoke-test checklist in Section 4 covers real llama-server validation
 The important assertions are:
 
 - HGA survives llama-server's incompatible embedding response shape.
-- Read-only open-state queries favor `GetLiveContext` over actuation safety tools.
+- Read-only open-state queries force-bind and favor `GetLiveContext` over
+  actuation safety tools.
 - Actuation safety tools are not force-injected solely because the query contains
   `open`.
+- The first read-only open-state `GetLiveContext` call is widened to
+  `{"domain": "binary_sensor"}` so local models can ask for current state without
+  brittle partial-name filters.
+- Broad live-context output is filtered before the model sees it so a door query
+  does not report open windows, and a window query does not report open doors.
 - Repeated unproductive tool calls return HGA's friendly loop-guard message
   instead of surfacing `GraphRecursionError`.
 
@@ -78,23 +91,34 @@ No fake HTTP server needed — the exception is what matters, not the transport.
 Do not add another embedding-shape test unless this existing assertion is
 removed or materially weakened.
 
-### 2. Read-only open-window tool selection (extend in `test_tool_retrieval.py`)
+### 2. Read-only open-window tool selection (covered in `test_tool_retrieval.py`)
 
-`test_retrieve_tools_no_actuation_safety_for_read_only_open` currently asserts
-that `GetLiveContext` is present in `result["tool_routing_map"]` and that
-`HassTurnOn` is absent. It does not assert anything about `result["selected_tools"]`
-or ordering.
+`test_retrieve_tools_no_actuation_safety_for_read_only_open` asserts that
+`GetLiveContext` is present, first in `selected_tools`, and that `HassTurnOn` is
+absent for read-only open-window queries.
 
-Extend this test with two additional assertions:
+`test_retrieve_tools_force_injects_live_context_for_open_doors` covers the
+weaker-model path where RAG retrieves nearby non-state tools but misses
+`GetLiveContext`; the retrieval layer now fetches and prepends `GetLiveContext`
+deterministically.
 
-- `result["selected_tools"][0]` is `"GetLiveContext"` (first in the ordered list).
-- No actuation safety tool name appears anywhere in `result["selected_tools"]`.
+`test_retrieve_tools_open_command_does_not_force_live_context` preserves true
+actuation behavior for commands such as `open the garage door`.
 
-The existing mock setup (`store.asearch` returning a single `GetLiveContext` item
-with `score=0.85`) is sufficient — no new fixtures needed.
+### 2a. Read-only open-state tool-call normalization (covered in `test_tool_retrieval.py`)
 
-Do not add a new open-window retrieval test unless the existing test is split for
-clarity.
+Some local tool-calling models emit brittle filters for these queries, such as
+`{"domain": ["binary_sensor"], "name": "Window"}` or list-valued names. The
+first `GetLiveContext` call in a read-only open-state turn is widened to
+`{"domain": "binary_sensor"}`. Focused tests cover normalization, preservation
+of true open commands, and leaving subsequent more-specific calls alone.
+
+### 2b. Scoped broad live-context results (covered in `test_tool_retrieval.py`)
+
+Because the first call is intentionally broad, HGA filters the tool result before
+returning it to the model. Door queries receive only open door entries or the
+scoped empty result `Live Context: No open doors were found.` Window queries keep
+only open window entries. Regression tests cover both cases.
 
 ### 3. Loop-guard regression (add to `test_regressions.py`)
 
@@ -136,7 +160,9 @@ Query: list all open windows
 Expected:
 - Tool retrieval shows GetLiveContext first or near the front.
 - safety=0/0 for the read-only open-state query.
-- The final answer lists open binary_sensor entities.
+- The first GetLiveContext call is broad binary_sensor live context.
+- The filtered tool result contains only the requested open entry type.
+- The final answer lists the requested open binary_sensor entities.
 - No GraphRecursionError reaches the user.
 - No AttributeError: 'list' object has no attribute 'data' escapes to HA logs.
 ```
@@ -145,6 +171,8 @@ Useful log evidence:
 
 ```text
 Tool retrieval: ... safety=0/0 ... tools=['GetLiveContext', ...]
+Normalized GetLiveContext args for read-only open-state query: ... -> {'domain': 'binary_sensor'}
+Live Context: Open entries matching the request:
 ```
 
 This checklist can be used by issue reporters, release testers, GitHub Actions,

--- a/tests/custom_components/home_generative_agent/test_tool_retrieval.py
+++ b/tests/custom_components/home_generative_agent/test_tool_retrieval.py
@@ -3,19 +3,24 @@
 
 from __future__ import annotations
 
+import json
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock
 
 import psycopg
 import pytest
 from homeassistant.helpers import llm
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
 
 from custom_components.home_generative_agent.agent.graph import (
     State,
+    _filter_open_state_live_context_content,
     _get_actuation_safety_tools,
     _get_allowed_api_ids,
     _get_rag_retrieved_tools,
+    _latest_open_state_query,
+    _normalize_live_context_args_for_open_state,
     _query_needs_actuation_safety,
     _retrieve_tools,
     _split_query_intents,
@@ -575,6 +580,138 @@ def test_query_needs_actuation_safety_no_actuation_keyword() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    ("tool_args", "query"),
+    [
+        ({"domain": ["binary_sensor"], "name": "Window"}, "list all open windows"),
+        (
+            {"domain": ["binary_sensor"], "name": "Door"},
+            "list the open doors in my house",
+        ),
+        (
+            {"domain": ["binary_sensor"], "name": ["Sliding Door", "Door Lock"]},
+            "list the open doors in my house",
+        ),
+    ],
+)
+def test_normalize_live_context_args_for_read_only_open_state(
+    tool_args: dict[str, Any], query: str
+) -> None:
+    """Brittle model-generated live-context filters are widened for open-state checks."""
+    assert _normalize_live_context_args_for_open_state(
+        "GetLiveContext", tool_args, query
+    ) == {"domain": "binary_sensor"}
+
+
+def test_normalize_live_context_args_does_not_touch_open_command() -> None:
+    """Actual open commands must not be converted to read-only live context."""
+    tool_args: dict[str, Any] = {"domain": ["cover"], "name": "Garage Door"}
+
+    assert (
+        _normalize_live_context_args_for_open_state(
+            "GetLiveContext", tool_args, "open the garage door"
+        )
+        == tool_args
+    )
+
+
+def test_normalize_live_context_args_can_leave_subsequent_calls_alone() -> None:
+    """Only the first live-context call is widened to avoid duplicate broad payloads."""
+    tool_args: dict[str, Any] = {
+        "domain": "binary_sensor",
+        "name": "Breakfast Nook Left Window",
+    }
+
+    assert (
+        _normalize_live_context_args_for_open_state(
+            "GetLiveContext",
+            tool_args,
+            "list all open windows",
+            force_broad=False,
+        )
+        == tool_args
+    )
+
+
+def test_latest_open_state_query_uses_previous_query_for_retry() -> None:
+    """Short retries should keep the prior read-only open-state query active."""
+    messages: list[BaseMessage] = [
+        HumanMessage(content="list all open windows"),
+        AIMessage(content="Would you like me to try once more?"),
+        HumanMessage(content="yes"),
+    ]
+
+    assert _latest_open_state_query(messages) == "list all open windows"
+
+
+def test_filter_open_state_live_context_scopes_door_query() -> None:
+    """Door queries must not expose open windows from the broad binary sensor context."""
+    payload = {
+        "success": True,
+        "result": (
+            "Live Context:\n"
+            "- names: Front Door\n"
+            "  domain: binary_sensor\n"
+            "  state: 'off'\n"
+            "  attributes:\n"
+            "    device_class: opening\n"
+            "- names: Family Room Right Window\n"
+            "  domain: binary_sensor\n"
+            "  state: 'on'\n"
+            "  attributes:\n"
+            "    device_class: opening\n"
+            "- names: Garage and Play Room Doors\n"
+            "  domain: binary_sensor\n"
+            "  state: 'off'\n"
+            "  attributes:\n"
+            "    device_class: opening\n"
+        ),
+    }
+
+    filtered = json.loads(
+        _filter_open_state_live_context_content(
+            json.dumps(payload), "list the open doors in my house"
+        )
+    )
+
+    assert filtered["result"] == "Live Context: No open doors were found."
+
+
+def test_filter_open_state_live_context_keeps_requested_open_windows() -> None:
+    """Window queries keep only matching open windows from the broad context."""
+    payload = {
+        "success": True,
+        "result": (
+            "Live Context:\n"
+            "- names: Breakfast Nook Side Right Window\n"
+            "  domain: binary_sensor\n"
+            "  state: 'on'\n"
+            "  attributes:\n"
+            "    device_class: opening\n"
+            "- names: Family Room Sliding Door\n"
+            "  domain: binary_sensor\n"
+            "  state: 'on'\n"
+            "  attributes:\n"
+            "    device_class: opening\n"
+            "- names: Landing Windows\n"
+            "  domain: binary_sensor\n"
+            "  state: 'on'\n"
+            "  attributes:\n"
+            "    device_class: opening\n"
+        ),
+    }
+
+    filtered = json.loads(
+        _filter_open_state_live_context_content(
+            json.dumps(payload), "list all open windows"
+        )
+    )
+
+    assert "Breakfast Nook Side Right Window" in filtered["result"]
+    assert "Landing Windows" in filtered["result"]
+    assert "Family Room Sliding Door" not in filtered["result"]
+
+
 def test_query_needs_actuation_safety_comma_compound_known_gap() -> None:
     """Known gap: comma-separated 'open' command is not detected; actuation suppressed."""
     query = "show me open windows, open the garage door"
@@ -640,6 +777,117 @@ async def test_retrieve_tools_no_actuation_safety_for_read_only_open() -> None:
     # No actuation tool should appear anywhere in the selection.
     selected_names = [t["function"]["name"] for t in result["selected_tools"]]
     assert "HassTurnOn" not in selected_names
+
+
+@pytest.mark.asyncio
+async def test_retrieve_tools_force_injects_live_context_for_open_doors() -> None:
+    """Read-only open-door queries must bind GetLiveContext even when RAG misses it."""
+    query = "list the open doors in my house"
+    state: State = {
+        "messages": [MagicMock(content=query)],
+        "summary": "",
+        "chat_model_usage_metadata": {},
+        "messages_to_remove": [],
+        "selected_tools": [],
+        "tool_routing_map": {},
+        "action_rounds": 0,
+    }
+    store = MagicMock()
+
+    rag_items = []
+    for name, is_actuation in (
+        ("get_entity_history", False),
+        ("HassBroadcast", True),
+        ("HassTurnOn", True),
+        ("resolve_entity_ids", False),
+        ("alarm_control", True),
+    ):
+        item = MagicMock()
+        item.value = {
+            "name": name,
+            "api_id": "assist",
+            "description": name,
+            "parameters": "{}",
+            "is_actuation": is_actuation,
+        }
+        item.score = 0.9
+        rag_items.append(item)
+
+    live_ctx_item = MagicMock()
+    live_ctx_item.value = {
+        "name": "GetLiveContext",
+        "api_id": "assist",
+        "description": "Get live home state",
+        "parameters": "{}",
+        "is_actuation": False,
+    }
+
+    store.asearch = AsyncMock(return_value=rag_items)
+    store.aget = AsyncMock(return_value=live_ctx_item)
+
+    config: RunnableConfig = {
+        "configurable": {
+            "options": {"llm_hass_api": ["assist"], "tool_relevance_threshold": 0.15},
+            "tool_index_ready": True,
+            "langchain_tools": {},
+            "ha_llm_api": MagicMock(apis={}),
+        }
+    }
+
+    result = await _retrieve_tools(state, config, store=store)
+    selected_names = [t["function"]["name"] for t in result["selected_tools"]]
+
+    assert selected_names[0] == "GetLiveContext"
+    assert "GetLiveContext" in result["tool_routing_map"]
+    assert "get_entity_history" in result["tool_routing_map"]
+    assert "resolve_entity_ids" in result["tool_routing_map"]
+    assert "HassTurnOn" not in result["tool_routing_map"]
+    assert "HassBroadcast" not in result["tool_routing_map"]
+    assert "alarm_control" not in result["tool_routing_map"]
+
+
+@pytest.mark.asyncio
+async def test_retrieve_tools_open_command_does_not_force_live_context() -> None:
+    """Open commands must keep actuation safety behavior."""
+    query = "open the garage door"
+    state: State = {
+        "messages": [MagicMock(content=query)],
+        "summary": "",
+        "chat_model_usage_metadata": {},
+        "messages_to_remove": [],
+        "selected_tools": [],
+        "tool_routing_map": {},
+        "action_rounds": 0,
+    }
+    store = MagicMock()
+
+    safety_item = MagicMock()
+    safety_item.value = {
+        "name": "HassTurnOn",
+        "api_id": "assist",
+        "description": "Turn on",
+        "parameters": "{}",
+        "is_actuation": True,
+    }
+    safety_item.score = 0.9
+
+    store.asearch = AsyncMock(return_value=[safety_item])
+    store.aget = AsyncMock()
+
+    config: RunnableConfig = {
+        "configurable": {
+            "options": {"llm_hass_api": ["assist"], "tool_relevance_threshold": 0.15},
+            "tool_index_ready": True,
+            "langchain_tools": {},
+            "ha_llm_api": MagicMock(apis={}),
+        }
+    }
+
+    result = await _retrieve_tools(state, config, store=store)
+
+    assert "HassTurnOn" in result["tool_routing_map"]
+    assert "GetLiveContext" not in result["tool_routing_map"]
+    store.aget.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- force-bind and promote GetLiveContext for read-only open-state queries even when RAG misses it
- normalize brittle GetLiveContext args from local models to broad binary_sensor context for the first open-state check
- filter broad live-context results back to the requested open entity type so door queries do not report windows

## Validation
- ./hga/bin/pytest tests/custom_components/home_generative_agent/test_tool_retrieval.py
- hga/bin/ruff check custom_components/home_generative_agent/agent/graph.py tests/custom_components/home_generative_agent/test_tool_retrieval.py
- hga/bin/pyright custom_components/home_generative_agent/agent/graph.py tests/custom_components/home_generative_agent/test_tool_retrieval.py
- git diff --check

## Manual HA logs
- ministral-3: open doors returns no open doors after normalized GetLiveContext call
- ministral-3: open windows returns Breakfast Nook Side Right Window, Family Room Right Window, Garage and Play Room Windows, Landing Windows
- qwen3.5: open doors returns no open doors
- qwen3.5: open windows returns the same four open windows