### PR TITLE
v3.14.13 feat: add rsync-over-SSH deploy script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.14.13] - 2026-05-23
+
+### Added
+
+- **Deploy script** — `scripts/deploy` syncs the integration to a running Home Assistant instance via rsync over SSH. Only changed files are transferred (checksum-based), `__pycache__` and `.pyc` files are excluded, and the script calls `ha core restart` after a successful sync. See [Contributing](docs/contributing.md) for setup instructions.
+
 ## [3.14.12] - 2026-05-19
 
 ### Fixed

--- a/custom_components/home_generative_agent/manifest.json
+++ b/custom_components/home_generative_agent/manifest.json
@@ -34,5 +34,5 @@
     "langchain-google-genai==3.1.0",
     "langchain-anthropic==1.4.3"
   ],
-  "version": "3.14.12"
+  "version": "3.14.13"
 }

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -4,6 +4,7 @@ Contributions are welcome! Please read the [Contribution guidelines](../CONTRIBU
 
 - [Development Setup](#development-setup)
 - [Makefile Reference](#makefile-reference)
+- [Deploying to Home Assistant](#deploying-to-home-assistant)
 - [Dependency Workflow](#dependency-workflow)
 
 ---
@@ -53,6 +54,30 @@ make clean       # Remove the venv
 ```
 
 > `make lint` fails if `requirements_runtime_manifest.txt` is out of date with `manifest.json`. Run `make runtimedeps` to regenerate it.
+
+---
+
+## Deploying to Home Assistant
+
+`scripts/deploy` syncs the integration to a running HA instance via rsync over SSH.
+
+```bash
+# Basic usage (defaults to root@ and /homeassistant config path)
+scripts/deploy 192.168.1.240
+
+# Explicit user and config path
+scripts/deploy root@192.168.1.240 /homeassistant
+
+# Skip the automatic HA restart
+scripts/deploy 192.168.1.240 --no-restart
+
+# Via environment variable
+HA_HOST=192.168.1.240 scripts/deploy
+```
+
+Only files that differ (by checksum) are transferred; `__pycache__` and `.pyc` files are excluded. After a successful sync the script calls `ha core restart` over SSH to reload the integration.
+
+**SSH key setup (one-time):** Add your public key (`~/.ssh/id_rsa.pub` or `~/.ssh/id_ed25519.pub`) to the HA SSH add-on under **Settings → Add-ons → SSH & Web Terminal → Configuration → authorized_keys**, then restart the add-on.
 
 ---
 

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Push custom_components/home_generative_agent to a remote HA instance via rsync over SSH.
+#
+# Usage:
+#   scripts/deploy [user@]host [remote-config-path]
+#
+# Defaults:
+#   user        root (HA OS SSH add-on default)
+#   host        required (first arg, or HA_HOST env var)
+#   remote path /homeassistant   (or HA_CONFIG_PATH env var)
+#
+# Examples:
+#   scripts/deploy homeassistant.local
+#   scripts/deploy pi@192.168.1.50 /home/pi/.homeassistant
+#   HA_HOST=homeassistant.local scripts/deploy
+#
+# After a successful sync the script restarts the integration via HA's CLI
+# (ha core restart) if SSH access allows it. Pass --no-restart to skip.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+COMPONENT="home_generative_agent"
+SRC="${REPO_ROOT}/custom_components/${COMPONENT}/"
+
+# ── argument parsing ──────────────────────────────────────────────────────────
+RESTART=true
+POSITIONAL=()
+for arg in "$@"; do
+  case "$arg" in
+    --no-restart) RESTART=false ;;
+    *) POSITIONAL+=("$arg") ;;
+  esac
+done
+
+HOST="${POSITIONAL[0]:-${HA_HOST:-}}"
+REMOTE_CONFIG="${POSITIONAL[1]:-${HA_CONFIG_PATH:-/homeassistant}}"
+
+if [[ -z "$HOST" ]]; then
+  echo "ERROR: no host specified." >&2
+  echo "Usage: scripts/deploy [user@]host [remote-config-path]" >&2
+  exit 1
+fi
+
+# Default SSH user to 'root' if not embedded in HOST (HA OS SSH add-on uses root)
+if [[ "$HOST" != *@* ]]; then
+  HOST="root@${HOST}"
+fi
+
+REMOTE_DEST="${HOST}:${REMOTE_CONFIG}/custom_components/${COMPONENT}/"
+
+# ── sync ──────────────────────────────────────────────────────────────────────
+echo "Syncing ${SRC}"
+echo "     -> ${REMOTE_DEST}"
+echo
+
+rsync \
+  --archive \
+  --checksum \
+  --compress \
+  --delete \
+  --exclude='__pycache__' \
+  --exclude='*.pyc' \
+  --exclude='*.egg-info' \
+  --human-readable \
+  --progress \
+  "${SRC}" \
+  "${REMOTE_DEST}"
+
+echo
+echo "Sync complete."
+
+# ── optional restart ──────────────────────────────────────────────────────────
+if [[ "$RESTART" == true ]]; then
+  echo "Restarting Home Assistant integration..."
+  # 'ha core restart' works on HA OS / Supervised installs.
+  # On a plain venv/container install, adjust or pass --no-restart.
+  if ssh "${HOST%%:*}" "command -v ha" &>/dev/null; then
+    ssh "${HOST%%:*}" "ha core restart"
+    echo "Restart triggered."
+  else
+    echo "NOTICE: 'ha' CLI not found on remote — skipping restart."
+    echo "  Restart manually or pass --no-restart to silence this."
+  fi
+fi


### PR DESCRIPTION
## Summary

**Tooling**
- New `scripts/deploy` bash script syncs `custom_components/home_generative_agent/` to a running HA instance via `rsync --checksum` over SSH
- Excludes `__pycache__` and `.pyc` files; calls `ha core restart` after a successful sync
- Supports `--no-restart` flag and `HA_HOST` / `HA_CONFIG_PATH` environment variables
- Defaults to `root@<host>:/homeassistant` (matches HA OS SSH add-on defaults)

**Docs**
- `docs/contributing.md` gains a "Deploying to Home Assistant" section with usage examples and one-time SSH key setup instructions

## Test Coverage

No new application code paths — deploy script is a developer tooling helper, not part of the integration runtime.

## Pre-Landing Review

No issues found. Pure docs + shell script — no SQL, LLM output, injection vectors, or frontend files.

## Plan Completion

No plan file — tooling improvement developed interactively.

## TODOS

No TODO items completed in this PR.

## Test plan
- [x] All pytest tests pass (1101 passed, 0 failures)
- [x] Deploy script tested end-to-end against live HA instance at 192.168.1.240
- [x] rsync correctly synced only changed files (checksum-based)
- [x] `ha core restart` triggered successfully after sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)