### PR TITLE
feat: Basic and Advanced setup mode for feature and Sentinel flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.14.20] - 2026-06-11
+
+### Added
+
+- **Basic and Advanced setup modes** — Feature setup and Sentinel setup now offer a mode selector. **Basic** enables all features (Conversation, Camera Image Analysis, Conversation Summary) with recommended defaults in a single screen and auto-creates the database subentry with no database prompt. **Advanced** steps through each feature individually, lets you assign providers, models, and fallback chains, and includes an explicit database configuration step. Closes [#433](https://github.com/goruck/home-generative-agent/issues/433).
+
+### Fixed
+
+- **Sentinel background tasks continue running after subentry deletion** — deleting the Sentinel subentry now stops all background tasks (monitor loop, baseline updater, discovery engine, notifier) immediately without waiting for the next integration reload. `_apply_sentinel_options` also forces `CONF_SENTINEL_ENABLED=False` when no Sentinel subentry exists, preventing tasks from being restarted on the subsequent reload.
+
+- **`ValueError: Config entry update listeners should not be used with OptionsFlowWithReload`** — saving main configuration options raised this error because the integration registered an `update_listener` on the config entry, which `OptionsFlowWithReload` explicitly forbids. The listener is now registered via `async_dispatcher_connect` on `SIGNAL_CONFIG_ENTRY_CHANGED`, which fires the same signals without touching `entry.update_listeners`.
+
+- **Infinite reload loop after subentry change** — `SIGNAL_CONFIG_ENTRY_CHANGED` fires on every entry state transition, not just data changes, causing the dispatcher callback to schedule an unbounded sequence of reloads. A snapshot of Sentinel subentry data captured at setup time is now compared on each signal; reloads are only scheduled when the subentry data actually changes.
+
+- **Advanced setup form not pre-populated when reconfiguring Sentinel** — reopening Sentinel Advanced setup now pre-fills every field with the current saved values instead of showing empty defaults.
+
+- **Basic setup silently overwrites existing configuration** — running Basic setup when a Setup or Sentinel subentry already exists now displays a warning and requires confirmation before overwriting the saved configuration.
+
+- **Misleading Conversation toggle removed from feature enable form** — the Conversation feature toggle was shown in the Advanced feature enable step but had no effect (Conversation is always enabled). It is no longer displayed.
+
 ## [3.14.19] - 2026-06-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Click the button below to add the repository, then install and configure the app
 
 **4. Add the integration:** Settings → Devices & Services → Add Integration → search **Home Generative Agent** → complete the initial instruction screen.
 
-**5. Open the integration page and click + Setup.** Enable the features you want (Conversation is on by default) and complete the database configuration step.
+**5. Open the integration page and click + Setup.** Choose **Basic** to enable all features with recommended defaults (fastest path), or **Advanced** to configure each feature individually. Complete the database step when prompted.
 
 **6. Add a Model Provider:** on the integration page click **+ Model Provider** and configure OpenAI, Ollama, Gemini, Anthropic, or any OpenAI-compatible endpoint.
 

--- a/README.md
+++ b/README.md
@@ -80,9 +80,11 @@ Click the button below to add the repository, then install and configure the app
 
 **4. Add the integration:** Settings → Devices & Services → Add Integration → search **Home Generative Agent** → complete the initial instruction screen.
 
-**5. Open the integration page and click + Setup.** Choose **Basic** to enable all features with recommended defaults (fastest path), or **Advanced** to configure each feature individually. Complete the database step when prompted.
+**5. Add a Model Provider:** on the integration page click **+ Model Provider** and configure OpenAI, Ollama, Gemini, Anthropic, or any OpenAI-compatible endpoint. A provider must exist before you can run Setup.
 
-**6. Add a Model Provider:** on the integration page click **+ Model Provider** and configure OpenAI, Ollama, Gemini, Anthropic, or any OpenAI-compatible endpoint.
+**6. Open the integration page and click + Setup.** Choose a setup mode:
+   - **Basic** — enables all features with recommended defaults and creates the database subentry automatically. No database prompt appears.
+   - **Advanced** — configure each feature individually; includes a database configuration step.
 
 **7. Set as your voice assistant:** Settings → Voice Assistants → select **Home Generative Agent** as the conversation agent.
 

--- a/custom_components/home_generative_agent/__init__.py
+++ b/custom_components/home_generative_agent/__init__.py
@@ -17,7 +17,12 @@ import voluptuous as vol
 from homeassistant.components import media_source
 from homeassistant.components.camera.const import DOMAIN as CAMERA_DOMAIN
 from homeassistant.components.http import StaticPathConfig
-from homeassistant.config_entries import ConfigEntry, ConfigSubentry
+from homeassistant.config_entries import (
+    SIGNAL_CONFIG_ENTRY_CHANGED,
+    ConfigEntry,
+    ConfigEntryChange,
+    ConfigSubentry,
+)
 from homeassistant.const import (
     CONF_API_KEY,
     CONF_HOST,
@@ -29,10 +34,13 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP,
     Platform,
 )
-from homeassistant.core import HomeAssistant, SupportsResponse
+from homeassistant.core import HomeAssistant, SupportsResponse, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.dispatcher import (
+    async_dispatcher_connect,
+    async_dispatcher_send,
+)
 from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.helpers.network import get_url
 from homeassistant.helpers.target import (
@@ -3084,27 +3092,41 @@ async def async_setup_entry(hass: HomeAssistant, entry: HGAConfigEntry) -> bool:
     # started to match the current subentry configuration.  Without this,
     # deleting a Sentinel subentry through the UI leaves background tasks
     # running indefinitely.
-    async def _reload_on_subentry_change(h: HomeAssistant, e: HGAConfigEntry) -> None:
+    #
+    # We use SIGNAL_CONFIG_ENTRY_CHANGED (dispatcher) rather than
+    # entry.add_update_listener because OptionsFlowWithReload forbids update
+    # listeners on its config entry and raises ValueError when the options flow
+    # completes.  The dispatcher signal fires for all entry mutations (options
+    # and subentry changes alike) without registering to update_listeners.
+    @callback
+    def _on_entry_changed(
+        change_type: ConfigEntryChange, changed_entry: HGAConfigEntry
+    ) -> None:
+        if changed_entry.entry_id != entry.entry_id:
+            return
+        if change_type != ConfigEntryChange.UPDATED:
+            return
         # When the Sentinel subentry is removed, stop its background tasks
         # immediately rather than waiting for the reload to call async_unload_entry.
-        # Without this, the sentinel engine can fire one more evaluation cycle
-        # during the async window between deletion and unload.
         sentinel_present = any(
-            s.subentry_type == SUBENTRY_TYPE_SENTINEL for s in e.subentries.values()
+            s.subentry_type == SUBENTRY_TYPE_SENTINEL
+            for s in changed_entry.subentries.values()
         )
         if not sentinel_present:
-            rd = e.runtime_data
+            rd = changed_entry.runtime_data
             if rd.sentinel is not None:
-                await rd.sentinel.stop()
+                hass.async_create_task(rd.sentinel.stop())
             if rd.baseline_updater is not None:
-                await rd.baseline_updater.stop()
+                hass.async_create_task(rd.baseline_updater.stop())
             if rd.discovery_engine is not None:
-                await rd.discovery_engine.stop()
+                hass.async_create_task(rd.discovery_engine.stop())
             if rd.notifier is not None:
                 rd.notifier.stop()
-        h.config_entries.async_schedule_reload(e.entry_id)
+        hass.config_entries.async_schedule_reload(entry.entry_id)
 
-    entry.async_on_unload(entry.add_update_listener(_reload_on_subentry_change))
+    entry.async_on_unload(
+        async_dispatcher_connect(hass, SIGNAL_CONFIG_ENTRY_CHANGED, _on_entry_changed)
+    )
 
     return True
 

--- a/custom_components/home_generative_agent/__init__.py
+++ b/custom_components/home_generative_agent/__init__.py
@@ -3087,17 +3087,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: HGAConfigEntry) -> bool:
         supports_response=_SERVICE_RESPONSE_ONLY,
     )
 
-    # Reload whenever a subentry is added, updated, or removed so that tasks
-    # started during setup (sentinel, baseline, discovery) are stopped or
-    # started to match the current subentry configuration.  Without this,
-    # deleting a Sentinel subentry through the UI leaves background tasks
-    # running indefinitely.
+    # Reload whenever a Sentinel subentry is added, updated, or removed so that
+    # tasks started during setup are stopped or started to match the current
+    # subentry configuration.
     #
     # We use SIGNAL_CONFIG_ENTRY_CHANGED (dispatcher) rather than
     # entry.add_update_listener because OptionsFlowWithReload forbids update
-    # listeners on its config entry and raises ValueError when the options flow
-    # completes.  The dispatcher signal fires for all entry mutations (options
-    # and subentry changes alike) without registering to update_listeners.
+    # listeners and raises ValueError when the options flow completes.
+    #
+    # SIGNAL_CONFIG_ENTRY_CHANGED fires for all entry mutations AND for every
+    # entry state transition (setup-in-progress → loaded, etc.) via
+    # ConfigEntry._async_set_state.  Reacting to state transitions would create
+    # an infinite reload loop.  Guard by snapshotting {subentry_id: dict(data)}
+    # at setup time; state transitions never alter subentry data.
+    _sentinel_snapshot: dict[str, dict[str, object]] = {
+        s.subentry_id: dict(s.data)
+        for s in entry.subentries.values()
+        if s.subentry_type == SUBENTRY_TYPE_SENTINEL
+    }
+
     @callback
     def _on_entry_changed(
         change_type: ConfigEntryChange, changed_entry: HGAConfigEntry
@@ -3106,13 +3114,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: HGAConfigEntry) -> bool:
             return
         if change_type != ConfigEntryChange.UPDATED:
             return
-        # When the Sentinel subentry is removed, stop its background tasks
-        # immediately rather than waiting for the reload to call async_unload_entry.
-        sentinel_present = any(
-            s.subentry_type == SUBENTRY_TYPE_SENTINEL
+        current_snapshot = {
+            s.subentry_id: dict(s.data)
             for s in changed_entry.subentries.values()
-        )
-        if not sentinel_present:
+            if s.subentry_type == SUBENTRY_TYPE_SENTINEL
+        }
+        if current_snapshot == _sentinel_snapshot:
+            return
+        # Sentinel subentry was added, removed, or its data changed.
+        # When removed, stop tasks immediately before the reload unloads the entry.
+        if not current_snapshot:
             rd = changed_entry.runtime_data
             if rd.sentinel is not None:
                 hass.async_create_task(rd.sentinel.stop())

--- a/custom_components/home_generative_agent/__init__.py
+++ b/custom_components/home_generative_agent/__init__.py
@@ -992,40 +992,6 @@ def _assign_first_provider_if_needed(hass: HomeAssistant, entry: ConfigEntry) ->
         )
 
 
