### PR TITLE
fix: ensure array-type tool params always have items field for Gemini

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.14.15] - 2026-05-31
+
+### Fixed
+
+- **Gemini provider: 400 error on every chat interaction** — Gemini's Protobuf schema validation requires an explicit `items` field on all array-type tool parameters. `GetLiveContextTool.domain` (always injected on tool-retrieval turns) uses `vol.Any(cv.string, [cv.string])`, which `voluptuous_openapi` emits as an `anyOf` schema. `langchain_google_genai` resolved the `anyOf` to `type_:ARRAY` but checked `items` on the outer dict where it was absent, producing a declaration Gemini rejected. Added `_ensure_array_items()` to `_format_and_dedupe_tools()` which hoists `items` from `anyOf` array variants and recursively patches any bare `{"type": "array"}` node. Closes [#428](https://github.com/goruck/home-generative-agent/issues/428).
+
 ## [3.14.14] - 2026-05-31
 
 ### Added

--- a/custom_components/home_generative_agent/agent/graph.py
+++ b/custom_components/home_generative_agent/agent/graph.py
@@ -1099,7 +1099,8 @@ def _tool_retrieval_fallback_reason(
 
 
 def _ensure_array_items(schema: dict[str, Any]) -> dict[str, Any]:
-    """Recursively ensure every array-type node has an ``items`` field.
+    """
+    Recursively ensure every array-type node has an ``items`` field.
 
     Gemini rejects function declarations where an array property lacks ``items``.
     OpenAI tolerates the omission; this normalisation is a no-op for other providers.
@@ -1115,7 +1116,9 @@ def _ensure_array_items(schema: dict[str, Any]) -> dict[str, Any]:
     # can find them when it resolves the anyOf to type_:ARRAY.
     if "anyOf" in schema and "items" not in schema:
         array_variants = [
-            v for v in schema["anyOf"] if isinstance(v, dict) and v.get("type") == "array"
+            v
+            for v in schema["anyOf"]
+            if isinstance(v, dict) and v.get("type") == "array"
         ]
         if array_variants:
             schema = {

--- a/custom_components/home_generative_agent/agent/graph.py
+++ b/custom_components/home_generative_agent/agent/graph.py
@@ -1098,6 +1098,44 @@ def _tool_retrieval_fallback_reason(
     return reason, tool_index_ready, tool_indexing_in_progress, tool_index_failed
 
 
+def _ensure_array_items(schema: dict[str, Any]) -> dict[str, Any]:
+    """Recursively ensure every array-type node has an ``items`` field.
+
+    Gemini rejects function declarations where an array property lacks ``items``.
+    OpenAI tolerates the omission; this normalisation is a no-op for other providers.
+
+    Also handles anyOf schemas such as ``vol.Any(cv.string, [cv.string])`` which
+    safe_convert emits as ``{"anyOf": [{}, {"type": "array", "items": {...}}]}``.
+    langchain_google_genai resolves these to type_:ARRAY but then checks
+    ``v.get("items")`` on the outer anyOf dict (where items is absent), so it
+    never populates properties_item["items"].  Hoisting items to the top level
+    of the anyOf schema makes it visible to the library's check.
+    """
+    # anyOf with an array variant: hoist items upward so langchain_google_genai
+    # can find them when it resolves the anyOf to type_:ARRAY.
+    if "anyOf" in schema and "items" not in schema:
+        array_variants = [
+            v for v in schema["anyOf"] if isinstance(v, dict) and v.get("type") == "array"
+        ]
+        if array_variants:
+            schema = {
+                **schema,
+                "items": array_variants[-1].get("items", {"type": "string"}),
+            }
+    if schema.get("type") == "array" and "items" not in schema:
+        schema = {**schema, "items": {"type": "string"}}
+    if "properties" in schema:
+        schema = {
+            **schema,
+            "properties": {
+                k: _ensure_array_items(v) for k, v in schema["properties"].items()
+            },
+        }
+    if isinstance(schema.get("items"), dict):
+        schema = {**schema, "items": _ensure_array_items(schema["items"])}
+    return schema
+
+
 def _format_and_dedupe_tools(
     raw_tools: list[RawTool],
 ) -> tuple[list[dict[str, Any]], dict[str, str]]:
@@ -1119,6 +1157,8 @@ def _format_and_dedupe_tools(
         # OpenAI requires 'properties' on all type:object schemas.
         if parameters.get("type") == "object" and "properties" not in parameters:
             parameters["properties"] = {}
+        # Gemini requires 'items' on all type:array properties.
+        parameters = _ensure_array_items(parameters)
         selected_tools.append(
             {
                 "type": "function",

--- a/custom_components/home_generative_agent/manifest.json
+++ b/custom_components/home_generative_agent/manifest.json
@@ -34,5 +34,5 @@
     "langchain-google-genai==3.1.0",
     "langchain-anthropic==1.4.3"
   ],
-  "version": "3.14.14"
+  "version": "3.14.15"
 }

--- a/tests/custom_components/home_generative_agent/test_graph_helpers.py
+++ b/tests/custom_components/home_generative_agent/test_graph_helpers.py
@@ -107,7 +107,10 @@ def test_ensure_array_items_recurses_into_properties() -> None:
         },
     }
     result = _ensure_array_items(schema)
-    assert result["properties"]["domain"] == {"type": "array", "items": {"type": "string"}}
+    assert result["properties"]["domain"] == {
+        "type": "array",
+        "items": {"type": "string"},
+    }
     assert result["properties"]["name"] == {"type": "string"}
 
 
@@ -119,7 +122,8 @@ def test_ensure_array_items_recurses_into_nested_items() -> None:
 
 
 def test_ensure_array_items_hoists_items_from_any_of_array_variant() -> None:
-    """anyOf with an array variant gets items hoisted to the top level.
+    """
+    AnyOf with an array variant gets items hoisted to the top level.
 
     GetLiveContextTool.domain uses vol.Any(cv.string, [cv.string]) which
     safe_convert emits as {"anyOf": [{}, {"type": "array", "items": {...}}]}.
@@ -139,14 +143,14 @@ def test_ensure_array_items_hoists_items_from_any_of_array_variant() -> None:
 
 
 def test_ensure_array_items_any_of_array_variant_without_items() -> None:
-    """anyOf array variant with no items gets the string default."""
+    """AnyOf array variant with no items gets the string default."""
     schema = {"anyOf": [{}, {"type": "array"}]}
     result = _ensure_array_items(schema)
     assert result["items"] == {"type": "string"}
 
 
 def test_ensure_array_items_any_of_no_array_variant_unchanged() -> None:
-    """anyOf without an array variant is left alone."""
+    """AnyOf without an array variant is left alone."""
     schema = {"anyOf": [{"type": "string"}, {"type": "integer"}]}
     result = _ensure_array_items(schema)
     assert "items" not in result

--- a/tests/custom_components/home_generative_agent/test_graph_helpers.py
+++ b/tests/custom_components/home_generative_agent/test_graph_helpers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from custom_components.home_generative_agent.agent.graph import (
     _determine_model_name,
+    _ensure_array_items,
     _format_and_dedupe_tools,
 )
 from custom_components.home_generative_agent.const import CONF_ANTHROPIC_CHAT_MODEL
@@ -80,6 +81,95 @@ def test_format_and_dedupe_tools_preserves_existing_type() -> None:
     params = selected[0]["function"]["parameters"]
     assert params["type"] == "object"
     assert "x" in params["properties"]
+
+
+def test_ensure_array_items_fills_missing_items() -> None:
+    """Array-type properties without items get items:{type:string} injected."""
+    schema = {"type": "array"}
+    result = _ensure_array_items(schema)
+    assert result == {"type": "array", "items": {"type": "string"}}
+
+
+def test_ensure_array_items_leaves_existing_items_alone() -> None:
+    """Array-type properties that already have items are not modified."""
+    schema = {"type": "array", "items": {"type": "integer"}}
+    result = _ensure_array_items(schema)
+    assert result == {"type": "array", "items": {"type": "integer"}}
+
+
+def test_ensure_array_items_recurses_into_properties() -> None:
+    """Array properties nested inside object properties are also fixed."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "domain": {"type": "array"},
+            "name": {"type": "string"},
+        },
+    }
+    result = _ensure_array_items(schema)
+    assert result["properties"]["domain"] == {"type": "array", "items": {"type": "string"}}
+    assert result["properties"]["name"] == {"type": "string"}
+
+
+def test_ensure_array_items_recurses_into_nested_items() -> None:
+    """Array-of-arrays schemas get items patched at every level."""
+    schema = {"type": "array", "items": {"type": "array"}}
+    result = _ensure_array_items(schema)
+    assert result["items"] == {"type": "array", "items": {"type": "string"}}
+
+
+def test_ensure_array_items_hoists_items_from_any_of_array_variant() -> None:
+    """anyOf with an array variant gets items hoisted to the top level.
+
+    GetLiveContextTool.domain uses vol.Any(cv.string, [cv.string]) which
+    safe_convert emits as {"anyOf": [{}, {"type": "array", "items": {...}}]}.
+    langchain_google_genai resolves anyOf to type_:ARRAY but only checks
+    v.get("items") on the outer dict, so items must be present there.
+    """
+    schema = {
+        "anyOf": [
+            {},  # cv.string falls through as empty schema
+            {"type": "array", "items": {"type": "string"}},
+        ]
+    }
+    result = _ensure_array_items(schema)
+    assert result["items"] == {"type": "string"}, (
+        "items must be hoisted from the array variant so langchain_google_genai can find it"
+    )
+
+
+def test_ensure_array_items_any_of_array_variant_without_items() -> None:
+    """anyOf array variant with no items gets the string default."""
+    schema = {"anyOf": [{}, {"type": "array"}]}
+    result = _ensure_array_items(schema)
+    assert result["items"] == {"type": "string"}
+
+
+def test_ensure_array_items_any_of_no_array_variant_unchanged() -> None:
+    """anyOf without an array variant is left alone."""
+    schema = {"anyOf": [{"type": "string"}, {"type": "integer"}]}
+    result = _ensure_array_items(schema)
+    assert "items" not in result
+
+
+def test_format_and_dedupe_tools_gemini_array_items_injected() -> None:
+    """Gemini: array-type tool params without items get items:{type:string} added."""
+    raw: list = [
+        {
+            "name": "ha_turn_on",
+            "api_id": "assist",
+            "description": "Turn on a device",
+            "parameters": (
+                '{"type": "object", "properties": {'
+                '"domain": {"type": "array"}, "name": {"type": "string"}}}'
+            ),
+            "is_actuation": True,
+        }
+    ]
+    selected, _ = _format_and_dedupe_tools(raw)
+    domain_schema = selected[0]["function"]["parameters"]["properties"]["domain"]
+    assert "items" in domain_schema, "Gemini requires items on array-type properties"
+    assert domain_schema["items"] == {"type": "string"}
 
 
 def test_determine_model_name_anthropic_returns_configured_model() -> None:


### PR DESCRIPTION
Closes #428

## Summary

Fixes a 400 error Gemini users hit on every chat interaction:
```
GenerateContentRequest.tools[0].function_declarations[5].parameters.properties[domain].items: missing field
```

**Root cause chain:**
- `GetLiveContextTool.domain` uses `vol.Any(cv.string, [cv.string])` (HA built-in, not modifiable)
- `voluptuous_openapi` converts this to `{"anyOf": [{}, {"type": "array", "items": {...}}]}`
- `langchain_google_genai._get_properties_from_schema` resolves the anyOf to `type_:ARRAY` but only checks `v.get("items")` on the *outer* dict — where `items` is absent — so it never sets `properties_item["items"]`
- Gemini's Protobuf validation rejects the resulting declaration
- Because `GetLiveContextTool` is injected on every tool-retrieval turn, this caused 100% failure for Gemini users

**Fix:** Added `_ensure_array_items()` to `_format_and_dedupe_tools()` in `graph.py`. The function:
- Detects `anyOf` schemas with an array variant and hoists `items` to the top level so `langchain_google_genai`'s check finds it
- Recursively patches direct `{"type": "array"}` nodes that lack `items`, defaulting to `{"type": "string"}`
- Recurses into nested `properties` and `items` schemas

Applied after existing OpenAI schema normalization; no-op for Anthropic (passes schemas through unchanged).

## Test Coverage

8 new unit tests in `test_graph_helpers.py` covering all schema shapes:
- Direct array missing `items` → injected
- Array with existing `items` → unchanged
- Nested array inside object properties → patched recursively
- Array-of-arrays → patched at every level
- `anyOf` with array variant → `items` hoisted (the `GetLiveContextTool` case)
- `anyOf` array variant without `items` → string default applied
- `anyOf` without array variant → unchanged
- Integration: `_format_and_dedupe_tools` end-to-end with array property

All 14 tests in the file pass.

## Integration Test

Verified on a live HA instance with `gemini-2.5-flash` — no more 400 errors.

## Test plan
- [x] All 14 unit tests pass
- [x] Integration tested on live HA instance with Gemini provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)