### PR TITLE
feat: add pet_detected_at_night_no_occupancy sentinel rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.14.14] - 2026-05-31
+
+### Added
+
+- **Sentinel built-in rule: `pet_detected_at_night_no_occupancy`** — fires when a pet (cat, dog, rabbit, hamster, bird, or parrot) is detected on any monitored camera at night while no residents are home. Requires at least one active motion or VMD signal. Severity: low, confidence: 0.85, informational only (no suggested action). Closes [#422](https://github.com/goruck/home-generative-agent/issues/422).
+
+### Changed
+
+- **`langchain-core` manifest pin loosened** — changed from `==1.3.2` to `>=1.3.2,<2.0.0` to prevent `uv` from silently skipping installation on hosts where a newer compatible version is already present.
+
 ## [3.14.13] - 2026-05-23
 
 Thanks to [Alex Ultra](https://github.com/alex-mextner) for contributing the original STT hallucination filter and model-provider fallback work in [#421](https://github.com/goruck/home-generative-agent/pull/421).

--- a/custom_components/home_generative_agent/manifest.json
+++ b/custom_components/home_generative_agent/manifest.json
@@ -34,5 +34,5 @@
     "langchain-google-genai==3.1.0",
     "langchain-anthropic==1.4.3"
   ],
-  "version": "3.14.13"
+  "version": "3.14.14"
 }

