### PR TITLE
fix: correct entity_staleness false resolution and missing person name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.14.21] - 2026-06-15
+
+### Fixed
+
+- **Entity staleness alert falsely reported as resolved after Execute** — after tapping Execute on a person tracking staleness alert, the agent incorrectly replied that the alert had resolved ("the person is no longer in a stale state") even though the person never came home. The generic execute prompt did not define what "resolved" means for staleness findings, so the agent treated `state = not_home` from `GetLiveContext` as a definitive non-stale state. A specialized execute prompt for `entity_staleness` findings now tells the agent the alert resolves only if the person is home (`state = 'home'`); if still away, it must acknowledge the staleness and advise the user to check whether the person's phone is on and reachable. Follows up on the incomplete fix in [#417](https://github.com/goruck/home-generative-agent/pull/417).
+
+- **Person name missing from entity staleness initial notification** — the initial notification body for person tracking staleness was generic ("The person tracking data has been outdated...") with no person name, while the Execute follow-up named the person. `_eval_entity_staleness` now includes `friendly_name` in the evidence dict, and a deterministic `_entity_staleness_mobile_message` generates a named, consistent body: e.g. "Lindo St Angel's location tracking has been outdated for about 1 day. Check if their phone is on and reachable."
+
+- **`friendly_name` in entity_staleness evidence caused unstable anomaly_id** — adding `friendly_name` to the evidence hash would make the anomaly_id change if the display name is renamed or temporarily unavailable, breaking cooldown/suppression/audit continuity for long-running alerts. `_build_finding` now strips `friendly_name` before hashing, matching the existing pattern in `baseline.py` and `appliance_power_duration.py`.
+
 ## [3.14.20] - 2026-06-11
 
 ### Added

--- a/custom_components/home_generative_agent/manifest.json
+++ b/custom_components/home_generative_agent/manifest.json
@@ -34,5 +34,5 @@
     "langchain-google-genai==3.1.0",
     "langchain-anthropic==1.4.3"
   ],
-  "version": "3.14.20"
+  "version": "3.14.21"
 }

--- a/custom_components/home_generative_agent/notify/actions.py
+++ b/custom_components/home_generative_agent/notify/actions.py
@@ -243,8 +243,54 @@ def _format_evidence_summary(evidence: dict[str, Any]) -> str:
     return ", ".join(parts[:6]) or "see entity"
 
 
+def _build_entity_staleness_execute_prompt(finding: AnomalyFinding) -> str:
+    """Build execute prompt for entity_staleness findings."""
+    entity_id = finding.evidence.get("entity_id") or (
+        finding.triggering_entities[0] if finding.triggering_entities else None
+    )
+    friendly = finding.evidence.get("friendly_name") or (
+        entity_id.split(".")[-1].replace("_", " ").title() if entity_id else "an entity"
+    )
+    detected_at_str = dt_util.as_utc(finding.detected_at).strftime(
+        "%Y-%m-%d %H:%M:%S UTC"
+    )
+    age_hours = finding.evidence.get("age_hours")
+    age_str = (
+        f"{float(age_hours):.0f}h" if age_hours is not None else "an extended period"
+    )
+    max_stale_hours = finding.evidence.get("max_stale_hours", 24)
+    is_person = bool(entity_id and entity_id.startswith("person."))
+
+    if is_person:
+        resolution_clause = (
+            f"Use GetLiveContext to check the current state of {entity_id}. "
+            f"This alert resolves ONLY if {friendly} is now home (state = 'home'). "
+            f"A Home Assistant restart resets last_changed without resuming "
+            f"location tracking — do NOT report resolved if last_changed looks recent. "
+            f"If {friendly} is still not_home, acknowledge the staleness and advise "
+            f"the user to check whether {friendly}'s phone is on and reachable."
+        )
+    else:
+        resolution_clause = (
+            f"Use GetLiveContext to check the current state of {entity_id}. "
+            f"This alert resolves only if the sensor has genuinely updated since "
+            f"{detected_at_str}. A system restart resets timestamps without the sensor "
+            f"actually reporting new data — report what you find honestly."
+        )
+
+    return (
+        f"Sentinel staleness alert detected at {detected_at_str}: "
+        f"{friendly} ({entity_id}) had not updated for {age_str} "
+        f"(threshold: {max_stale_hours}h). "
+        f"{resolution_clause} "
+        f"After assessing, reply in 1-2 plain-text sentences under 220 characters."
+    )
+
+
 def _build_execute_prompt(finding: AnomalyFinding) -> str:
     """Build a natural-language prompt for non-sensitive execute actions."""
+    if finding.evidence.get("template_id") == "entity_staleness":
+        return _build_entity_staleness_execute_prompt(finding)
     entity_id = finding.evidence.get("entity_id") or (
         finding.triggering_entities[0] if finding.triggering_entities else None
     )