-def _ensure_default_sentinel_subentry(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Ensure a singleton sentinel subentry exists for deterministic settings."""
-    exists = any(
-        s.subentry_type == SUBENTRY_TYPE_SENTINEL for s in entry.subentries.values()
-    )
-    if exists:
-        return
-
-    payload = {
-        CONF_SENTINEL_ENABLED: RECOMMENDED_SENTINEL_ENABLED,
-        CONF_SENTINEL_INTERVAL_SECONDS: RECOMMENDED_SENTINEL_INTERVAL_SECONDS,
-        CONF_SENTINEL_COOLDOWN_MINUTES: RECOMMENDED_SENTINEL_COOLDOWN_MINUTES,
-        CONF_SENTINEL_ENTITY_COOLDOWN_MINUTES: (
-            RECOMMENDED_SENTINEL_ENTITY_COOLDOWN_MINUTES
-        ),
-        CONF_SENTINEL_PENDING_PROMPT_TTL_MINUTES: (
-            RECOMMENDED_SENTINEL_PENDING_PROMPT_TTL_MINUTES
-        ),
-        CONF_SENTINEL_DISCOVERY_ENABLED: RECOMMENDED_SENTINEL_DISCOVERY_ENABLED,
-        CONF_SENTINEL_DISCOVERY_INTERVAL_SECONDS: (
-            RECOMMENDED_SENTINEL_DISCOVERY_INTERVAL_SECONDS
-        ),
-        CONF_SENTINEL_DISCOVERY_MAX_RECORDS: RECOMMENDED_SENTINEL_DISCOVERY_MAX_RECORDS,
-        CONF_EXPLAIN_ENABLED: RECOMMENDED_EXPLAIN_ENABLED,
-    }
-    subentry = ConfigSubentry(
-        subentry_type=SUBENTRY_TYPE_SENTINEL,
-        title="Sentinel",
-        unique_id=f"{entry.entry_id}_sentinel",
-        data=MappingProxyType(payload),
-    )
-    hass.config_entries.async_add_subentry(entry, subentry)
-
-
 # Database and vector index bootstrapping.
 # store.setup() only runs the vector migrations when store.index_config is set.
 # If index_config is None (no embeddings configured yet), setup() runs only the
@@ -1294,7 +1260,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: HGAConfigEntry) -> bool:
 
     _register_services(hass, entry)
     _ensure_default_feature_subentries(hass, entry)
-    _ensure_default_sentinel_subentry(hass, entry)
     _assign_first_provider_if_needed(hass, entry)
 
     # Resolve effective options (data + options + subentries).
@@ -3113,6 +3078,33 @@ async def async_setup_entry(hass: HomeAssistant, entry: HGAConfigEntry) -> bool:
         schema=SENTINEL_RESET_BASELINE_SCHEMA,
         supports_response=_SERVICE_RESPONSE_ONLY,
     )
+
+    # Reload whenever a subentry is added, updated, or removed so that tasks
+    # started during setup (sentinel, baseline, discovery) are stopped or
+    # started to match the current subentry configuration.  Without this,
+    # deleting a Sentinel subentry through the UI leaves background tasks
+    # running indefinitely.
+    async def _reload_on_subentry_change(h: HomeAssistant, e: HGAConfigEntry) -> None:
+        # When the Sentinel subentry is removed, stop its background tasks
+        # immediately rather than waiting for the reload to call async_unload_entry.
+        # Without this, the sentinel engine can fire one more evaluation cycle
+        # during the async window between deletion and unload.
+        sentinel_present = any(
+            s.subentry_type == SUBENTRY_TYPE_SENTINEL for s in e.subentries.values()
+        )
+        if not sentinel_present:
+            rd = e.runtime_data
+            if rd.sentinel is not None:
+                await rd.sentinel.stop()
+            if rd.baseline_updater is not None:
+                await rd.baseline_updater.stop()
+            if rd.discovery_engine is not None:
+                await rd.discovery_engine.stop()
+            if rd.notifier is not None:
+                rd.notifier.stop()
+        h.config_entries.async_schedule_reload(e.entry_id)
+
+    entry.async_on_unload(entry.add_update_listener(_reload_on_subentry_change))
 
     return True
 

--- a/custom_components/home_generative_agent/core/subentry_resolver.py
+++ b/custom_components/home_generative_agent/core/subentry_resolver.py
@@ -292,6 +292,9 @@ def _apply_sentinel_options(
     if sentinel_subentry is None:
         for key, value in sentinel_defaults.items():
             options.setdefault(key, value)
+        # No subentry → Sentinel is not configured; force disabled so that tasks
+        # are not restarted after the subentry is deleted and the entry reloads.
+        options[CONF_SENTINEL_ENABLED] = False
         return
 
     data = dict(sentinel_subentry.data)

--- a/custom_components/home_generative_agent/flows/feature_subentry_flow.py
+++ b/custom_components/home_generative_agent/flows/feature_subentry_flow.py
@@ -431,11 +431,10 @@ class FeatureSubentryFlow(ConfigSubentryFlow):
         if user_input is None:
             schema_dict: dict[Any, Any] = {}
             for feature_type, info in FEATURE_DEFS.items():
-                is_required = info["required"]
-                enabled = (
-                    is_required or _feature_subentry(entry, feature_type) is not None
-                )
-                if not is_required and feature_type in disabled_cache:
+                if info["required"]:
+                    continue
+                enabled = _feature_subentry(entry, feature_type) is not None
+                if feature_type in disabled_cache:
                     enabled = False
                 schema_dict[vol.Required(feature_type, default=enabled)] = (
                     BooleanSelector()

--- a/custom_components/home_generative_agent/flows/feature_subentry_flow.py
+++ b/custom_components/home_generative_agent/flows/feature_subentry_flow.py
@@ -276,6 +276,18 @@ class FeatureSubentryFlow(ConfigSubentryFlow):
     ) -> SubentryFlowResult:
         """Show Basic/Advanced mode selector for new setup."""
         if user_input is None:
+            entry = self._get_entry()
+            has_existing = any(
+                s.subentry_type == SUBENTRY_TYPE_FEATURE
+                for s in entry.subentries.values()
+            )
+            overwrite_warning = (
+                "\n\n⚠️ Features are already configured. "
+                "Choosing **Basic setup** will overwrite your current "
+                "provider assignments with recommended defaults."
+                if has_existing
+                else ""
+            )
             return self.async_show_form(
                 step_id="setup_mode",
                 data_schema=vol.Schema(
@@ -297,6 +309,7 @@ class FeatureSubentryFlow(ConfigSubentryFlow):
                         )
                     }
                 ),
+                description_placeholders={"overwrite_warning": overwrite_warning},
             )
         self._setup_mode = True
         if user_input.get("setup_mode", "basic") == "basic":

--- a/custom_components/home_generative_agent/flows/feature_subentry_flow.py
+++ b/custom_components/home_generative_agent/flows/feature_subentry_flow.py
@@ -436,13 +436,9 @@ class FeatureSubentryFlow(ConfigSubentryFlow):
                 enabled = _feature_subentry(entry, feature_type) is not None
                 if feature_type in disabled_cache:
                     enabled = False
-                schema_dict[
-                    vol.Optional(
-                        feature_type,
-                        default=enabled,
-                        description={"suggested_value": enabled},
-                    )
-                ] = BooleanSelector()
+                schema_dict[vol.Required(feature_type, default=enabled)] = (
+                    BooleanSelector()
+                )
             return self.async_show_form(
                 step_id="feature_enable", data_schema=vol.Schema(schema_dict)
             )

--- a/custom_components/home_generative_agent/flows/feature_subentry_flow.py
+++ b/custom_components/home_generative_agent/flows/feature_subentry_flow.py
@@ -357,8 +357,33 @@ class FeatureSubentryFlow(ConfigSubentryFlow):
                 )
 
         self._persist_disabled_cache(disabled_cache)
+        current_db = next(
+            (
+                s
+                for s in entry.subentries.values()
+                if s.subentry_type == SUBENTRY_TYPE_DATABASE
+            ),
+            None,
+        )
+        if current_db is None:
+            db_subentry = ConfigSubentry(
+                subentry_type=SUBENTRY_TYPE_DATABASE,
+                title="Database",
+                unique_id=f"{entry.entry_id}_database",
+                data=MappingProxyType(
+                    {
+                        CONF_USERNAME: RECOMMENDED_DB_USERNAME,
+                        CONF_PASSWORD: RECOMMENDED_DB_PASSWORD,
+                        CONF_HOST: RECOMMENDED_DB_HOST,
+                        CONF_PORT: RECOMMENDED_DB_PORT,
+                        CONF_DB_NAME: RECOMMENDED_DB_NAME,
+                        CONF_DB_PARAMS: RECOMMENDED_DB_PARAMS,
+                    }
+                ),
+            )
+            self.hass.config_entries.async_add_subentry(entry, db_subentry)
         self._schedule_reload()
-        return await self.async_step_database(None)
+        return await self.async_step_setup_status()
 
     async def async_step_setup_status(
         self, user_input: dict[str, Any] | None = None
@@ -957,7 +982,7 @@ class FeatureSubentryFlow(ConfigSubentryFlow):
             )
         self._schedule_reload()
 
-        if self._basic_mode:
+        if self._setup_mode:
             return await self.async_step_setup_status()
         if not _provider_options(entry, "chat"):
             return await self.async_step_instructions()

--- a/custom_components/home_generative_agent/flows/feature_subentry_flow.py
+++ b/custom_components/home_generative_agent/flows/feature_subentry_flow.py
@@ -193,6 +193,8 @@ class FeatureSubentryFlow(ConfigSubentryFlow):
     def __init__(self) -> None:
         """Initialize the feature subentry flow."""
         self._setup_mode = False
+        self._basic_mode = False
+        self._basic_skipped_features: list[str] = []
         self._feature_queue: list[str] = []
         self._active_feature: str | None = None
         self._pending_provider_id: str | None = None
@@ -255,11 +257,131 @@ class FeatureSubentryFlow(ConfigSubentryFlow):
             self._setup_mode = False
             self._active_feature = current.data.get("feature_type")
             return await self._async_step_feature(self._active_feature, user_input)
+        return await self.async_step_setup_mode(user_input)
 
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> SubentryFlowResult:
+        """Reconfigure — bypass mode selector, go directly to the Advanced path."""
+        current = _current_subentry(self)
+        if current is not None:
+            self._setup_mode = False
+            self._active_feature = current.data.get("feature_type")
+            return await self._async_step_feature(self._active_feature, user_input)
         self._setup_mode = True
         return await self.async_step_feature_enable(user_input)
 
-    async_step_reconfigure = async_step_user
+    async def async_step_setup_mode(
+        self, user_input: dict[str, Any] | None = None
+    ) -> SubentryFlowResult:
+        """Show Basic/Advanced mode selector for new setup."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="setup_mode",
+                data_schema=vol.Schema(
+                    {
+                        vol.Required("setup_mode", default="basic"): SelectSelector(
+                            SelectSelectorConfig(
+                                options=[
+                                    SelectOptionDict(
+                                        label="Basic setup", value="basic"
+                                    ),
+                                    SelectOptionDict(
+                                        label="Advanced setup", value="advanced"
+                                    ),
+                                ],
+                                mode=SelectSelectorMode.LIST,
+                                sort=False,
+                                custom_value=False,
+                            )
+                        )
+                    }
+                ),
+            )
+        self._setup_mode = True
+        if user_input.get("setup_mode", "basic") == "basic":
+            self._basic_mode = True
+            return await self._async_step_basic_setup()
+        self._basic_mode = False
+        return await self.async_step_feature_enable(None)
+
+    async def _async_step_basic_setup(self) -> SubentryFlowResult:
+        """Auto-create feature subentries with the first compatible provider."""
+        entry = self._get_entry()
+        any_providers = any(
+            s.subentry_type == SUBENTRY_TYPE_MODEL_PROVIDER
+            for s in entry.subentries.values()
+        )
+        if not any_providers:
+            return self.async_abort(reason="no_provider_for_basic_setup")
+
+        self._basic_skipped_features = []
+        disabled_cache = self._disabled_feature_cache()
+
+        for feature_type, info in FEATURE_DEFS.items():
+            category = FEATURE_CATEGORY_MAP.get(feature_type, "")
+            provider_opts = _provider_options(entry, category)
+            if not provider_opts:
+                self._basic_skipped_features.append(feature_type)
+                continue
+            provider_id = provider_opts[0]["value"]
+            provider_type = _provider_type_for_id(entry, provider_id)
+            model_data = _default_model_data(category, provider_type)
+            payload = self._feature_payload(feature_type, provider_id, model_data, {})
+            existing = _feature_subentry(entry, feature_type)
+            if existing is None:
+                disabled_cache.pop(feature_type, None)
+                subentry = ConfigSubentry(
+                    subentry_type=SUBENTRY_TYPE_FEATURE,
+                    title=info["name"],
+                    unique_id=f"{entry.entry_id}_{feature_type}",
+                    data=MappingProxyType(payload),
+                )
+                self.hass.config_entries.async_add_subentry(entry, subentry)
+            else:
+                self.hass.config_entries.async_update_subentry(  # type: ignore[attr-defined]
+                    entry, existing, data=payload, title=info["name"]
+                )
+
+        self._persist_disabled_cache(disabled_cache)
+        self._schedule_reload()
+        return await self.async_step_database(None)
+
+    async def async_step_setup_status(
+        self, user_input: dict[str, Any] | None = None
+    ) -> SubentryFlowResult:
+        """Show final status screen after basic setup writes."""
+        if user_input is not None:
+            return self.async_abort(reason="setup_complete")
+
+        entry = self._get_entry()
+        enabled_names = [
+            FEATURE_DEFS[ft]["name"]
+            for ft in FEATURE_DEFS
+            if _feature_subentry(entry, ft) is not None
+        ]
+        db_ok = any(
+            s.subentry_type == SUBENTRY_TYPE_DATABASE for s in entry.subentries.values()
+        )
+        skipped_names = [
+            FEATURE_DEFS[ft]["name"] for ft in self._basic_skipped_features
+        ]
+        skipped_section = (
+            f"\n\n**Skipped (no compatible provider):** {', '.join(skipped_names)}"
+            if skipped_names
+            else ""
+        )
+        return self.async_show_form(
+            step_id="setup_status",
+            data_schema=vol.Schema({}),
+            description_placeholders={
+                "features_enabled": (
+                    ", ".join(enabled_names) if enabled_names else "None"
+                ),
+                "database_status": "Configured" if db_ok else "Not configured",
+                "skipped_section": skipped_section,
+            },
+        )
 
     async def async_step_feature_enable(
         self, user_input: dict[str, Any] | None = None
@@ -822,6 +944,8 @@ class FeatureSubentryFlow(ConfigSubentryFlow):
             )
         self._schedule_reload()
 
+        if self._basic_mode:
+            return await self.async_step_setup_status()
         if not _provider_options(entry, "chat"):
             return await self.async_step_instructions()
         return self.async_abort(reason="setup_complete")

--- a/custom_components/home_generative_agent/flows/feature_subentry_flow.py
+++ b/custom_components/home_generative_agent/flows/feature_subentry_flow.py
@@ -431,10 +431,11 @@ class FeatureSubentryFlow(ConfigSubentryFlow):
         if user_input is None:
             schema_dict: dict[Any, Any] = {}
             for feature_type, info in FEATURE_DEFS.items():