--- a/custom_components/home_generative_agent/manifest.json
+++ b/custom_components/home_generative_agent/manifest.json
@@ -20,7 +20,7 @@
   "requirements": [
     "aiofiles==25.1.0",
     "langchain==1.2.12",
-    "langchain-core==1.3.2",
+    "langchain-core>=1.3.2,<2.0.0",
     "langchain-openai==1.0.3",
     "langchain-ollama==0.3.10",
     "langgraph==1.1.2",

--- a/custom_components/home_generative_agent/sentinel/engine.py
+++ b/custom_components/home_generative_agent/sentinel/engine.py
@@ -69,6 +69,7 @@ from .rules.appliance_power_duration import AppliancePowerDurationRule
 from .rules.camera_entry_unsecured import CameraEntryUnsecuredRule
 from .rules.camera_missing_snapshot import CameraMissingSnapshotRule
 from .rules.open_entry_while_away import OpenEntryWhileAwayRule
+from .rules.pet_detected_at_night_no_occupancy import PetDetectedAtNightNoOccupancyRule
 from .rules.phone_battery_low_at_night import PhoneBatteryLowAtNightRule
 from .rules.unknown_person_camera_night_home import UnknownPersonAtNightWhileHomeRule
 from .rules.unknown_person_camera_no_home import UnknownPersonCameraNoHomeRule
@@ -213,6 +214,7 @@ class SentinelEngine:
             UnknownPersonCameraNoHomeRule(),
             UnknownPersonAtNightWhileHomeRule(),
             VehicleDetectedNearCameraRule(),
+            PetDetectedAtNightNoOccupancyRule(),
             CameraMissingSnapshotRule(),
             AlarmDisarmedDuringExternalThreatRule(),
             PhoneBatteryLowAtNightRule(),

--- a/custom_components/home_generative_agent/sentinel/rules/pet_detected_at_night_no_occupancy.py
+++ b/custom_components/home_generative_agent/sentinel/rules/pet_detected_at_night_no_occupancy.py
@@ -1,0 +1,88 @@
+"""Rule: pet detected by camera at night while no one is home."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from custom_components.home_generative_agent.sentinel.models import (
+    AnomalyFinding,
+    build_anomaly_id,
+)
+
+if TYPE_CHECKING:
+    from custom_components.home_generative_agent.snapshot.schema import (
+        FullStateSnapshot,
+    )
+
+_PET_KEYWORDS = frozenset(
+    {
+        "cat",
+        "kitten",
+        "dog",
+        "puppy",
+        "rabbit",
+        "hamster",
+        "bird",
+        "parrot",
+        "pet",
+    }
+)
+
+
+def _snapshot_mentions_pet(summary: str) -> bool:
+    """Return True if the snapshot summary contains a pet keyword."""
+    lower = summary.lower()
+    return any(kw in lower for kw in _PET_KEYWORDS)
+
+
+class PetDetectedAtNightNoOccupancyRule:
+    """Detect a pet on camera at night while no residents are home."""
+
+    rule_id = "pet_detected_at_night_no_occupancy"
+
+    def evaluate(self, snapshot: FullStateSnapshot) -> list[AnomalyFinding]:
+        """Return findings when a pet is seen at night with no one home."""
+        if not snapshot["derived"]["is_night"]:
+            return []
+        if snapshot["derived"]["anyone_home"]:
+            return []
+
+        findings: list[AnomalyFinding] = []
+        for activity in snapshot["camera_activity"]:
+            summary = activity.get("snapshot_summary")
+            if not summary:
+                continue
+            if (
+                not activity.get("motion_entities")
+                and not activity.get("vmd_entities")
+                and not activity.get("last_activity")
+            ):
+                continue
+            if not _snapshot_mentions_pet(summary):
+                continue
+
+            evidence = {
+                "camera_entity_id": activity["camera_entity_id"],
+                "area": activity.get("area"),
+                "snapshot_summary": summary,
+                "last_activity": activity.get("last_activity"),
+                "is_night": snapshot["derived"]["is_night"],
+                "anyone_home": snapshot["derived"]["anyone_home"],
+                "people_away": snapshot["derived"]["people_away"],
+            }
+            anomaly_id = build_anomaly_id(
+                self.rule_id, [activity["camera_entity_id"]], evidence
+            )
+            findings.append(
+                AnomalyFinding(
+                    anomaly_id=anomaly_id,
+                    type=self.rule_id,
+                    severity="low",
+                    confidence=0.85,
+                    triggering_entities=[activity["camera_entity_id"]],
+                    evidence=evidence,
+                    suggested_actions=[],
+                    is_sensitive=False,
+                )
+            )
+        return findings

--- a/docs/sentinel.md
+++ b/docs/sentinel.md
@@ -91,6 +91,7 @@ These rules run on every detection cycle without any configuration or approval.
 | Rule | Description |
 |---|---|
 | `vehicle_detected_near_camera_home` | Vehicle detected on any monitored camera while residents are home |
+| `pet_detected_at_night_no_occupancy` | Pet detected on any monitored camera at night while no residents are home (informational; no suggested action) |
 | `camera_missing_snapshot_night_home` | Any monitored camera (with active motion sensors) has no snapshot summary at night while the home is occupied |
 
 **Devices**

--- a/requirements_runtime_manifest.txt
+++ b/requirements_runtime_manifest.txt
@@ -1,6 +1,6 @@
 aiofiles==25.1.0
 langchain==1.2.12
-langchain-core==1.3.2
+langchain-core>=1.3.2,<2.0.0
 langchain-openai==1.0.3
 langchain-ollama==0.3.10
 langgraph==1.1.2

--- a/tests/custom_components/home_generative_agent/test_rules_sentinel.py
+++ b/tests/custom_components/home_generative_agent/test_rules_sentinel.py
@@ -24,6 +24,9 @@ from custom_components.home_generative_agent.sentinel.rules.camera_missing_snaps
 from custom_components.home_generative_agent.sentinel.rules.open_entry_while_away import (
     OpenEntryWhileAwayRule,
 )
+from custom_components.home_generative_agent.sentinel.rules.pet_detected_at_night_no_occupancy import (
+    PetDetectedAtNightNoOccupancyRule,
+)
 from custom_components.home_generative_agent.sentinel.rules.phone_battery_low_at_night import (
     PhoneBatteryLowAtNightRule,
 )
@@ -2279,3 +2282,151 @@ def test_unlocked_lock_at_night_no_one_home_is_high_severity() -> None:
     f = findings[0]
     assert f.severity == "high"
     assert f.is_sensitive is True
+
+
+# ---------------------------------------------------------------------------
+# PetDetectedAtNightNoOccupancyRule
+# ---------------------------------------------------------------------------
+
+
+def test_pet_detected_at_night_no_occupancy_triggers() -> None:
+    """Cat in snapshot summary at night with no one home should trigger."""
+    snapshot = _base_snapshot()
+    snapshot["derived"]["is_night"] = True
+    snapshot["derived"]["anyone_home"] = False
+    snapshot["derived"]["people_away"] = ["person.alice"]
+    snapshot["camera_activity"] = [
+        _camera_activity(
+            "camera.tapo_c225_hd_stream",
+            snapshot_summary="A cat is walking across the living room floor.",
+            motion_entities=["binary_sensor.living_room_motion"],
+        )
+    ]
+    findings = PetDetectedAtNightNoOccupancyRule().evaluate(snapshot)
+    assert len(findings) == 1
+    assert findings[0].type == "pet_detected_at_night_no_occupancy"
+    assert findings[0].severity == "low"
+    assert findings[0].confidence == 0.85
+    assert findings[0].triggering_entities == ["camera.tapo_c225_hd_stream"]
+
+
+def test_pet_detected_at_night_no_occupancy_dog_triggers() -> None:
+    """Dog keyword in summary also triggers."""
+    snapshot = _base_snapshot()
+    snapshot["derived"]["is_night"] = True
+    snapshot["derived"]["anyone_home"] = False
+    snapshot["camera_activity"] = [
+        _camera_activity(
+            "camera.hallway",
+            snapshot_summary="A small dog is resting near the couch.",
+            vmd_entities=["binary_sensor.hallway_vmd"],
+        )
+    ]
+    findings = PetDetectedAtNightNoOccupancyRule().evaluate(snapshot)
+    assert len(findings) == 1
+    assert findings[0].triggering_entities == ["camera.hallway"]
+
+
+def test_pet_detected_at_night_no_occupancy_two_cameras() -> None:
+    """Two cameras with pet summaries yield two findings."""
+    snapshot = _base_snapshot()
+    snapshot["derived"]["is_night"] = True
+    snapshot["derived"]["anyone_home"] = False
+    snapshot["camera_activity"] = [
+        _camera_activity(
+            "camera.living_room",
+            snapshot_summary="A cat is sleeping on the sofa.",
+            motion_entities=["binary_sensor.living_room_motion"],
+        ),
+        _camera_activity(
+            "camera.hallway",
+            snapshot_summary="A dog is walking down the hallway.",
+            motion_entities=["binary_sensor.hallway_motion"],
+        ),
+    ]
+    findings = PetDetectedAtNightNoOccupancyRule().evaluate(snapshot)
+    assert len(findings) == 2
+    entity_ids = {f.triggering_entities[0] for f in findings}
+    assert entity_ids == {"camera.living_room", "camera.hallway"}
+
+
+def test_pet_detected_at_night_no_occupancy_no_trigger_when_home() -> None:
+    """No finding when someone is home."""
+    snapshot = _base_snapshot()
+    snapshot["derived"]["is_night"] = True
+    snapshot["derived"]["anyone_home"] = True
+    snapshot["camera_activity"] = [
+        _camera_activity(
+            "camera.living_room",
+            snapshot_summary="A cat is walking across the living room.",
+            motion_entities=["binary_sensor.living_room_motion"],
+        )
+    ]
+    findings = PetDetectedAtNightNoOccupancyRule().evaluate(snapshot)
+    assert len(findings) == 0
+
+
+def test_pet_detected_at_night_no_occupancy_no_trigger_daytime() -> None:
+    """No finding during the day even when away."""
+    snapshot = _base_snapshot()
+    snapshot["derived"]["is_night"] = False
+    snapshot["derived"]["anyone_home"] = False
+    snapshot["camera_activity"] = [
+        _camera_activity(
+            "camera.living_room",
+            snapshot_summary="A cat is on the couch.",
+            motion_entities=["binary_sensor.living_room_motion"],
+        )
+    ]
+    findings = PetDetectedAtNightNoOccupancyRule().evaluate(snapshot)
+    assert len(findings) == 0
+
+
+def test_pet_detected_at_night_no_occupancy_no_trigger_no_pet_keyword() -> None:
+    """No finding when summary doesn't mention a pet."""
+    snapshot = _base_snapshot()
+    snapshot["derived"]["is_night"] = True
+    snapshot["derived"]["anyone_home"] = False
+    snapshot["camera_activity"] = [
+        _camera_activity(
+            "camera.living_room",
+            snapshot_summary="The room appears empty and dark.",
+            motion_entities=["binary_sensor.living_room_motion"],
+        )
+    ]
+    findings = PetDetectedAtNightNoOccupancyRule().evaluate(snapshot)
+    assert len(findings) == 0
+
+
+def test_pet_detected_at_night_no_occupancy_no_trigger_no_motion_context() -> None:
+    """No finding when camera has no motion context."""
+    snapshot = _base_snapshot()
+    snapshot["derived"]["is_night"] = True
+    snapshot["derived"]["anyone_home"] = False
+    snapshot["camera_activity"] = [
+        _camera_activity(
+            "camera.living_room",
+            snapshot_summary="A cat is on the couch.",
+            motion_entities=None,
+            vmd_entities=None,
+            last_activity=None,
+        )
+    ]
+    findings = PetDetectedAtNightNoOccupancyRule().evaluate(snapshot)
+    assert len(findings) == 0
+
+
+def test_pet_detected_at_night_no_occupancy_no_trigger_no_summary() -> None:
+    """No finding when camera has no snapshot summary."""
+    snapshot = _base_snapshot()
+    snapshot["derived"]["is_night"] = True
+    snapshot["derived"]["anyone_home"] = False
+    snapshot["camera_activity"] = [
+        _camera_activity(
+            "camera.living_room",
+            snapshot_summary=None,
+            motion_entities=["binary_sensor.living_room_motion"],
+        )
+    ]
+    findings = PetDetectedAtNightNoOccupancyRule().evaluate(snapshot)
+    assert len(findings) == 0


### PR DESCRIPTION
Closes #422.

## Summary

- Adds `PetDetectedAtNightNoOccupancyRule` — a new built-in Sentinel rule that fires when a pet keyword (`cat`, `kitten`, `dog`, `puppy`, `rabbit`, `hamster`, `bird`, `parrot`, `pet`) appears in a camera `snapshot_summary` at night while no residents are home, with at least one motion/VMD/activity signal present
- Rule properties: severity=`low`, confidence=`0.85`, no suggested actions (informational only), `is_sensitive=False`, 30-min default cooldown
- Loosens `langchain-core` manifest pin from `==1.3.2` to `>=1.3.2,<2.0.0` to prevent uv silently skipping the install on hosts with a newer compatible version already present

## Test plan

- [x] 8 new unit tests covering: trigger on cat/dog keyword, two-camera fan-out, no-trigger when home, no-trigger daytime, no-trigger without pet keyword, no-trigger without motion context, no-trigger without snapshot summary
- [x] Full test suite passes (`make test`)
- [x] `make lint` passes
- [x] Integration verified loading cleanly on HA host after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)