### PR TITLE
fix: disambiguate entity lookup when re-added device creates _N duplicate (issue #414)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.14.12] - 2026-05-19
+
+### Fixed
+
+- **Ambiguous entity name no longer loops the agent** — when multiple entities
+  share a friendly name (e.g. `binary_sensor.haustur` and `binary_sensor.haustur_2`
+  after a device is re-added), `get_entity_history` now silently picks the
+  canonical entity (no numeric `_N` suffix). If ambiguity cannot be resolved
+  this way, the tool returns `{"error": "..."}` so the LLM can report the
+  problem to the user instead of looping on an empty `{}` response (issue #414).
+
 ## [3.14.11] - 2026-05-19
 
 ### Changed

--- a/custom_components/home_generative_agent/agent/tools.py
+++ b/custom_components/home_generative_agent/agent/tools.py
@@ -1026,6 +1026,10 @@ async def _get_existing_entity_id(
         msg = f"No '{domain}' entity found with friendly name '{name}'"
         raise ValueError(msg)
     if len(candidates) > 1:
+        # Prefer the canonical entity (no _N suffix) over duplicates from re-adds.
+        canonical = [e for e in candidates if not re.search(r"_\d+$", e)]
+        if len(canonical) == 1:
+            return canonical[0]
         msg = f"Multiple '{domain}' entities found for '{name}': {candidates}"
         raise ValueError(msg)
 
@@ -1046,7 +1050,7 @@ async def get_entity_history(  # noqa: D417
     *,
     # Hide these arguments from the model.
     config: Annotated[RunnableConfig, InjectedToolArg()],
-) -> dict[str, dict[str, list[dict[str, str]]]]:
+) -> dict[str, Any]:
     """
     Retrieve historical state changes for Home Assistant entities over a time range.
 
@@ -1071,6 +1075,8 @@ async def get_entity_history(  # noqa: D417
                     {"state": "on", "last_changed": "2025-07-24T04:47:28-0700"},
                     ...]}
             }.
+        On error, returns {"error": "<description>"} so the model can report the
+        problem to the user (e.g. ambiguous entity name) and request clarification.
 
     """
     if "configurable" not in config:
@@ -1092,9 +1098,9 @@ async def get_entity_history(  # noqa: D417
             await _get_existing_entity_id(n, hass, d)
             for n, d in zip(friendly_names, domains, strict=False)
         ]
-    except ValueError:
+    except ValueError as e:
         LOGGER.exception("Invalid name %s or domain: %s", friendly_names, domains)
-        return {}
+        return {"error": str(e)}
 
     now = dt_util.utcnow()
     one_day = timedelta(days=1)

--- a/custom_components/home_generative_agent/manifest.json
+++ b/custom_components/home_generative_agent/manifest.json
@@ -34,5 +34,5 @@
     "langchain-google-genai==3.1.0",
     "langchain-anthropic==1.4.3"
   ],
-  "version": "3.14.11"
+  "version": "3.14.12"
 }

--- a/tests/custom_components/home_generative_agent/test_regressions.py
+++ b/tests/custom_components/home_generative_agent/test_regressions.py
@@ -44,6 +44,50 @@ history_tool = cast(
 )
 
 
+# ---------------------------------------------------------------------------
+# _get_existing_entity_id — issue #414: ambiguous friendly name disambiguation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_existing_entity_id_prefers_canonical_over_numbered_duplicate(
+    hass: HomeAssistant,
+) -> None:
+    """_get_existing_entity_id picks the un-suffixed entity when a _N duplicate exists (issue #414)."""
+    hass.states.async_set("binary_sensor.haustur", "off", {"friendly_name": "Haustür"})
+    hass.states.async_set(
+        "binary_sensor.haustur_2", "off", {"friendly_name": "Haustür"}
+    )
+
+    result = await agent_tools._get_existing_entity_id("Haustür", hass, "binary_sensor")
+    assert result == "binary_sensor.haustur"
+
+
+@pytest.mark.asyncio
+async def test_get_entity_history_returns_error_dict_on_genuinely_ambiguous_entity(
+    hass: HomeAssistant,
+) -> None:
+    """get_entity_history returns {"error": ...} when the entity name is genuinely ambiguous (issue #414)."""
+    hass.states.async_set(
+        "binary_sensor.front_door_a", "off", {"friendly_name": "Front Door"}
+    )
+    hass.states.async_set(
+        "binary_sensor.front_door_b", "off", {"friendly_name": "Front Door"}
+    )
+
+    config = {"configurable": {"hass": hass}}
+    result = await history_tool(
+        ["Front Door"],
+        ["binary_sensor"],
+        "2025-01-01T00:00:00+0000",
+        "2025-01-02T00:00:00+0000",
+        config=config,
+    )
+
+    assert "error" in result
+    assert "Front Door" in result["error"]
+
+
 @pytest.mark.asyncio
 async def test_get_entity_history_pairs_zip_warns(
     hass: HomeAssistant,


### PR DESCRIPTION
## Summary

- `_get_existing_entity_id` now silently prefers the canonical entity (no `_N` suffix) when multiple entities share a friendly name — handles the dominant case of a re-added device creating a `_2` duplicate
- `get_entity_history` returns `{"error": "<message>"}` instead of `{}` when ambiguity cannot be resolved, so the LLM can surface the problem to the user rather than looping on an empty response
- Two regression tests added covering both code paths

## Root cause

HA does not enforce unique friendly names. When a device is deleted and re-added, HA creates `binary_sensor.haustur_2` alongside the orphaned `binary_sensor.haustur`, both with the same friendly name. The previous code raised `ValueError` immediately, which was caught and returned `{}` — giving the LLM nothing to reason with.

## Test plan

- [x] `make lint` passes
- [x] `test_get_existing_entity_id_prefers_canonical_over_numbered_duplicate` — canonical entity selected from `[haustur, haustur_2]`
- [x] `test_get_entity_history_returns_error_dict_on_genuinely_ambiguous_entity` — `{"error": ...}` returned when both candidates lack a numeric suffix

## Scope note

This PR addresses the concrete duplicate-entity `ValueError` logged in #414 (first symptom). The later symptom in that thread — session hanging with `...` after a successful history response, accompanied by haffmpeg `RuntimeError: read() called while another coroutine is already waiting for incoming data` — appears to be a separate camera/FFmpeg issue and warrants its own investigation.

Partially addresses #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)