-                if info["required"]:
-                    continue
-                enabled = _feature_subentry(entry, feature_type) is not None
-                if feature_type in disabled_cache:
+                is_required = info["required"]
+                enabled = (
+                    is_required or _feature_subentry(entry, feature_type) is not None
+                )
+                if not is_required and feature_type in disabled_cache:
                     enabled = False
                 schema_dict[vol.Required(feature_type, default=enabled)] = (
                     BooleanSelector()
@@ -444,11 +445,10 @@ class FeatureSubentryFlow(ConfigSubentryFlow):
             )
 
         cache = self._disabled_feature_cache()
-        enabled_features = {"conversation"}
+        enabled_features: set[str] = set()
         for feature_type, info in FEATURE_DEFS.items():
-            if info["required"]:
-                continue
-            enabled = bool(user_input.get(feature_type, False))
+            is_required = info["required"]
+            enabled = is_required or bool(user_input.get(feature_type, False))
             if enabled:
                 enabled_features.add(feature_type)
             existing = _feature_subentry(entry, feature_type)

--- a/custom_components/home_generative_agent/flows/sentinel_subentry_flow.py
+++ b/custom_components/home_generative_agent/flows/sentinel_subentry_flow.py
@@ -374,8 +374,185 @@ class SentinelSubentryFlow(ConfigSubentryFlow):
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> SubentryFlowResult:
-        """Entry point for Sentinel setup/reconfigure."""
+        """Entry point for new Sentinel setup — show mode selector."""
+        return await self.async_step_setup_mode(user_input)
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> SubentryFlowResult:
+        """Reconfigure — bypass mode selector, go directly to full settings."""
         return await self.async_step_settings(user_input)
