### PR TITLE
fix: raise cyclical-load sustained gate default to 45 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.14.19] - 2026-06-07
+
+### Fixed
+
+- **Sentinel Baseline: cyclical-load sustained gate default too short** — the default `sentinel_baseline_sustained_minutes` of 20 minutes matched the length of a normal fridge/freezer compressor off-cycle, causing a notification on every idle cycle. Raised to 45 minutes, which filters normal off-cycles (20–40 min) while still catching genuine malfunctions (door left open, failed compressor) that sustain for hours. The setting is now documented in `docs/sentinel.md` with tuning guidance.
+
 ## [3.14.18] - 2026-06-07
 
 ### Fixed

--- a/custom_components/home_generative_agent/const.py
+++ b/custom_components/home_generative_agent/const.py
@@ -252,7 +252,7 @@ RECOMMENDED_SENTINEL_BASELINE_DOW_MIN_SAMPLES: int = 4
 # Cyclical load sustained deviation gate — Sprint 4
 # Entities matching CYCLICAL_LOAD_HINTS (fridge/freezer/compressor) must stay
 # above the deviation threshold for this many minutes before firing.  0 = disabled.
-# Default is 45 min: normal compressor off-cycles run 20–40 min, so 20 min fired
+# Default is 45 min: normal compressor off-cycles run 20-40 min, so 20 min fired
 # on every normal cycle.  Real malfunctions (door left open, failed compressor)
 # sustain for hours, so 45 min still catches them while eliminating false positives.
 CONF_SENTINEL_BASELINE_SUSTAINED_MINUTES = "sentinel_baseline_sustained_minutes"

--- a/custom_components/home_generative_agent/const.py
+++ b/custom_components/home_generative_agent/const.py
@@ -252,8 +252,11 @@ RECOMMENDED_SENTINEL_BASELINE_DOW_MIN_SAMPLES: int = 4
 # Cyclical load sustained deviation gate — Sprint 4
 # Entities matching CYCLICAL_LOAD_HINTS (fridge/freezer/compressor) must stay
 # above the deviation threshold for this many minutes before firing.  0 = disabled.
+# Default is 45 min: normal compressor off-cycles run 20–40 min, so 20 min fired
+# on every normal cycle.  Real malfunctions (door left open, failed compressor)
+# sustain for hours, so 45 min still catches them while eliminating false positives.
 CONF_SENTINEL_BASELINE_SUSTAINED_MINUTES = "sentinel_baseline_sustained_minutes"
-RECOMMENDED_SENTINEL_BASELINE_SUSTAINED_MINUTES: int = 20
+RECOMMENDED_SENTINEL_BASELINE_SUSTAINED_MINUTES: int = 45
 
 # ---- Sentinel daily digest notification ----
 CONF_SENTINEL_DAILY_DIGEST_ENABLED = "sentinel_daily_digest_enabled"

--- a/custom_components/home_generative_agent/manifest.json
+++ b/custom_components/home_generative_agent/manifest.json
@@ -34,5 +34,5 @@
     "langchain-google-genai==3.1.0",
     "langchain-anthropic==1.4.3"
   ],
-  "version": "3.14.18"
+  "version": "3.14.19"
 }

--- a/docs/sentinel.md
+++ b/docs/sentinel.md
@@ -182,6 +182,11 @@ Both templates produce no findings while the table is empty — baselines accumu
 | `sentinel_baseline_drift_threshold_pct` | `30.0` | Default percent deviation that triggers a finding |
 | `sentinel_baseline_weekly_patterns` | `false` | Enable per-(day-of-week, hour) baselines for `time_of_day_anomaly` |
 | `sentinel_baseline_dow_min_samples` | `4` | Observations per DOW-hour slot before blend weight reaches 1.0 |
+| `sentinel_baseline_sustained_minutes` | `45` | Minutes a cyclical-load entity (fridge, freezer, compressor) must remain anomalous before a notification fires. Set to `0` to disable the gate. |
+
+> **Tuning `sentinel_baseline_sustained_minutes` for cyclical loads**
+>
+> Appliances with a natural on/off duty cycle — refrigerators, freezers, and anything with a compressor — will always read far below their time-averaged baseline while the compressor is idle. Sentinel suppresses these transient deviations until they have persisted for `sentinel_baseline_sustained_minutes` across consecutive detection cycles. The default of 45 minutes is chosen because normal compressor off-cycles typically last 20–40 minutes, while genuine malfunctions (door left open, failed compressor) sustain for hours. If your fridge has unusually long idle cycles you may need to raise this value; if you want faster alerting for high-value appliances you can lower it or set it to `0` to fire immediately.
 
 ---
 


### PR DESCRIPTION
## Summary

- Raises `RECOMMENDED_SENTINEL_BASELINE_SUSTAINED_MINUTES` from 20 → 45 minutes to eliminate false-positive fridge/freezer notifications caused by normal compressor off-cycles (which typically last 20–40 min)
- Adds the missing `sentinel_baseline_sustained_minutes` row to the baseline configuration table in `docs/sentinel.md`
- Adds a tuning callout explaining the tradeoff and when users should raise or lower the value

## Background

The 20-minute default fired on every normal compressor idle cycle, making the alert effectively useless. Genuine malfunctions (door left open, compressor failure) sustain for hours, so 45 minutes still catches them reliably.

## Test plan

- [x] Confirm existing installations with a manually configured value are unaffected (default only applies to fresh installs / reset-to-defaults)
- [x] Verify fridge power anomaly notifications no longer fire during normal compressor off-cycles
- [ ] Verify a simulated sustained anomaly (>45 min) still triggers a notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)