--- a/custom_components/home_generative_agent/sentinel/dynamic_rules.py
+++ b/custom_components/home_generative_agent/sentinel/dynamic_rules.py
@@ -864,6 +864,7 @@ def _eval_entity_staleness(
         "rule_id": rule.get("rule_id"),
         "template_id": rule.get("template_id"),
         "entity_id": entity_id,
+        "friendly_name": entity.get("friendly_name") or None,
         "state": entity.get("state"),
         "max_stale_hours": max_stale_hours,
         "age_hours": age_hours,

--- a/custom_components/home_generative_agent/sentinel/dynamic_rules.py
+++ b/custom_components/home_generative_agent/sentinel/dynamic_rules.py
@@ -931,7 +931,8 @@ def _build_finding(
     if not isinstance(suggested_actions, list):
         suggested_actions = []
     is_sensitive = bool(rule.get("is_sensitive", False))
-    anomaly_id = build_anomaly_id(rule_id, triggering_entities, evidence)
+    _hash_evidence = {k: v for k, v in evidence.items() if k != "friendly_name"}
+    anomaly_id = build_anomaly_id(rule_id, triggering_entities, _hash_evidence)
     return AnomalyFinding(
         anomaly_id=anomaly_id,
         type=rule_id,

--- a/custom_components/home_generative_agent/sentinel/notifier.py
+++ b/custom_components/home_generative_agent/sentinel/notifier.py
@@ -875,6 +875,43 @@ def _baseline_deviation_mobile_message(finding: AnomalyFinding) -> str:
     return msg[:MAX_MOBILE_MESSAGE_CHARS].rstrip()
 
 
+def _entity_staleness_mobile_message(finding: AnomalyFinding) -> str:
+    """Deterministic mobile copy for entity_staleness findings."""
+    ev = finding.evidence
+    entity_id = str(ev.get("entity_id") or "").strip()
+    raw_name = str(ev.get("friendly_name") or "").strip()
+    if not raw_name and entity_id:
+        raw_name = _friendly_entity(entity_id)
+
+    age_hours = ev.get("age_hours")
+    age_str = "an extended period"
+    if age_hours is not None:
+        try:
+            age_h = float(age_hours)
+            if age_h >= 48:  # noqa: PLR2004
+                age_str = f"about {int(age_h // 24)} days"
+            elif age_h >= 24:  # noqa: PLR2004
+                age_str = "about 1 day"
+            elif age_h >= 2:  # noqa: PLR2004
+                age_str = f"about {int(age_h)} hours"
+            else:
+                age_str = "about 1 hour"
+        except (TypeError, ValueError):
+            pass
+
+    if entity_id.startswith("person."):
+        msg = (
+            f"{raw_name}'s location tracking has been outdated for {age_str}. "
+            f"Check if their phone is on and reachable."
+        )
+    else:
+        msg = (
+            f"{raw_name or 'Sensor'} data has been outdated for {age_str}. "
+            f"Please check the sensor."
+        )
+    return msg[:MAX_MOBILE_MESSAGE_CHARS].rstrip()
+
+
 def _mobile_message(explanation: str | None, finding: AnomalyFinding) -> str:
     if finding.type == "alarm_disarmed_during_external_threat":
         return _alarm_disarmed_mobile_message(finding)
@@ -885,6 +922,8 @@ def _mobile_message(explanation: str | None, finding: AnomalyFinding) -> str:
         "time_of_day_anomaly",
     }:
         return _baseline_deviation_mobile_message(finding)
+    if finding.evidence.get("template_id") == "entity_staleness":
+        return _entity_staleness_mobile_message(finding)
     if explanation:
         text = _normalize_text(explanation)
         if text and len(text) <= MAX_MOBILE_MESSAGE_CHARS:

--- a/tests/custom_components/home_generative_agent/test_notify_actions.py
+++ b/tests/custom_components/home_generative_agent/test_notify_actions.py
@@ -13,6 +13,7 @@ from custom_components.home_generative_agent.notify.actions import (
     EVENT_SENTINEL_EXECUTE_REQUESTED,
     ActionHandler,
     _build_ask_prompt,
+    _build_entity_staleness_execute_prompt,
     _build_execute_prompt,
     _format_evidence_summary,
 )
@@ -671,3 +672,80 @@ def test_anomaly_finding_as_dict_includes_detected_at() -> None:
         or "Z" in detected_at_str
         or "UTC" not in detected_at_str
     )
+
+
+# ---------------------------------------------------------------------------
+# entity_staleness execute prompt
+# ---------------------------------------------------------------------------
+
+
+def _make_staleness_finding(
+    entity_id: str = "person.lindo_st_angel",
+    friendly_name: str | None = "Lindo St Angel",
+    age_hours: float = 42.0,
+) -> AnomalyFinding:
+    return AnomalyFinding(
+        anomaly_id="stale-1",
+        type="person_tracking_staleness",
+        severity="low",
+        confidence=0.9,
+        triggering_entities=[entity_id],
+        evidence={
+            "template_id": "entity_staleness",
+            "entity_id": entity_id,
+            "friendly_name": friendly_name,
+            "state": "not_home",
+            "max_stale_hours": 24.0,
+            "age_hours": age_hours,
+        },
+        suggested_actions=["check_sensor"],
+        is_sensitive=False,
+    )
+
+
+def test_entity_staleness_execute_prompt_dispatched() -> None:
+    """entity_staleness findings use the specialized prompt, not the generic one."""
+    finding = _make_staleness_finding()
+    prompt = _build_execute_prompt(finding)
+    assert "Alert-time evidence:" not in prompt  # generic prompt marker absent
+
+
+def test_entity_staleness_execute_prompt_person_not_home_guidance() -> None:
+    """Prompt tells agent NOT to report resolved if person is still not_home."""
+    finding = _make_staleness_finding()
+    prompt = _build_entity_staleness_execute_prompt(finding)
+    assert "not_home" in prompt
+    assert "ONLY if" in prompt or "only if" in prompt
+
+
+def test_entity_staleness_execute_prompt_restart_warning() -> None:
+    """Prompt warns that HA restarts can reset last_changed without tracking resuming."""
+    finding = _make_staleness_finding()
+    prompt = _build_entity_staleness_execute_prompt(finding)
+    assert "restart" in prompt.lower()
+    assert "last_changed" in prompt
+
+
+def test_entity_staleness_execute_prompt_includes_person_name() -> None:
+    """Prompt contains the person's friendly name."""
+    finding = _make_staleness_finding()
+    prompt = _build_entity_staleness_execute_prompt(finding)
+    assert "Lindo St Angel" in prompt
+
+
+def test_entity_staleness_execute_prompt_includes_detected_at() -> None:
+    """Prompt includes the detection timestamp."""
+    finding = _make_staleness_finding()
+    prompt = _build_entity_staleness_execute_prompt(finding)
+    assert "UTC" in prompt
+
+
+def test_entity_staleness_execute_prompt_non_person() -> None:
+    """Non-person entity uses sensor-specific resolution guidance (no home check)."""
+    finding = _make_staleness_finding(
+        entity_id="sensor.front_door_battery",
+        friendly_name="Front Door Battery",
+    )
+    prompt = _build_entity_staleness_execute_prompt(finding)
+    assert "Front Door Battery" in prompt
+    assert "home" not in prompt.lower() or "not_home" not in prompt

--- a/tests/custom_components/home_generative_agent/test_sentinel_notifier.py
+++ b/tests/custom_components/home_generative_agent/test_sentinel_notifier.py
@@ -26,6 +26,7 @@ from custom_components.home_generative_agent.sentinel.notifier import (
     _alarm_disarmed_mobile_message,
     _appliance_power_duration_mobile_message,
     _build_actions,
+    _entity_staleness_mobile_message,
     _friendly_type,
     _mobile_message,
     _redact_if_sensitive,
@@ -1221,6 +1222,82 @@ def test_appliance_power_duration_mobile_message_wins_over_llm() -> None:
     msg = _mobile_message(llm_explanation, finding)
     assert msg.startswith("Washer ")
     assert "An appliance" not in msg
+
+
+# ---------------------------------------------------------------------------
+# entity_staleness mobile message
+# ---------------------------------------------------------------------------
+
+
+def _staleness_finding(
+    entity_id: str = "person.lindo_st_angel",
+    friendly_name: str | None = "Lindo St Angel",
+    age_hours: float = 42.0,
+) -> AnomalyFinding:
+    return AnomalyFinding(
+        anomaly_id="stale-1",
+        type="person_tracking_staleness",
+        severity="low",
+        confidence=0.9,
+        triggering_entities=[entity_id],
+        evidence={
+            "template_id": "entity_staleness",
+            "entity_id": entity_id,
+            "friendly_name": friendly_name,
+            "state": "not_home",
+            "max_stale_hours": 24.0,
+            "age_hours": age_hours,
+        },
+        suggested_actions=["check_sensor"],
+        is_sensitive=False,
+    )
+
+
+def test_entity_staleness_mobile_message_person_name() -> None:
+    """Mobile message includes the person's friendly name."""
+    msg = _entity_staleness_mobile_message(_staleness_finding())
+    assert "Lindo St Angel" in msg
+    assert len(msg) <= MAX_MOBILE_MESSAGE_CHARS
+
+
+def test_entity_staleness_mobile_message_age_about_1_day() -> None:
+    """42-hour staleness rounds to 'about 1 day'."""
+    msg = _entity_staleness_mobile_message(_staleness_finding(age_hours=42.0))
+    assert "about 1 day" in msg
+
+
+def test_entity_staleness_mobile_message_age_over_2_days() -> None:
+    """50-hour staleness rounds to 'about 2 days'."""
+    msg = _entity_staleness_mobile_message(_staleness_finding(age_hours=50.0))
+    assert "2 days" in msg
+
+
+def test_entity_staleness_mobile_message_person_fallback_name() -> None:
+    """Falls back to entity_id-derived name when friendly_name is absent."""
+    finding = _staleness_finding(friendly_name=None)
+    msg = _entity_staleness_mobile_message(finding)
+    assert "Lindo St Angel" in msg
+
+
+def test_entity_staleness_mobile_message_non_person() -> None:
+    """Non-person entity uses 'data has been outdated' phrasing."""
+    finding = _staleness_finding(
+        entity_id="sensor.front_door_battery",
+        friendly_name="Front Door Battery",
+        age_hours=30.0,
+    )
+    msg = _entity_staleness_mobile_message(finding)
+    assert "Front Door Battery" in msg
+    assert "data has been outdated" in msg
+
+
+def test_entity_staleness_mobile_message_wins_over_llm() -> None:
+    """Deterministic copy wins even when an LLM explanation is available."""
+    finding = _staleness_finding()
+    llm_msg = "The person tracking data has been outdated for about 42 hours."
+    msg = _mobile_message(llm_msg, finding)
+    assert "Lindo St Angel" in msg
+    assert "person tracking data" not in msg
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two bugs in the `entity_staleness` (person tracking staleness) notification flow, plus a correctness fix for anomaly_id stability.

### Bug 1: Agent falsely reports alert as resolved

After tapping Execute, the agent replied: *"The Sentinel alert for Lindo St Angel's staleness ... has resolved, as the person is no longer in a stale state."* — even though the person never came home.

**Root cause:** The generic `_build_execute_prompt` told the agent to use `GetLiveContext` to check if the alert condition was still active, but gave no definition of what "resolved" means for a staleness finding. The agent saw `state = not_home` from `GetLiveContext` and treated it as a definitive, non-stale tracking state rather than evaluating `last_changed` age.

**Fix:** Added `_build_entity_staleness_execute_prompt` (dispatched from `_build_execute_prompt` when `template_id == "entity_staleness"`). For person entities it tells the agent explicitly: the alert resolves **only** if the person is now home (`state = 'home'`). If still `not_home`, the agent must acknowledge the staleness and advise the user to check whether the person's phone is on and reachable — not claim resolution.

### Bug 2: Missing person name in initial notification body

The initial notification body was generic: *"The person tracking data has been outdated for about 42 hours. Please check the sensor to update the status."* — no person name. The follow-up (after Execute) named the person, making the pairing confusing.

**Root cause:** `_eval_entity_staleness` never populated `friendly_name` in the evidence dict. The LLM explanation received no name context and produced a generic message.

**Fix:** Added `friendly_name` to the entity_staleness evidence dict, and added a deterministic `_entity_staleness_mobile_message` (same pattern as `_appliance_power_duration_mobile_message`) that produces a consistent, named body: *"Lindo St Angel's location tracking has been outdated for about 1 day. Check if their phone is on and reachable."*

### Additional: anomaly_id stability when friendly_name is present

`_build_finding` was passing the full evidence dict (including `friendly_name`) to `build_anomaly_id`, making the hash — and therefore the anomaly_id — unstable if the friendly name is renamed or temporarily unavailable. This breaks cooldown/suppression/audit continuity for long-running staleness alerts.

**Fix:** Strip `friendly_name` before hashing inside `_build_finding`, matching the existing pattern already used in `baseline.py` and `appliance_power_duration.py`.

## Relationship to prior work

PR #417 added the "explicitly acknowledge if condition resolved" language to `_build_execute_prompt` but left the agent free to misinterpret `not_home` as resolved for staleness findings. This PR is the targeted follow-through for that incomplete fix.

## Test plan

- [x] New `test_entity_staleness_execute_prompt_*` tests in `test_notify_actions.py` verify the specialized prompt is dispatched and contains the correct guidance (person-home-only resolution, HA restart caveat, person name, timestamp)
- [x] New `test_entity_staleness_mobile_message_*` tests in `test_sentinel_notifier.py` verify the deterministic body includes the person name, correct age phrasing, and wins over any LLM explanation
- [x] All 1236 existing tests pass, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)