+
+    async def async_step_setup_mode(
+        self, user_input: dict[str, Any] | None = None
+    ) -> SubentryFlowResult:
+        """Show Basic/Advanced mode selector for new Sentinel setup."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="setup_mode",
+                data_schema=vol.Schema(
+                    {
+                        vol.Required("setup_mode", default="basic"): SelectSelector(
+                            SelectSelectorConfig(
+                                options=[
+                                    SelectOptionDict(
+                                        label="Basic setup", value="basic"
+                                    ),
+                                    SelectOptionDict(
+                                        label="Advanced setup", value="advanced"
+                                    ),
+                                ],
+                                mode=SelectSelectorMode.LIST,
+                                sort=False,
+                                custom_value=False,
+                            )
+                        )
+                    }
+                ),
+            )
+        if user_input.get("setup_mode", "basic") == "basic":
+            return await self.async_step_basic_settings(None)
+        return await self.async_step_settings(None)
+
+    async def async_step_basic_settings(  # noqa: PLR0912
+        self, user_input: dict[str, Any] | None = None
+    ) -> SubentryFlowResult:
+        """Expose only the four essential Sentinel fields; fill rest from defaults."""
+        current = _current_subentry(self)
+        payload = _default_payload()
+        if current is not None:
+            payload.update(dict(current.data))
+
+        mobile_opts = list_mobile_notify_services(self.hass)
+        notify_value = str(payload.get(CONF_NOTIFY_SERVICE, "") or "")
+
+        schema: dict[Any, Any] = {
+            vol.Required(
+                CONF_SENTINEL_ENABLED,
+                default=bool(
+                    payload.get(CONF_SENTINEL_ENABLED, RECOMMENDED_SENTINEL_ENABLED)
+                ),
+            ): BooleanSelector(),
+            vol.Required(
+                CONF_SENTINEL_DAILY_DIGEST_ENABLED,
+                default=bool(
+                    payload.get(
+                        CONF_SENTINEL_DAILY_DIGEST_ENABLED,
+                        RECOMMENDED_SENTINEL_DAILY_DIGEST_ENABLED,
+                    )
+                ),
+            ): BooleanSelector(),
+            vol.Required(
+                CONF_SENTINEL_DAILY_DIGEST_TIME,
+                default=str(
+                    payload.get(
+                        CONF_SENTINEL_DAILY_DIGEST_TIME,
+                        RECOMMENDED_SENTINEL_DAILY_DIGEST_TIME,
+                    )
+                ),
+            ): TimeSelector(),
+            vol.Optional(
+                CONF_CRITICAL_ACTION_PIN,
+                description={"suggested_value": ""},
+                default="",
+            ): TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD)),
+        }
+
+        if mobile_opts:
+            default_notify = notify_value if notify_value in mobile_opts else ""
+            schema[
+                vol.Optional(
+                    CONF_NOTIFY_SERVICE,
+                    description={"suggested_value": notify_value},
+                    default=default_notify,
+                )
+            ] = SelectSelector(
+                SelectSelectorConfig(
+                    options=[
+                        SelectOptionDict(label=s.replace("notify.", ""), value=s)
+                        for s in ["", *mobile_opts]
+                    ],
+                    mode=SelectSelectorMode.DROPDOWN,
+                    sort=False,
+                    custom_value=False,
+                )
+            )
+        else:
+            schema[
+                vol.Optional(
+                    CONF_NOTIFY_SERVICE,
+                    description={"suggested_value": notify_value},
+                    default=notify_value,
+                )
+            ] = TextSelector(TextSelectorConfig(type=TextSelectorType.TEXT))
+
+        if user_input is None:
+            return self.async_show_form(
+                step_id="basic_settings",
+                data_schema=vol.Schema(schema),
+            )
+
+        data = _default_payload()
+        errors: dict[str, str] = {}
+
+        notify_service = str(user_input.get(CONF_NOTIFY_SERVICE, "") or "").strip()
+        if notify_service:
+            data[CONF_NOTIFY_SERVICE] = notify_service
+        else:
+            data.pop(CONF_NOTIFY_SERVICE, None)
+
+        raw_pin = str(user_input.get(CONF_CRITICAL_ACTION_PIN, "") or "").strip()
+        data.pop(CONF_CRITICAL_ACTION_PIN, None)
+        if raw_pin:
+            if (
+                not raw_pin.isdigit()
+                or not CRITICAL_PIN_MIN_LEN <= len(raw_pin) <= CRITICAL_PIN_MAX_LEN
+            ):
+                errors["base"] = "invalid_pin"
+            else:
+                hashed, salt = hash_pin(raw_pin)
+                data[CONF_SENTINEL_LEVEL_INCREASE_PIN_HASH] = hashed
+                data[CONF_SENTINEL_LEVEL_INCREASE_PIN_SALT] = salt
+
+        data[CONF_SENTINEL_ENABLED] = bool(
+            user_input.get(CONF_SENTINEL_ENABLED, RECOMMENDED_SENTINEL_ENABLED)
+        )
+        data[CONF_SENTINEL_DAILY_DIGEST_ENABLED] = bool(
+            user_input.get(
+                CONF_SENTINEL_DAILY_DIGEST_ENABLED,
+                RECOMMENDED_SENTINEL_DAILY_DIGEST_ENABLED,
+            )
+        )
+        data[CONF_SENTINEL_DAILY_DIGEST_TIME] = str(
+            user_input.get(
+                CONF_SENTINEL_DAILY_DIGEST_TIME,
+                RECOMMENDED_SENTINEL_DAILY_DIGEST_TIME,
+            )
+        )
+
+        if errors:
+            return self.async_show_form(
+                step_id="basic_settings",
+                data_schema=vol.Schema(schema),
+                errors=errors,
+            )
+
+        if current is None:
+            if self.source not in (SOURCE_USER, SOURCE_RECONFIGURE):
+                return self.async_abort(reason="no_existing_subentry")
+            if self.source == SOURCE_RECONFIGURE:
+                self._source = SOURCE_USER
+                self.context["source"] = SOURCE_USER
+            self._schedule_reload()
+            return self.async_create_entry(title="Sentinel", data=data)
+
+        self._schedule_reload()
+        return self.async_update_and_abort(
+            self._get_entry(),
+            current,
+            data=data,
+            title="Sentinel",
+        )
 
     async def async_step_settings(  # noqa: PLR0912, PLR0915
         self, user_input: dict[str, Any] | None = None
@@ -475,5 +652,3 @@ class SentinelSubentryFlow(ConfigSubentryFlow):
             data=data,
             title="Sentinel",
         )
-
-    async_step_reconfigure = async_step_user

--- a/custom_components/home_generative_agent/flows/sentinel_subentry_flow.py
+++ b/custom_components/home_generative_agent/flows/sentinel_subentry_flow.py
@@ -388,6 +388,18 @@ class SentinelSubentryFlow(ConfigSubentryFlow):
     ) -> SubentryFlowResult:
         """Show Basic/Advanced mode selector for new Sentinel setup."""
         if user_input is None:
+            entry = self._get_entry()
+            has_existing = any(
+                s.subentry_type == SUBENTRY_TYPE_SENTINEL
+                for s in entry.subentries.values()
+            )
+            overwrite_warning = (
+                "\n\n⚠️ Sentinel is already configured. "
+                "Choosing **Basic setup** will overwrite your current "
+                "settings with recommended defaults."
+                if has_existing
+                else ""
+            )
             return self.async_show_form(
                 step_id="setup_mode",
                 data_schema=vol.Schema(
@@ -409,6 +421,7 @@ class SentinelSubentryFlow(ConfigSubentryFlow):
                         )
                     }
                 ),
+                description_placeholders={"overwrite_warning": overwrite_warning},
             )
         if user_input.get("setup_mode", "basic") == "basic":
             return await self.async_step_basic_settings(None)

--- a/custom_components/home_generative_agent/flows/sentinel_subentry_flow.py
+++ b/custom_components/home_generative_agent/flows/sentinel_subentry_flow.py
@@ -107,7 +107,7 @@ def _current_subentry(flow: ConfigSubentryFlow) -> ConfigSubentry | None:
         for subentry in entry.subentries.values()
         if subentry.subentry_type == SUBENTRY_TYPE_SENTINEL
     ]
-    if len(matches) == 1:
+    if matches:
         return matches[0]
     return None
 
@@ -441,7 +441,8 @@ class SentinelSubentryFlow(ConfigSubentryFlow):
             payload.update(dict(current.data))
 
         mobile_opts = list_mobile_notify_services(self.hass)
-        notify_value = str(payload.get(CONF_NOTIFY_SERVICE, "") or "")
+        # Basic setup always starts from defaults — no pre-existing notify service.
+        notify_value = ""
 
         schema: dict[Any, Any] = {
             vol.Required(
@@ -503,10 +504,19 @@ class SentinelSubentryFlow(ConfigSubentryFlow):
                 )
             ] = TextSelector(TextSelectorConfig(type=TextSelectorType.TEXT))
 
+        # Basic setup always shows recommended defaults in the form, regardless of
+        # any existing configuration (the overwrite warning makes this intent explicit).
+        defaults = _default_payload()
+        suggested: dict[str, Any] = {
+            k: v for k, v in defaults.items() if k != CONF_CRITICAL_ACTION_PIN
+        }
+
         if user_input is None:
             return self.async_show_form(
                 step_id="basic_settings",
-                data_schema=vol.Schema(schema),
+                data_schema=self.add_suggested_values_to_schema(
+                    vol.Schema(schema), suggested
+                ),
             )
 
         data = _default_payload()
@@ -550,7 +560,9 @@ class SentinelSubentryFlow(ConfigSubentryFlow):
         if errors:
             return self.async_show_form(
                 step_id="basic_settings",
-                data_schema=vol.Schema(schema),
+                data_schema=self.add_suggested_values_to_schema(
+                    vol.Schema(schema), suggested
+                ),
                 errors=errors,
             )
 
@@ -581,9 +593,17 @@ class SentinelSubentryFlow(ConfigSubentryFlow):
             payload.update(dict(current.data))
 
         if user_input is None:
+            suggested: dict[str, Any] = {
+                k: v for k, v in payload.items() if k != CONF_CRITICAL_ACTION_PIN
+            }
+            suggested[CONF_SENTINEL_CAMERA_ENTRY_LINKS] = _camera_entry_links_json(
+                payload
+            )
             return self.async_show_form(
                 step_id="settings",
-                data_schema=self._schema(payload),
+                data_schema=self.add_suggested_values_to_schema(
+                    self._schema(payload), suggested
+                ),
             )
 
         data = dict(user_input)
@@ -647,9 +667,17 @@ class SentinelSubentryFlow(ConfigSubentryFlow):
                 error_payload.get(CONF_SENTINEL_CAMERA_ENTRY_LINKS), dict
             ):
                 error_payload.pop(CONF_SENTINEL_CAMERA_ENTRY_LINKS, None)
+            error_suggested: dict[str, Any] = {
+                k: v for k, v in error_payload.items() if k != CONF_CRITICAL_ACTION_PIN
+            }
+            error_suggested[CONF_SENTINEL_CAMERA_ENTRY_LINKS] = (
+                _camera_entry_links_json(error_payload)
+            )
             return self.async_show_form(
                 step_id="settings",
-                data_schema=self._schema(error_payload),
+                data_schema=self.add_suggested_values_to_schema(
+                    self._schema(error_payload), error_suggested
+                ),
                 errors=errors,
             )
 

--- a/custom_components/home_generative_agent/flows/sentinel_subentry_flow.py
+++ b/custom_components/home_generative_agent/flows/sentinel_subentry_flow.py
@@ -96,7 +96,12 @@ def _current_subentry(flow: ConfigSubentryFlow) -> ConfigSubentry | None:
     if not subentry_id:
         subentry_id = flow.context.get("subentry_id")
     if subentry_id:
-        return entry.subentries.get(subentry_id)
+        # For reconfigure flows this will find the subentry being edited.
+        # For user flows HA pre-generates a UUID that doesn't exist yet, so
+        # the get() returns None and we fall through to the type scan below.
+        found = entry.subentries.get(subentry_id)
+        if found is not None:
+            return found
     matches = [
         subentry
         for subentry in entry.subentries.values()

--- a/custom_components/home_generative_agent/flows/sentinel_subentry_flow.py
+++ b/custom_components/home_generative_agent/flows/sentinel_subentry_flow.py
@@ -97,14 +97,13 @@ def _current_subentry(flow: ConfigSubentryFlow) -> ConfigSubentry | None:
         subentry_id = flow.context.get("subentry_id")
     if subentry_id:
         return entry.subentries.get(subentry_id)
-    if flow.source == SOURCE_RECONFIGURE:
-        matches = [
-            subentry
-            for subentry in entry.subentries.values()
-            if subentry.subentry_type == SUBENTRY_TYPE_SENTINEL
-        ]
-        if len(matches) == 1:
-            return matches[0]
+    matches = [
+        subentry
+        for subentry in entry.subentries.values()
+        if subentry.subentry_type == SUBENTRY_TYPE_SENTINEL
+    ]
+    if len(matches) == 1:
+        return matches[0]
     return None
 
 

--- a/custom_components/home_generative_agent/manifest.json
+++ b/custom_components/home_generative_agent/manifest.json
@@ -34,5 +34,5 @@
     "langchain-google-genai==3.1.0",
     "langchain-anthropic==1.4.3"
   ],
-  "version": "3.14.19"
+  "version": "3.14.20"
 }

--- a/custom_components/home_generative_agent/strings.json
+++ b/custom_components/home_generative_agent/strings.json
@@ -219,7 +219,7 @@
       "step": {
         "setup_mode": {
           "title": "Setup",
-          "description": "Choose a setup type. Basic setup enables all features with recommended defaults. Advanced setup gives you full control over each feature.",
+          "description": "Choose a setup type. Basic setup enables all features with recommended defaults. Advanced setup gives you full control over each feature.{overwrite_warning}",
           "data": {
             "setup_mode": "Setup type"
           }

--- a/custom_components/home_generative_agent/strings.json
+++ b/custom_components/home_generative_agent/strings.json
@@ -226,7 +226,7 @@
         },
         "setup_status": {
           "title": "Setup complete",
-          "description": "Basic setup is done.\n\n**Features enabled:** {features_enabled}{skipped_section}\n\n**Database:** {database_status}\n\n**Next steps:**\n- Run **Configure Sentinel** to enable anomaly monitoring.\n- Go to **Settings → Voice Assistants** to add Home Generative Agent as your voice assistant."
+          "description": "Setup is done.\n\n**Features enabled:** {features_enabled}{skipped_section}\n\n**Database:** {database_status}\n\n**Next steps:**\n- Run **Configure Sentinel** to enable anomaly monitoring.\n- Add an **STT Provider** for voice input.\n- Go to **Settings → Voice Assistants** to add Home Generative Agent as your voice assistant."
         },
         "feature_enable": {
           "title": "Feature setup",

--- a/custom_components/home_generative_agent/strings.json
+++ b/custom_components/home_generative_agent/strings.json
@@ -230,14 +230,10 @@
         },
         "feature_enable": {
           "title": "Feature setup",
-          "description": "Enable or disable features.",
+          "description": "**Conversation** is always enabled. Enable or disable optional features below.",
           "data": {
-            "conversation": "Conversation",
             "camera_image_analysis": "Camera Image Analysis",
             "conversation_summary": "Conversation Summary"
-          },
-          "data_description": {
-            "conversation": "Always enabled."
           }
         },
         "feature_provider": {

--- a/custom_components/home_generative_agent/strings.json
+++ b/custom_components/home_generative_agent/strings.json
@@ -142,13 +142,32 @@
         "reconfigure_successful": "Sentinel configuration updated."
       },
       "error": {
-        "invalid_camera_entry_links": "Must be a JSON object mapping camera entity IDs to lists of entry entity IDs, e.g. {{\"camera.driveway\": [\"lock.front_door\"]}}."
+        "invalid_camera_entry_links": "Must be a JSON object mapping camera entity IDs to lists of entry entity IDs, e.g. {{\"camera.driveway\": [\"lock.front_door\"]}}.",
+        "invalid_pin": "PIN must be 4-10 digits."
       },
       "initiate_flow": {
         "reconfigure": "Reconfigure Sentinel",
         "user": "Configure Sentinel"
       },
       "step": {
+        "setup_mode": {
+          "title": "Sentinel Setup",
+          "description": "Choose how to configure Sentinel monitoring.",
+          "data": {
+            "setup_mode": "Setup type"
+          }
+        },
+        "basic_settings": {
+          "title": "Sentinel",
+          "description": "Configure the essential Sentinel settings. All other options use recommended defaults.",
+          "data": {
+            "sentinel_enabled": "Enable anomaly alerting",
+            "sentinel_daily_digest_enabled": "Enable daily digest notification",
+            "sentinel_daily_digest_time": "Daily digest time (HH:MM:SS)",
+            "critical_action_pin": "Level-increase PIN (optional, 4-10 digits)",
+            "notify_service": "Notify service (optional)"
+          }
+        },
         "settings": {
           "title": "Sentinel",
           "description": "Configure proactive Sentinel monitoring and discovery.",
@@ -183,7 +202,8 @@
       "entry_type": "service",
       "abort": {
         "reconfigure_successful": "Feature updated.",
-        "setup_complete": "Setup completed."
+        "setup_complete": "Setup completed.",
+        "no_provider_for_basic_setup": "No model provider is configured. Add a **Model Provider** first, then retry setup."
       },
       "error": {
         "no_providers": "No model providers are configured.",
@@ -197,6 +217,17 @@
         "user": "Setup"
       },
       "step": {
+        "setup_mode": {
+          "title": "Setup",
+          "description": "Choose a setup type. Basic setup enables all features with recommended defaults. Advanced setup gives you full control over each feature.",
+          "data": {
+            "setup_mode": "Setup type"
+          }
+        },
+        "setup_status": {
+          "title": "Setup complete",
+          "description": "Basic setup is done.\n\n**Features enabled:** {features_enabled}{skipped_section}\n\n**Database:** {database_status}\n\n**Next steps:**\n- Run **Configure Sentinel** to enable anomaly monitoring.\n- Go to **Settings → Voice Assistants** to add Home Generative Agent as your voice assistant."
+        },
         "feature_enable": {
           "title": "Feature setup",
           "description": "Enable or disable optional features.",

--- a/custom_components/home_generative_agent/strings.json
+++ b/custom_components/home_generative_agent/strings.json
@@ -230,10 +230,14 @@
         },
         "feature_enable": {
           "title": "Feature setup",
-          "description": "Enable or disable optional features.",
+          "description": "Enable or disable features.",
           "data": {
+            "conversation": "Conversation",
             "camera_image_analysis": "Camera Image Analysis",
             "conversation_summary": "Conversation Summary"
+          },
+          "data_description": {
+            "conversation": "Always enabled."
           }
         },
         "feature_provider": {

--- a/custom_components/home_generative_agent/strings.json
+++ b/custom_components/home_generative_agent/strings.json
@@ -152,7 +152,7 @@
       "step": {
         "setup_mode": {
           "title": "Sentinel Setup",
-          "description": "Choose how to configure Sentinel monitoring.",
+          "description": "Choose how to configure Sentinel monitoring.{overwrite_warning}",
           "data": {
             "setup_mode": "Setup type"
           }

--- a/custom_components/home_generative_agent/translations/en.json
+++ b/custom_components/home_generative_agent/translations/en.json
@@ -219,7 +219,7 @@
       "step": {
         "setup_mode": {
           "title": "Setup",
-          "description": "Choose a setup type. Basic setup enables all features with recommended defaults. Advanced setup gives you full control over each feature.",
+          "description": "Choose a setup type. Basic setup enables all features with recommended defaults. Advanced setup gives you full control over each feature.{overwrite_warning}",
           "data": {
             "setup_mode": "Setup type"
           }

--- a/custom_components/home_generative_agent/translations/en.json
+++ b/custom_components/home_generative_agent/translations/en.json
@@ -226,7 +226,7 @@
         },
         "setup_status": {
           "title": "Setup complete",
-          "description": "Basic setup is done.\n\n**Features enabled:** {features_enabled}{skipped_section}\n\n**Database:** {database_status}\n\n**Next steps:**\n- Run **Configure Sentinel** to enable anomaly monitoring.\n- Go to **Settings → Voice Assistants** to add Home Generative Agent as your voice assistant."
+          "description": "Setup is done.\n\n**Features enabled:** {features_enabled}{skipped_section}\n\n**Database:** {database_status}\n\n**Next steps:**\n- Run **Configure Sentinel** to enable anomaly monitoring.\n- Add an **STT Provider** for voice input.\n- Go to **Settings → Voice Assistants** to add Home Generative Agent as your voice assistant."
         },
         "feature_enable": {
           "title": "Feature setup",

--- a/custom_components/home_generative_agent/translations/en.json
+++ b/custom_components/home_generative_agent/translations/en.json
@@ -230,14 +230,10 @@
         },
         "feature_enable": {
           "title": "Feature setup",
-          "description": "Enable or disable features.",
+          "description": "**Conversation** is always enabled. Enable or disable optional features below.",
           "data": {
-            "conversation": "Conversation",
             "camera_image_analysis": "Camera Image Analysis",
             "conversation_summary": "Conversation Summary"
-          },
-          "data_description": {
-            "conversation": "Always enabled."
           }
         },
         "feature_provider": {

--- a/custom_components/home_generative_agent/translations/en.json
+++ b/custom_components/home_generative_agent/translations/en.json
@@ -230,10 +230,14 @@
         },
         "feature_enable": {
           "title": "Feature setup",
-          "description": "Enable or disable optional features.",
+          "description": "Enable or disable features.",
           "data": {
+            "conversation": "Conversation",
             "camera_image_analysis": "Camera Image Analysis",
             "conversation_summary": "Conversation Summary"
+          },
+          "data_description": {
+            "conversation": "Always enabled."
           }
         },
         "feature_provider": {

--- a/custom_components/home_generative_agent/translations/en.json
+++ b/custom_components/home_generative_agent/translations/en.json
@@ -152,7 +152,7 @@
       "step": {
         "setup_mode": {
           "title": "Sentinel Setup",
-          "description": "Choose how to configure Sentinel monitoring.",
+          "description": "Choose how to configure Sentinel monitoring.{overwrite_warning}",
           "data": {
             "setup_mode": "Setup type"
           }

--- a/custom_components/home_generative_agent/translations/en.json
+++ b/custom_components/home_generative_agent/translations/en.json
@@ -141,11 +141,33 @@
       "abort": {
         "reconfigure_successful": "Sentinel configuration updated."
       },
+      "error": {
+        "invalid_camera_entry_links": "Must be a JSON object mapping camera entity IDs to lists of entry entity IDs, e.g. {{\"camera.driveway\": [\"lock.front_door\"]}}.",
+        "invalid_pin": "PIN must be 4-10 digits."
+      },
       "initiate_flow": {
         "reconfigure": "Reconfigure Sentinel",
         "user": "Configure Sentinel"
       },
       "step": {
+        "setup_mode": {
+          "title": "Sentinel Setup",
+          "description": "Choose how to configure Sentinel monitoring.",
+          "data": {
+            "setup_mode": "Setup type"
+          }
+        },
+        "basic_settings": {
+          "title": "Sentinel",
+          "description": "Configure the essential Sentinel settings. All other options use recommended defaults.",
+          "data": {
+            "sentinel_enabled": "Enable anomaly alerting",
+            "sentinel_daily_digest_enabled": "Enable daily digest notification",
+            "sentinel_daily_digest_time": "Daily digest time (HH:MM:SS)",
+            "critical_action_pin": "Level-increase PIN (optional, 4-10 digits)",
+            "notify_service": "Notify service (optional)"
+          }
+        },
         "settings": {
           "title": "Sentinel",
           "description": "Configure proactive Sentinel monitoring and discovery.",
@@ -174,16 +196,14 @@
             "notify_service": "Sentinel Notify Service (optional)"
           }
         }
-      },
-      "error": {
-        "invalid_camera_entry_links": "Must be a JSON object mapping camera entity IDs to lists of entry entity IDs, e.g. {{\"camera.driveway\": [\"lock.front_door\"]}}."
       }
     },
     "feature": {
       "entry_type": "service",
       "abort": {
         "reconfigure_successful": "Feature updated.",
-        "setup_complete": "Setup completed."
+        "setup_complete": "Setup completed.",
+        "no_provider_for_basic_setup": "No model provider is configured. Add a **Model Provider** first, then retry setup."
       },
       "error": {
         "no_providers": "No model providers are configured.",
@@ -197,6 +217,17 @@
         "user": "Setup"
       },
       "step": {
+        "setup_mode": {
+          "title": "Setup",
+          "description": "Choose a setup type. Basic setup enables all features with recommended defaults. Advanced setup gives you full control over each feature.",
+          "data": {
+            "setup_mode": "Setup type"
+          }
+        },
+        "setup_status": {
+          "title": "Setup complete",
+          "description": "Basic setup is done.\n\n**Features enabled:** {features_enabled}{skipped_section}\n\n**Database:** {database_status}\n\n**Next steps:**\n- Run **Configure Sentinel** to enable anomaly monitoring.\n- Go to **Settings → Voice Assistants** to add Home Generative Agent as your voice assistant."
+        },
         "feature_enable": {
           "title": "Feature setup",
           "description": "Enable or disable optional features.",

--- a/custom_components/home_generative_agent/translations/ru.json
+++ b/custom_components/home_generative_agent/translations/ru.json
@@ -173,17 +173,37 @@
             "critical_action_pin": "Sentinel level-increase PIN (optional)",
             "notify_service": "Sentinel Notify Service (optional)"
           }
+        },
+        "setup_mode": {
+          "title": "Sentinel Setup",
+          "description": "Choose how to configure Sentinel monitoring.{overwrite_warning}",
+          "data": {
+            "setup_mode": "Setup type"
+          }
+        },
+        "basic_settings": {
+          "title": "Sentinel",
+          "description": "Configure the essential Sentinel settings. All other options use recommended defaults.",
+          "data": {
+            "sentinel_enabled": "Enable anomaly alerting",
+            "sentinel_daily_digest_enabled": "Enable daily digest notification",
+            "sentinel_daily_digest_time": "Daily digest time (HH:MM:SS)",
+            "notify_service": "Notify service (optional)",
+            "critical_action_pin": "Level-increase PIN (optional, 4-10 digits)"
+          }
         }
       },
       "error": {
-        "invalid_camera_entry_links": "Must be a JSON object mapping camera entity IDs to lists of entry entity IDs, e.g. {{\"camera.driveway\": [\"lock.front_door\"]}}."
+        "invalid_camera_entry_links": "Must be a JSON object mapping camera entity IDs to lists of entry entity IDs, e.g. {{\"camera.driveway\": [\"lock.front_door\"]}}.",
+        "invalid_pin": "PIN must be 4-10 digits."
       }
     },
     "feature": {
       "entry_type": "service",
       "abort": {
         "reconfigure_successful": "Feature updated.",
-        "setup_complete": "Setup completed."
+        "setup_complete": "Setup completed.",
+        "no_provider_for_basic_setup": "No model provider is configured. Add a **Model Provider** first, then retry setup."
       },
       "error": {
         "no_providers": "No model providers are configured.",
@@ -242,6 +262,17 @@
         "instructions": {
           "title": "Add a model provider",
           "description": "No model provider is configured yet. Add one from **Model Provider**."
+        },
+        "setup_mode": {
+          "title": "Setup",
+          "description": "Choose a setup type. Basic setup enables all features with recommended defaults. Advanced setup gives you full control over each feature.{overwrite_warning}",
+          "data": {
+            "setup_mode": "Setup type"
+          }
+        },
+        "setup_status": {
+          "title": "Setup complete",
+          "description": "Setup is done.\n\n**Features enabled:** {features_enabled}{skipped_section}\n\n**Database:** {database_status}\n\n**Next steps:**\n- Run **Configure Sentinel** to enable anomaly monitoring.\n- Add an **STT Provider** for voice input.\n- Go to **Settings → Voice Assistants** to add Home Generative Agent as your voice assistant."
         }
       }
     }

--- a/custom_components/home_generative_agent/translations/tr.json
+++ b/custom_components/home_generative_agent/translations/tr.json
@@ -167,19 +167,43 @@
             "sentinel_daily_digest_time": "Günlük özet saati (SS:DD:SN)",
             "sentinel_camera_entry_links": "Kamera giriş bağlantıları (JSON, isteğe bağlı)",
             "critical_action_pin": "Sentinel düzey artırma PIN'i (isteğe bağlı)",
-            "notify_service": "Sentinel Bildirim Servisi (isteğe bağlı)"
+            "notify_service": "Sentinel Bildirim Servisi (isteğe bağlı)",
+            "sentinel_baseline_weekly_patterns": "Haftanın günü temellerini etkinleştir (hafta sonu yanlış pozitiflerini azaltır)",
+            "sentinel_baseline_dow_min_samples": "HGG temel minimum örnek sayısı (slot başına veri haftası)",
+            "sentinel_baseline_min_samples": "Sapma uyarıları tetiklenmeden önce gereken minimum örnek sayısı",
+            "sentinel_baseline_sustained_minutes": "Döngüsel yük kapısı: Uyarı vermeden önce eşiğin üzerinde geçen dakika (0 = devre dışı)"
+          }
+        },
+        "setup_mode": {
+          "title": "Sentinel Kurulumu",
+          "description": "Sentinel izlemeyi nasıl yapılandıracağınızı seçin.{overwrite_warning}",
+          "data": {
+            "setup_mode": "Kurulum türü"
+          }
+        },
+        "basic_settings": {
+          "title": "Sentinel",
+          "description": "Temel Sentinel ayarlarını yapılandırın. Diğer tüm seçenekler önerilen varsayılanları kullanır.",
+          "data": {
+            "sentinel_enabled": "Anomali uyarılarını etkinleştir",
+            "sentinel_daily_digest_enabled": "Günlük özet bildirimini etkinleştir",
+            "sentinel_daily_digest_time": "Günlük özet saati (SS:DD:SN)",
+            "notify_service": "Bildirim servisi (isteğe bağlı)",
+            "critical_action_pin": "Düzey artırma PIN'i (isteğe bağlı, 4-10 rakam)"
           }
         }
       },
       "error": {
-        "invalid_camera_entry_links": "Kamera varlık kimliklerini giriş varlık kimliklerinin listesiyle eşleştiren bir JSON nesnesi olmalıdır, ör. {{\"camera.driveway\": [\"lock.front_door\"]}}."
+        "invalid_camera_entry_links": "Kamera varlık kimliklerini giriş varlık kimliklerinin listesiyle eşleştiren bir JSON nesnesi olmalıdır, ör. {{\"camera.driveway\": [\"lock.front_door\"]}}.",
+        "invalid_pin": "PIN 4-10 rakam olmalıdır."
       }
     },
     "feature": {
       "entry_type": "service",
       "abort": {
         "reconfigure_successful": "Özellik güncellendi.",
-        "setup_complete": "Kurulum tamamlandı."
+        "setup_complete": "Kurulum tamamlandı.",
+        "no_provider_for_basic_setup": "Model sağlayıcı yapılandırılmamış. Önce bir **Model Sağlayıcı** ekleyin, sonra kurulumu tekrar deneyin."
       },
       "error": {
         "no_providers": "Hiç model sağlayıcı yapılandırılmamış.",
@@ -238,6 +262,17 @@
         "instructions": {
           "title": "Model sağlayıcı ekleyin",
           "description": "Henüz bir model sağlayıcı yok. **Model Sağlayıcı** bölümünden bir tane ekleyin."
+        },
+        "setup_mode": {
+          "title": "Kurulum",
+          "description": "Kurulum türünü seçin. Temel kurulum tüm özellikleri önerilen varsayılanlarla etkinleştirir. Gelişmiş kurulum her özellik üzerinde tam kontrol sağlar.{overwrite_warning}",
+          "data": {
+            "setup_mode": "Kurulum türü"
+          }
+        },
+        "setup_status": {
+          "title": "Kurulum tamamlandı",
+          "description": "Kurulum tamamlandı.\n\n**Etkinleştirilen özellikler:** {features_enabled}{skipped_section}\n\n**Veritabanı:** {database_status}\n\n**Sonraki adımlar:**\n- Anomali izlemeyi etkinleştirmek için **Sentinel Yapılandır**'ı çalıştırın.\n- Sesli giriş için bir **STT Sağlayıcı** ekleyin.\n- Home Generative Agent'ı sesli asistanınız olarak eklemek için **Ayarlar → Sesli Asistanlar**'a gidin."
         }
       }
     }
@@ -281,13 +316,17 @@
           "schema_first_yaml": "YAML istekleri için şema-öncelikli JSON",
           "stt_filters_section": "Konuşma girişi filtreleri",
           "stt_hallucination_patterns": "Yok sayılan STT alt dizeleri",
-          "stt_hallucination_exact_patterns": "Yok sayılan tam STT ifadeleri"
+          "stt_hallucination_exact_patterns": "Yok sayılan tam STT ifadeleri",
+          "tool_relevance_threshold": "Araç ilgi eşiği",
+          "tool_retrieval_limit": "Araç getirme limiti"
         },
         "data_description": {
           "prompt": "LLM'in nasıl yanıt vermesi gerektiğini belirtin. Bu bir şablon olabilir.",
           "schema_first_yaml": "Etkinleştirildiğinde, YAML istekleri YAML'ye çevrilecek sıkı JSON ile yanıtlanır.",
           "stt_hallucination_patterns": "Her satıra bir alt dize yazın. STT metni herhangi bir girdiyi içerirse LLM çalışmadan önce yok sayılır. Eşleşme büyük/küçük harfe duyarsızdır.",
-          "stt_hallucination_exact_patterns": "Her satıra bir ifade yazın. STT metninin tamamı herhangi bir girdiye eşitse LLM çalışmadan önce yok sayılır. Eşleşme büyük/küçük harfe duyarsızdır."
+          "stt_hallucination_exact_patterns": "Her satıra bir ifade yazın. STT metninin tamamı herhangi bir girdiye eşitse LLM çalışmadan önce yok sayılır. Eşleşme büyük/küçük harfe duyarsızdır.",
+          "tool_relevance_threshold": "Bir aracın getirilmesi için gereken minimum anlamsal benzerlik puanı (0,0 ile 1,0 arasında).",
+          "tool_retrieval_limit": "Kullanıcının sorgusuna anlamsal benzerliğe göre getirilecek maksimum araç sayısı."
         }
       }
     }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,11 +17,12 @@ Configuration is done entirely in the Home Assistant UI using subentry flows. A 
 ## Basic Setup
 
 1. Open **Settings → Devices & Services → Home Generative Agent**.
-2. Click **+ Setup** to enable features and configure the database. Choose a setup mode:
-   - **Basic** — enables all features (Conversation, Camera Image Analysis, Conversation Summary) with recommended defaults. Completes in one screen plus a database step.
-   - **Advanced** — step through each feature individually to assign providers, models, and fallback chains.
-3. Click **+ Model Provider** to add a provider (Cloud or Edge → provider type → credentials → model defaults).
+2. Click **+ Model Provider** to add a provider (Cloud or Edge → provider type → credentials → model defaults).
    - The first provider added is automatically assigned to all features.
+   - A provider must exist before you can run **+ Setup**.
+3. Click **+ Setup** to enable features. Choose a setup mode:
+   - **Basic** — enables all features (Conversation, Camera Image Analysis, Conversation Summary) with recommended defaults and creates the database subentry automatically. No database prompt appears.
+   - **Advanced** — step through each feature individually to assign providers, models, and fallback chains; includes a database configuration step.
 4. Use the **gear icon** on any feature to adjust its model settings later.
 5. Click **+ Sentinel** to configure proactive anomaly detection (see [Sentinel guide](sentinel.md)). Choose a setup mode:
    - **Basic** — enables anomaly alerting with recommended defaults. Prompts for notify service, daily digest, and an optional level-increase PIN.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,13 +17,19 @@ Configuration is done entirely in the Home Assistant UI using subentry flows. A 
 ## Basic Setup
 
 1. Open **Settings → Devices & Services → Home Generative Agent**.
-2. Click **+ Setup** to enable features and configure the database.
-   - Default features: Conversation, Camera Image Analysis, Conversation Summary.
-   - Each feature can be individually enabled and assigned its own model.
+2. Click **+ Setup** to enable features and configure the database. Choose a setup mode:
+   - **Basic** — enables all features (Conversation, Camera Image Analysis, Conversation Summary) with recommended defaults. Completes in one screen plus a database step.
+   - **Advanced** — step through each feature individually to assign providers, models, and fallback chains.
 3. Click **+ Model Provider** to add a provider (Cloud or Edge → provider type → credentials → model defaults).
    - The first provider added is automatically assigned to all features.
 4. Use the **gear icon** on any feature to adjust its model settings later.
-5. Click **+ Sentinel** to configure proactive anomaly detection (see [Sentinel guide](sentinel.md)).
+5. Click **+ Sentinel** to configure proactive anomaly detection (see [Sentinel guide](sentinel.md)). Choose a setup mode:
+   - **Basic** — enables anomaly alerting with recommended defaults. Prompts for notify service, daily digest, and an optional level-increase PIN.
+   - **Advanced** — exposes all Sentinel options: intervals, cooldowns, triage, baseline, discovery, and camera entry links.
+
+> **Reconfiguring:** Running **+ Setup** or **+ Sentinel** again when a subentry already exists opens the same mode selector. Advanced mode pre-populates every field with the current saved values. Basic mode always starts from recommended defaults and warns before overwriting.
+
+> **Removing Sentinel:** Delete the Sentinel subentry from the integration page to stop all monitoring immediately. Sentinel background tasks stop and the health sensor transitions to `disabled`.
 
 ---
 

--- a/docs/issue-433-basic-advanced-setup-plan.md
+++ b/docs/issue-433-basic-advanced-setup-plan.md
@@ -1,0 +1,262 @@
+# Issue 433: Basic and Advanced Setup Plan
+
+Issue #433 asks for setup to be easier for basic users while still allowing
+advanced users to adjust specific configuration. The current integration already
+has separate subentry flows for model providers, features, database, STT, and
+Sentinel, but the setup path exposes too many tuning controls before a new user
+has a working configuration.
+
+## Goal
+
+Provide two clear setup paths:
+
+- **Basic setup** creates a complete recommended configuration with minimal
+  required input.
+- **Advanced setup** preserves the current detailed controls for users who want
+  per-feature models, fallbacks, tuning, and Sentinel internals.
+
+This should be a config-flow improvement first, with documentation updated after
+the behavior is settled.
+
+## Design decisions to resolve before writing code
+
+The following questions gate the implementation. Answers should be agreed upon
+before any code is written, ideally confirmed with a prototype or mockup.
+
+### A. How does Basic setup create all three feature subentries in one flow?
+
+HA's subentry model normally requires a separate user action per subentry. Two
+viable options:
+
+- **Option A — compound flow:** Basic setup programmatically calls
+  `async_create_subentry` for all three feature subentries before returning.
+  Requires verifying that `SubentryFlowManager` supports programmatic subentry
+  creation from within a running flow.
+- **Option B — collapsed iteration (recommended):** Basic setup remains a single
+  feature subentry flow execution. `FeatureSubentryFlow` already iterates all
+  three features sequentially; Basic mode auto-enables all three and skips the
+  per-feature tuning screens. No new HA internals required.
+
+Option B is preferred. The plan below assumes Option B.
+
+Sentinel creation is explicitly out of scope for the feature flow. Sentinel
+remains under its own `+ Sentinel` subentry entry point with its own Basic /
+Advanced split (Step 6). Mixing subentry ownership by having the feature flow
+trigger Sentinel creation would couple unrelated flows and make reconfiguration
+harder.
+
+### B. Original issue scope
+
+The upstream issue is a single sentence with no detailed requirements. All
+product decisions in this plan (which features are default-on, what Sentinel
+Basic exposes, the summary screen contents) are design choices made to fill that
+gap. A prototype or screenshot mockup should be reviewed before Step 1 is
+implemented.
+
+## Plan
+
+### 1. Resolve the compound-subentry mechanism
+
+Confirm Option B (collapsed iteration) works for the feature flow. Sentinel
+creation is out of scope here; it has its own entry point and flow (see Step 6).
+
+### 2. Add a setup mode choice
+
+Add a first step to the `+ Setup` flow in
+`custom_components/home_generative_agent/flows/feature_subentry_flow.py`.
+
+The first screen should offer:
+
+- **Basic setup**
+- **Advanced setup**
+
+Basic setup should create the standard full setup with recommended defaults.
+Advanced setup should preserve the existing detailed per-feature flow.
+
+`async_step_reconfigure` must bypass this screen entirely and go directly to the
+Advanced flow, since users reconfiguring an existing subentry already have a
+configuration.
+
+### 3. Handle a missing provider with an abort
+
+The feature setup path works best when at least one model provider already
+exists. If Basic setup starts and no provider exists, abort with
+`FlowResultType.ABORT` and a clear reason string directing the user to add a
+provider subentry first, then retry.
+
+Do not attempt to redirect to another running flow or inline provider creation;
+HA config flows have no redirect-and-resume mechanism.
+
+Provider-specific validation should remain in
+`custom_components/home_generative_agent/flows/model_provider_subentry_flow.py`.
+
+### 4. Define Basic setup as guided full setup
+
+Basic setup should:
+
+- Enable the default features with the following capability requirements:
+  - Conversation (requires a chat-capable provider)
+  - Camera Image Analysis (requires a VLM-capable provider; skip and note in
+    summary if none exists)
+  - Conversation Summary (requires a summarization-capable provider)
+- Assign the first compatible provider to each feature, where "first" means the
+  first entry in `entry.subentries.values()` iteration order that advertises the
+  required capability. This matches how the existing provider option helper
+  iterates subentries, so the behavior is consistent and testable. If no
+  compatible provider exists for a feature, disable that feature and surface it
+  in the summary screen.
+- Use existing recommended model defaults from
+  `custom_components/home_generative_agent/const.py`.
+- Ask only for required external resources:
+  - database connection
+  - notify service, if available and useful
+
+Basic setup should not expose model temperature, keepalive, context size,
+reasoning, fallback providers, or Sentinel tuning.
+
+### 5. Add a final status screen after validated writes
+
+`FeatureSubentryFlow` does not end with `async_create_entry`. It writes subentry
+data incrementally during the flow via `async_add_subentry` /
+`async_update_subentry`, then finishes by aborting with reason `setup_complete`.
+A "pre-write summary" is therefore not practical without restructuring when
+writes occur.
+
+Instead, add a final read-only status step immediately before the
+`setup_complete` abort. All feature and database writes have already been
+committed at that point. The screen confirms what was written and surfaces any
+items that still need attention.
+
+The screen should display:
+
+- provider assigned per feature (or a warning if a feature was skipped due to
+  missing provider capability)
+- database configured
+- enabled features
+- Sentinel not yet configured (reminder to run `+ Sentinel` if desired)
+- reminder to set Home Generative Agent as the voice assistant
+
+The step reads its display values from the flow's accumulated state, not from
+re-querying the config entry.
+
+### 6. Split Sentinel into Basic and Advanced setup
+
+Update `custom_components/home_generative_agent/flows/sentinel_subentry_flow.py`
+so Sentinel also has Basic and Advanced paths. Apply the same mode selector as
+the feature flow, and skip the selector on `async_step_reconfigure`.
+
+Basic Sentinel setup should expose only:
+
+- enable or disable anomaly alerting
+- notify service
+- daily digest
+- optional PIN
+
+Advanced Sentinel setup should keep the current full schema:
+
+- intervals
+- cooldowns
+- discovery
+- baseline configuration
+- day-of-week patterns
+- camera-entry JSON links
+- all other current Sentinel tuning fields
+
+Use `_default_payload()` for Basic defaults so the path stays aligned with
+current recommended constants.
+
+Note: the database step lives inside `feature_subentry_flow.py` and is shared by
+all features. Sentinel Basic setup assumes the database is already configured via
+the feature flow. Do not duplicate the database step inside the Sentinel flow.
+
+### 7. Preserve the existing Advanced path
+
+Advanced setup should keep the current power-user behavior:
+
+- per-feature provider selection
+- per-feature model settings
+- fallback providers
+- Ollama-specific tuning
+- database fields
+- full Sentinel settings
+
+### 8. Update strings end-to-end
+
+Add and update strings in `custom_components/home_generative_agent/strings.json`
+and mirror them in
+`custom_components/home_generative_agent/translations/en.json`.
+
+Required additions:
+
+- Mode-selection step: title, description, Basic label, Advanced label.
+- Abort reason when no provider exists.
+- Final status screen: all status labels and the voice assistant reminder.
+
+Required reviews:
+
+- "Model & advanced options" and similar labels: update wording to make clear
+  these are optional tuning controls, not required setup steps.
+
+### 9. Add focused tests
+
+Add flow coverage in
+`tests/custom_components/home_generative_agent/test_subentries.py`.
+
+Cover:
+
+- Basic setup creates default feature subentries with all three features when a
+  compatible provider exists.
+- Basic setup skips Camera Image Analysis and notes it in the summary when no
+  VLM-capable provider exists.
+- Basic setup aborts with the expected reason string when no provider exists at
+  all.
+- Basic setup assigns the first compatible provider in `entry.subentries.values()`
+  iteration order.
+- Basic setup status screen shows correct status after writes and before the
+  `setup_complete` abort.
+- `async_step_reconfigure` bypasses the mode selector and goes to the Advanced
+  flow.
+- Advanced setup still reaches the current feature provider, model, and database
+  steps.
+- Sentinel Basic setup stores `_default_payload()` values plus selected user
+  fields.
+- Sentinel Advanced setup still accepts the current full payload.
+- Sentinel `async_step_reconfigure` bypasses the mode selector.
+
+### 10. Update documentation after behavior is implemented
+
+After the config-flow changes are in place, update:
+
+- `docs/installation.md`: make the first-run path "Add provider -> Basic setup
+  -> Voice Assistant".
+- `docs/configuration.md`: explain Basic vs Advanced setup.
+- `docs/sentinel.md`: explain Basic Sentinel vs advanced tuning.
+- `README.md`: keep it short and point to the canonical docs.
+
+### 11. Verify the change
+
+Run focused flow tests first:
+
+```bash
+./hga/bin/pytest tests/custom_components/home_generative_agent/test_subentries.py
+./hga/bin/pytest tests/custom_components/home_generative_agent/test_options_schema.py
+```
+
+Then run:
+
+```bash
+hga/bin/ruff check custom_components/home_generative_agent tests/custom_components/home_generative_agent/test_subentries.py
+hga/bin/pyright
+git diff --check
+```
+
+For documentation-only follow-up edits, `git diff --check` is the high-value
+minimum.
+
+## Recommendation
+
+Implement this as one focused PR for the flow behavior and matching docs. A
+docs-only fix would not fully address the issue because the current product
+surface still exposes advanced configuration too early.
+
+Confirm the Option B mechanism and review a prototype before writing flow code.

--- a/docs/sentinel.md
+++ b/docs/sentinel.md
@@ -27,9 +27,13 @@ Sentinel is a singleton service per Home Generative Agent config entry. Configur
 
 1. Open **Settings → Devices & Services → Home Generative Agent**.
 2. Click **+ Sentinel**.
-3. Configure runtime options (detection interval, cooldowns, notify service, autonomy level).
-4. Optionally enable Discovery, Triage, and Baseline (see sections below).
-5. Save. Sentinel starts on the next HA restart or integration reload.
+3. Choose a setup mode:
+   - **Basic** — enables anomaly alerting with recommended defaults. Configure only the essentials: notify service, daily digest toggle and time, and an optional level-increase PIN.
+   - **Advanced** — exposes all options: detection interval, cooldowns, triage, baseline, discovery, and camera entry links. All fields pre-populate with current values when reconfiguring.
+4. Optionally enable Discovery, Triage, and Baseline via **Advanced** setup or by reconfiguring later (see sections below).
+5. Save. Sentinel starts automatically — no HA restart required.
+
+> **Removing Sentinel:** Delete the Sentinel subentry from the integration page. Background tasks stop immediately and monitoring is disabled. The `sentinel_health` sensor transitions to `disabled`.
 
 ### Autonomy Levels
 

--- a/tests/custom_components/home_generative_agent/test_fallback_setup.py
+++ b/tests/custom_components/home_generative_agent/test_fallback_setup.py
@@ -278,9 +278,6 @@ def _patch_setup_dependencies(
         hga_component, "_ensure_default_feature_subentries", lambda *_args: None
     )
     monkeypatch.setattr(
-        hga_component, "_ensure_default_sentinel_subentry", lambda *_args: None
-    )
-    monkeypatch.setattr(
         hga_component, "_assign_first_provider_if_needed", lambda *_args: None
     )
     monkeypatch.setattr(

--- a/tests/custom_components/home_generative_agent/test_subentries.py
+++ b/tests/custom_components/home_generative_agent/test_subentries.py
@@ -1372,9 +1372,9 @@ async def test_feature_basic_setup_creates_all_features(hass: HomeAssistant) -> 
     await flow.async_step_user()
     result = await flow.async_step_setup_mode({"setup_mode": "basic"})
 
-    # Feature subentries are written before the database form is shown.
+    # Basic setup skips the database form and shows the status screen directly.
     assert result.get("type") == "form"
-    assert result.get("step_id") == "database"
+    assert result.get("step_id") == "setup_status"
 
     feature_types = {
         s.data.get("feature_type")
@@ -1386,6 +1386,17 @@ async def test_feature_basic_setup_creates_all_features(hass: HomeAssistant) -> 
         "camera_image_analysis",
         "conversation_summary",
     }
+
+    # A database subentry with default credentials was created.
+    db_subentry = next(
+        (
+            s
+            for s in entry.subentries.values()
+            if s.subentry_type == SUBENTRY_TYPE_DATABASE
+        ),
+        None,
+    )
+    assert db_subentry is not None
 
 
 @pytest.mark.asyncio

--- a/tests/custom_components/home_generative_agent/test_subentries.py
+++ b/tests/custom_components/home_generative_agent/test_subentries.py
@@ -1604,6 +1604,7 @@ def _make_sentinel_flow_for_mode(hass: Any, entry: DummyEntry) -> SentinelSubent
         "step_id": kwargs.get("step_id"),
         "data_schema": kwargs["data_schema"],
         "errors": kwargs.get("errors"),
+        "description_placeholders": kwargs.get("description_placeholders"),
     }
     flow.async_create_entry = lambda **kwargs: {  # type: ignore[assignment]
         "type": "create_entry",
@@ -1628,6 +1629,39 @@ async def test_sentinel_new_setup_shows_mode_selector(hass: HomeAssistant) -> No
     result = await flow.async_step_user()
     assert result.get("type") == "form"
     assert result.get("step_id") == "setup_mode"
+
+
+@pytest.mark.asyncio
+async def test_sentinel_mode_selector_shows_overwrite_warning_when_configured(
+    hass: HomeAssistant,
+) -> None:
+    """Mode selector includes overwrite warning when a Sentinel subentry already exists."""
+    existing = DummySubentry(
+        "sent1",
+        SUBENTRY_TYPE_SENTINEL,
+        "Sentinel",
+        {CONF_SENTINEL_ENABLED: True},
+    )
+    entry = DummyEntry()
+    entry.subentries[existing.subentry_id] = existing
+    flow = _make_sentinel_flow_for_mode(hass, entry)
+
+    result = await flow.async_step_user()
+    placeholders = result.get("description_placeholders") or {}
+    assert placeholders.get("overwrite_warning") != ""
+
+
+@pytest.mark.asyncio
+async def test_sentinel_mode_selector_no_warning_when_not_configured(
+    hass: HomeAssistant,
+) -> None:
+    """Mode selector has an empty overwrite_warning when no Sentinel subentry exists."""
+    entry = DummyEntry()
+    flow = _make_sentinel_flow_for_mode(hass, entry)
+
+    result = await flow.async_step_user()
+    placeholders = result.get("description_placeholders") or {}
+    assert placeholders.get("overwrite_warning") == ""
 
 
 @pytest.mark.asyncio

--- a/tests/custom_components/home_generative_agent/test_subentries.py
+++ b/tests/custom_components/home_generative_agent/test_subentries.py
@@ -52,6 +52,7 @@ from custom_components.home_generative_agent.const import (
     DOMAIN,
     MODEL_CATEGORY_SPECS,
     RECOMMENDED_OPENAI_COMPATIBLE_EMBEDDING_DIMS,
+    SUBENTRY_TYPE_DATABASE,
     SUBENTRY_TYPE_FEATURE,
     SUBENTRY_TYPE_MODEL_PROVIDER,
     SUBENTRY_TYPE_SENTINEL,
@@ -1257,3 +1258,403 @@ def test_build_model_deployments_anthropic_returns_cloud() -> None:
     assert result.get("chat") == "cloud"
     assert result.get("vlm") == "cloud"
     assert result.get("summarization") == "cloud"
+
+
+# ---------------------------------------------------------------------------
+# Basic and Advanced setup mode — feature flow (Issue #433)
+# ---------------------------------------------------------------------------
+
+
+def _make_feature_flow_for_basic(hass: Any, entry: DummyEntry) -> FeatureSubentryFlow:
+    """Return a FeatureSubentryFlow patched for basic-setup tests."""
+    flow = FeatureSubentryFlow()
+    flow.hass = hass
+    flow.async_show_form = lambda **kwargs: {  # type: ignore[assignment]
+        "type": "form",
+        "step_id": kwargs.get("step_id"),
+        "data_schema": kwargs["data_schema"],
+        "errors": kwargs.get("errors"),
+        "description_placeholders": kwargs.get("description_placeholders"),
+    }
+    flow.async_abort = lambda **kwargs: {  # type: ignore[assignment]
+        "type": "abort",
+        "reason": kwargs.get("reason"),
+    }
+    flow._schedule_reload = lambda: None  # type: ignore[assignment]
+    _patch_entry(flow, entry)
+
+    def _add_subentry(_entry: Any, subentry: Any) -> None:
+        entry.subentries[subentry.subentry_id] = subentry
+
+    def _update_subentry(
+        _entry: Any, subentry: Any, data: Any = None, **_kw: Any
+    ) -> None:
+        if data is not None:
+            subentry.data = dict(data)
+
+    def _update_entry(_entry: Any, **kwargs: Any) -> None:
+        if "options" in kwargs:
+            _entry.options = kwargs["options"]
+
+    flow.hass.config_entries.async_add_subentry = _add_subentry  # type: ignore[assignment]
+    flow.hass.config_entries.async_update_subentry = _update_subentry  # type: ignore[assignment]
+    flow.hass.config_entries.async_update_entry = _update_entry  # type: ignore[assignment]
+    return flow
+
+
+@pytest.mark.asyncio
+async def test_feature_new_setup_shows_mode_selector(hass: HomeAssistant) -> None:
+    """New setup shows the Basic/Advanced mode selector."""
+    entry = DummyEntry()
+    flow = _make_feature_flow_for_basic(hass, entry)
+
+    result = await flow.async_step_user()
+    assert result.get("type") == "form"
+    assert result.get("step_id") == "setup_mode"
+
+
+@pytest.mark.asyncio
+async def test_feature_basic_setup_creates_all_features(hass: HomeAssistant) -> None:
+    """Basic setup creates feature subentries for all three features when a compatible provider exists."""
+    provider = DummySubentry(
+        "prov1",
+        SUBENTRY_TYPE_MODEL_PROVIDER,
+        "All-in-one Provider",
+        {"provider_type": "openai", "capabilities": ["chat", "vlm", "summarization"]},
+    )
+    entry = DummyEntry()
+    entry.subentries[provider.subentry_id] = provider
+
+    flow = _make_feature_flow_for_basic(hass, entry)
+
+    await flow.async_step_user()
+    result = await flow.async_step_setup_mode({"setup_mode": "basic"})
+
+    # Feature subentries are written before the database form is shown.
+    assert result.get("type") == "form"
+    assert result.get("step_id") == "database"
+
+    feature_types = {
+        s.data.get("feature_type")
+        for s in entry.subentries.values()
+        if s.subentry_type == SUBENTRY_TYPE_FEATURE
+    }
+    assert feature_types == {
+        "conversation",
+        "camera_image_analysis",
+        "conversation_summary",
+    }
+
+
+@pytest.mark.asyncio
+async def test_feature_basic_setup_assigns_first_compatible_provider(
+    hass: HomeAssistant,
+) -> None:
+    """Basic setup assigns the first provider in entry.subentries.values() order."""
+    prov_a = DummySubentry(
+        "prov_a",
+        SUBENTRY_TYPE_MODEL_PROVIDER,
+        "Provider A",
+        {"provider_type": "openai", "capabilities": ["chat", "vlm", "summarization"]},
+    )
+    prov_b = DummySubentry(
+        "prov_b",
+        SUBENTRY_TYPE_MODEL_PROVIDER,
+        "Provider B",
+        {"provider_type": "openai", "capabilities": ["chat", "vlm", "summarization"]},
+    )
+    entry = DummyEntry()
+    entry.subentries["prov_a"] = prov_a
+    entry.subentries["prov_b"] = prov_b
+
+    flow = _make_feature_flow_for_basic(hass, entry)
+
+    await flow.async_step_setup_mode({"setup_mode": "basic"})
+
+    conversation_subentry = next(
+        (
+            s
+            for s in entry.subentries.values()
+            if s.subentry_type == SUBENTRY_TYPE_FEATURE
+            and s.data.get("feature_type") == "conversation"
+        ),
+        None,
+    )
+    assert conversation_subentry is not None
+    assert conversation_subentry.data.get("model_provider_id") == "prov_a"
+
+
+@pytest.mark.asyncio
+async def test_feature_basic_setup_skips_camera_without_vlm_provider(
+    hass: HomeAssistant,
+) -> None:
+    """Basic setup skips Camera Image Analysis when no VLM-capable provider exists."""
+    chat_only = DummySubentry(
+        "chat1",
+        SUBENTRY_TYPE_MODEL_PROVIDER,
+        "Chat Only",
+        {"provider_type": "openai", "capabilities": ["chat", "summarization"]},
+    )
+    entry = DummyEntry()
+    entry.subentries[chat_only.subentry_id] = chat_only
+
+    flow = _make_feature_flow_for_basic(hass, entry)
+
+    await flow.async_step_setup_mode({"setup_mode": "basic"})
+
+    feature_types = {
+        s.data.get("feature_type")
+        for s in entry.subentries.values()
+        if s.subentry_type == SUBENTRY_TYPE_FEATURE
+    }
+    assert "camera_image_analysis" not in feature_types
+    assert "conversation" in feature_types
+    assert "camera_image_analysis" in flow._basic_skipped_features
+
+
+@pytest.mark.asyncio
+async def test_feature_basic_setup_aborts_when_no_providers(
+    hass: HomeAssistant,
+) -> None:
+    """Basic setup aborts with no_provider_for_basic_setup when no providers exist."""
+    entry = DummyEntry()
+    flow = _make_feature_flow_for_basic(hass, entry)
+
+    result = await flow.async_step_setup_mode({"setup_mode": "basic"})
+
+    assert result.get("type") == "abort"
+    assert result.get("reason") == "no_provider_for_basic_setup"
+
+
+@pytest.mark.asyncio
+async def test_feature_basic_setup_status_screen(hass: HomeAssistant) -> None:
+    """Basic setup status screen shows feature and database status after writes."""
+    provider = DummySubentry(
+        "prov1",
+        SUBENTRY_TYPE_MODEL_PROVIDER,
+        "Provider",
+        {"provider_type": "openai", "capabilities": ["chat", "vlm", "summarization"]},
+    )
+    db_subentry = DummySubentry(
+        "db1",
+        SUBENTRY_TYPE_DATABASE,
+        "Database",
+        {"username": "user"},
+    )
+    feature_subentry = DummySubentry(
+        "feat1",
+        SUBENTRY_TYPE_FEATURE,
+        "Conversation",
+        {"feature_type": "conversation"},
+    )
+    entry = DummyEntry()
+    entry.subentries = {
+        provider.subentry_id: provider,
+        db_subentry.subentry_id: db_subentry,
+        feature_subentry.subentry_id: feature_subentry,
+    }
+
+    flow = _make_feature_flow_for_basic(hass, entry)
+    flow._basic_mode = True
+    flow._basic_skipped_features = ["camera_image_analysis"]
+
+    result = await flow.async_step_setup_status(None)
+
+    assert result.get("type") == "form"
+    assert result.get("step_id") == "setup_status"
+    placeholders = result.get("description_placeholders") or {}
+    assert "Conversation" in placeholders.get("features_enabled", "")
+    assert "Configured" in placeholders.get("database_status", "")
+    assert "Camera Image Analysis" in placeholders.get("skipped_section", "")
+
+    # Submitting the form aborts with setup_complete.
+    done = await flow.async_step_setup_status({})
+    assert done.get("type") == "abort"
+    assert done.get("reason") == "setup_complete"
+
+
+@pytest.mark.asyncio
+async def test_feature_reconfigure_bypasses_mode_selector(
+    hass: HomeAssistant,
+) -> None:
+    """async_step_reconfigure goes directly to the Advanced path, not the mode selector."""
+    provider = DummySubentry(
+        "prov1",
+        SUBENTRY_TYPE_MODEL_PROVIDER,
+        "Provider",
+        {"provider_type": "openai", "capabilities": ["chat"]},
+    )
+    feature = DummySubentry(
+        "feat1",
+        SUBENTRY_TYPE_FEATURE,
+        "Conversation",
+        {"feature_type": "conversation", "model_provider_id": "prov1"},
+    )
+    entry = DummyEntry()
+    entry.subentries = {
+        provider.subentry_id: provider,
+        feature.subentry_id: feature,
+    }
+
+    flow = _make_feature_flow_for_basic(hass, entry)
+    flow.context["subentry_id"] = feature.subentry_id
+
+    result = await flow.async_step_reconfigure()
+
+    assert result.get("type") == "form"
+    assert result.get("step_id") != "setup_mode"
+
+
+@pytest.mark.asyncio
+async def test_feature_advanced_mode_reaches_feature_enable(
+    hass: HomeAssistant,
+) -> None:
+    """Selecting Advanced setup routes to the feature_enable form."""
+    provider = DummySubentry(
+        "prov1",
+        SUBENTRY_TYPE_MODEL_PROVIDER,
+        "Provider",
+        {"provider_type": "openai", "capabilities": ["chat"]},
+    )
+    feature = DummySubentry(
+        "feat1",
+        SUBENTRY_TYPE_FEATURE,
+        "Conversation",
+        {"feature_type": "conversation", "model_provider_id": "prov1"},
+    )
+    entry = DummyEntry()
+    entry.subentries = {
+        provider.subentry_id: provider,
+        feature.subentry_id: feature,
+    }
+
+    flow = _make_feature_flow_for_basic(hass, entry)
+
+    await flow.async_step_user()
+    result = await flow.async_step_setup_mode({"setup_mode": "advanced"})
+
+    assert result.get("type") == "form"
+    assert result.get("step_id") == "feature_enable"
+
+
+# ---------------------------------------------------------------------------
+# Basic and Advanced setup mode — Sentinel flow (Issue #433)
+# ---------------------------------------------------------------------------
+
+
+def _make_sentinel_flow_for_mode(hass: Any, entry: DummyEntry) -> SentinelSubentryFlow:
+    """Return a SentinelSubentryFlow patched for mode-selector tests."""
+    flow = SentinelSubentryFlow()
+    flow.hass = hass
+    flow.async_show_form = lambda **kwargs: {  # type: ignore[assignment]
+        "type": "form",
+        "step_id": kwargs.get("step_id"),
+        "data_schema": kwargs["data_schema"],
+        "errors": kwargs.get("errors"),
+    }
+    flow.async_create_entry = lambda **kwargs: {  # type: ignore[assignment]
+        "type": "create_entry",
+        "title": kwargs.get("title"),
+        "data": kwargs.get("data"),
+    }
+    flow.async_abort = lambda **kwargs: {  # type: ignore[assignment]
+        "type": "abort",
+        "reason": kwargs.get("reason"),
+    }
+    flow._schedule_reload = lambda: None  # type: ignore[assignment]
+    _patch_entry(flow, entry)
+    return flow
+
+
+@pytest.mark.asyncio
+async def test_sentinel_new_setup_shows_mode_selector(hass: HomeAssistant) -> None:
+    """New Sentinel setup shows the Basic/Advanced mode selector."""
+    entry = DummyEntry()
+    flow = _make_sentinel_flow_for_mode(hass, entry)
+
+    result = await flow.async_step_user()
+    assert result.get("type") == "form"
+    assert result.get("step_id") == "setup_mode"
+
+
+@pytest.mark.asyncio
+async def test_sentinel_basic_setup_stores_defaults_plus_user_fields(
+    hass: HomeAssistant,
+) -> None:
+    """Sentinel Basic setup stores _default_payload() values plus the user-provided fields."""
+    entry = DummyEntry()
+    flow = _make_sentinel_flow_for_mode(hass, entry)
+
+    await flow.async_step_setup_mode({"setup_mode": "basic"})
+    result = await flow.async_step_basic_settings(
+        {
+            CONF_SENTINEL_ENABLED: False,
+            CONF_SENTINEL_DAILY_DIGEST_ENABLED: True,
+            CONF_SENTINEL_DAILY_DIGEST_TIME: "07:00:00",
+        }
+    )
+
+    assert result.get("type") == "create_entry"
+    data = result.get("data")
+    assert data is not None
+    assert data[CONF_SENTINEL_ENABLED] is False
+    assert data[CONF_SENTINEL_DAILY_DIGEST_ENABLED] is True
+    assert data[CONF_SENTINEL_DAILY_DIGEST_TIME] == "07:00:00"
+    # All default-payload keys must also be present.
+    defaults = _default_payload()
+    for key in defaults:
+        assert key in data, f"missing default key in basic settings result: {key}"
+
+
+@pytest.mark.asyncio
+async def test_sentinel_basic_setup_rejects_invalid_pin(hass: HomeAssistant) -> None:
+    """Sentinel Basic setup returns an error for a non-digit PIN."""
+    entry = DummyEntry()
+    flow = _make_sentinel_flow_for_mode(hass, entry)
+
+    await flow.async_step_setup_mode({"setup_mode": "basic"})
+    result = await flow.async_step_basic_settings(
+        {
+            CONF_SENTINEL_ENABLED: True,
+            CONF_SENTINEL_DAILY_DIGEST_ENABLED: False,
+            CONF_SENTINEL_DAILY_DIGEST_TIME: "08:00:00",
+            CONF_CRITICAL_ACTION_PIN: "abc",
+        }
+    )
+    assert result.get("type") == "form"
+    assert (result.get("errors") or {}).get("base") == "invalid_pin"
+
+
+@pytest.mark.asyncio
+async def test_sentinel_advanced_setup_still_works(hass: HomeAssistant) -> None:
+    """Selecting Advanced setup routes to the full settings form."""
+    entry = DummyEntry()
+    flow = _make_sentinel_flow_for_mode(hass, entry)
+
+    await flow.async_step_user()
+    result = await flow.async_step_setup_mode({"setup_mode": "advanced"})
+
+    assert result.get("type") == "form"
+    assert result.get("step_id") == "settings"
+
+
+@pytest.mark.asyncio
+async def test_sentinel_reconfigure_bypasses_mode_selector(
+    hass: HomeAssistant,
+) -> None:
+    """async_step_reconfigure goes directly to the full settings form."""
+    sentinel_sub = DummySubentry(
+        "sentinel1",
+        SUBENTRY_TYPE_SENTINEL,
+        "Sentinel",
+        {CONF_SENTINEL_ENABLED: True},
+    )
+    entry = DummyEntry()
+    entry.subentries[sentinel_sub.subentry_id] = sentinel_sub
+
+    flow = _make_sentinel_flow_for_mode(hass, entry)
+
+    result = await flow.async_step_reconfigure()
+
+    assert result.get("type") == "form"
+    assert result.get("step_id") != "setup_mode"

--- a/tests/custom_components/home_generative_agent/test_subentries.py
+++ b/tests/custom_components/home_generative_agent/test_subentries.py
@@ -1314,6 +1314,48 @@ async def test_feature_new_setup_shows_mode_selector(hass: HomeAssistant) -> Non
 
 
 @pytest.mark.asyncio
+async def test_feature_mode_selector_shows_overwrite_warning_when_features_exist(
+    hass: HomeAssistant,
+) -> None:
+    """Mode selector includes overwrite warning when feature subentries already exist."""
+    provider = DummySubentry(
+        "prov1",
+        SUBENTRY_TYPE_MODEL_PROVIDER,
+        "Provider",
+        {"provider_type": "openai", "capabilities": ["chat"]},
+    )
+    existing_feature = DummySubentry(
+        "feat1",
+        SUBENTRY_TYPE_FEATURE,
+        "Conversation",
+        {"feature_type": "conversation", "model_provider_id": "prov1"},
+    )
+    entry = DummyEntry()
+    entry.subentries = {
+        provider.subentry_id: provider,
+        existing_feature.subentry_id: existing_feature,
+    }
+    flow = _make_feature_flow_for_basic(hass, entry)
+
+    result = await flow.async_step_user()
+    placeholders = result.get("description_placeholders") or {}
+    assert placeholders.get("overwrite_warning") != ""
+
+
+@pytest.mark.asyncio
+async def test_feature_mode_selector_no_warning_when_no_features_exist(
+    hass: HomeAssistant,
+) -> None:
+    """Mode selector has an empty overwrite_warning when no feature subentries exist."""
+    entry = DummyEntry()
+    flow = _make_feature_flow_for_basic(hass, entry)
+
+    result = await flow.async_step_user()
+    placeholders = result.get("description_placeholders") or {}
+    assert placeholders.get("overwrite_warning") == ""
+
+
+@pytest.mark.asyncio
 async def test_feature_basic_setup_creates_all_features(hass: HomeAssistant) -> None:
     """Basic setup creates feature subentries for all three features when a compatible provider exists."""
     provider = DummySubentry(

--- a/tests/custom_components/home_generative_agent/test_subentries.py
+++ b/tests/custom_components/home_generative_agent/test_subentries.py
@@ -505,6 +505,13 @@ def test_legacy_ollama_urls_split_providers() -> None:
     assert options[CONF_OLLAMA_SUMMARIZATION_URL] == "http://ollama-sum:11434"
 
 
+def test_resolve_runtime_options_no_sentinel_subentry_disables_sentinel() -> None:
+    """When no Sentinel subentry exists, CONF_SENTINEL_ENABLED must be False."""
+    entry = DummyEntry(options={})
+    options = resolve_runtime_options(entry)  # type: ignore[arg-type]
+    assert options[CONF_SENTINEL_ENABLED] is False
+
+
 def test_resolve_runtime_options_prefers_sentinel_subentry() -> None:
     """Sentinel subentry should override legacy sentinel option keys."""
     sentinel_interval = 120
@@ -1745,3 +1752,73 @@ async def test_sentinel_reconfigure_bypasses_mode_selector(
 
     assert result.get("type") == "form"
     assert result.get("step_id") != "setup_mode"
+
+
+@pytest.mark.asyncio
+async def test_sentinel_user_flow_updates_existing_not_duplicate(
+    hass: HomeAssistant,
+) -> None:
+    """User flow with an existing Sentinel subentry updates it, not create a duplicate."""
+    existing = DummySubentry(
+        "sentinel1",
+        SUBENTRY_TYPE_SENTINEL,
+        "Sentinel",
+        {CONF_SENTINEL_ENABLED: True},
+    )
+    entry = DummyEntry()
+    entry.subentries[existing.subentry_id] = existing
+
+    flow = _make_sentinel_flow_for_mode(hass, entry)
+    update_calls: list[Any] = []
+    flow.async_update_and_abort = lambda *args, **_kwargs: (  # type: ignore[assignment]
+        update_calls.append(args)
+        or {"type": "abort", "reason": "reconfigure_successful"}
+    )
+
+    await flow.async_step_setup_mode({"setup_mode": "advanced"})
+    # Minimal user_input — schema validation is bypassed in unit tests
+    result = await flow.async_step_settings(
+        {
+            CONF_SENTINEL_ENABLED: False,
+            CONF_SENTINEL_REQUIRE_PIN_FOR_LEVEL_INCREASE: False,
+            CONF_SENTINEL_DAILY_DIGEST_ENABLED: False,
+            CONF_SENTINEL_DAILY_DIGEST_TIME: "08:00:00",
+            CONF_SENTINEL_CAMERA_ENTRY_LINKS: "{}",
+        }
+    )
+
+    assert result.get("type") == "abort", "expected update-and-abort, not create_entry"
+    assert len(update_calls) == 1, "async_update_and_abort should be called once"
+
+
+@pytest.mark.asyncio
+async def test_sentinel_user_flow_with_duplicate_sentinels_updates_first(
+    hass: HomeAssistant,
+) -> None:
+    """User flow with multiple Sentinel subentries updates the first, adds no more."""
+    sub1 = DummySubentry("sent1", SUBENTRY_TYPE_SENTINEL, "Sentinel", {})
+    sub2 = DummySubentry("sent2", SUBENTRY_TYPE_SENTINEL, "Sentinel", {})
+    entry = DummyEntry()
+    entry.subentries[sub1.subentry_id] = sub1
+    entry.subentries[sub2.subentry_id] = sub2
+
+    flow = _make_sentinel_flow_for_mode(hass, entry)
+    update_calls: list[Any] = []
+    flow.async_update_and_abort = lambda *args, **_kwargs: (  # type: ignore[assignment]
+        update_calls.append(args)
+        or {"type": "abort", "reason": "reconfigure_successful"}
+    )
+
+    await flow.async_step_setup_mode({"setup_mode": "basic"})
+    result = await flow.async_step_basic_settings(
+        {
+            CONF_SENTINEL_ENABLED: True,
+            CONF_SENTINEL_DAILY_DIGEST_ENABLED: False,
+            CONF_SENTINEL_DAILY_DIGEST_TIME: "08:00:00",
+        }
+    )
+
+    assert result.get("type") == "abort", (
+        "must update, not create, when duplicates exist"
+    )
+    assert len(update_calls) == 1


### PR DESCRIPTION
Closes #433.

## Summary

- New `+ Setup` flow shows a **Basic / Advanced** mode selector before entering any configuration screens.
- **Basic setup** auto-assigns the first compatible provider (in `entry.subentries.values()` order) to each feature, skips optional features with no compatible provider (Camera Image Analysis requires a VLM-capable provider), aborts with a clear message if no providers exist at all, and ends with a read-only status screen summarising what was written.
- **`async_step_reconfigure`** is now a standalone method on both flows and bypasses the mode selector, going directly to the Advanced path.
- **Basic Sentinel setup** exposes only four fields (enabled, daily digest, notify service, PIN) and fills all other settings from `_default_payload()`.
- **Advanced setup** is unchanged — all existing per-feature and Sentinel controls remain as-is.
- Strings and translations updated end-to-end: mode selector step, status screen, abort reason, Sentinel basic settings, `invalid_pin` added to Sentinel error section.
- 14 new focused flow tests covering: mode selector display, all-feature creation, provider iteration order, VLM-skip, no-provider abort, status screen placeholders and submit, reconfigure bypass, advanced routing, Sentinel basic/advanced/reconfigure paths.

## Test plan

- [ ] `./hga/bin/pytest tests/custom_components/home_generative_agent/test_subentries.py` — 53 pass
- [ ] `hga/bin/ruff check` — clean
- [ ] `hga/bin/pyright` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)