### PR TITLE
fix: improve alarm_disarmed_open_entry notification clarity and agent response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.14.23] - 2026-06-19
+
+### Fixed
+
+- **Sentinel: `alarm_disarmed_open_entry` notifications were confusing and showed the wrong timestamp** — the notification subtitle was derived from the raw rule ID ("Alarm disarmed open entry alarm control panel home alarm") and the message body showed the window sensor's `last_changed` time instead of when the alarm was actually disarmed. Fixes:
+  - Added a dedicated subtitle and mobile message formatter for the `alarm_disarmed_open_entry` template; subtitle now reads e.g. "Family Room Right Window open, alarm disarmed" and the body shows the actual disarm time ("Alarm disarmed since 10:15 PM").
+  - Dynamic rule evaluator now stores `alarm_last_changed` and `entry_last_changed` as separate evidence fields so the correct timestamp is always available.
+  - "Ask Agent" handoff prompt now distinguishes read-only `binary_sensor` entries (cannot be closed programmatically) from actuatable `cover.*` entities. For sensors it explicitly forbids arming the alarm as a substitute and instructs the agent to advise the user to close the entry manually or use "Snooze 24h"/"Snooze Always" if the open window is expected.
+  - Added direct regression tests for the new mobile copy, subtitle, LLM-bypass routing, and the binary_sensor vs cover Ask Agent prompt branches.
+
 ## [3.14.22] - 2026-06-19
 
 ### Fixed

--- a/custom_components/home_generative_agent/manifest.json
+++ b/custom_components/home_generative_agent/manifest.json
@@ -34,5 +34,5 @@
     "langchain-google-genai==3.1.0",
     "langchain-anthropic==1.4.3"
   ],
-  "version": "3.14.22"
+  "version": "3.14.23"
 }

--- a/custom_components/home_generative_agent/notify/actions.py
+++ b/custom_components/home_generative_agent/notify/actions.py
@@ -359,6 +359,30 @@ def _build_ask_prompt(finding: AnomalyFinding) -> str:
         "%Y-%m-%d %H:%M:%S UTC"
     )
     evidence_summary = _format_evidence_summary(finding.evidence)
+
+    template_id = finding.evidence.get("template_id", "")
+    if template_id == "alarm_disarmed_open_entry":
+        entry_id = str(finding.evidence.get("entry_entity_id") or entity_id or "")
+        entry_domain = entry_id.split(".", maxsplit=1)[0] if "." in entry_id else ""
+        if entry_domain == "cover":
+            action_clause = (
+                f"Use your Home Assistant tools to close the cover entity {entry_id}."
+            )
+        else:
+            action_clause = (
+                f"The open entry ({entry_id}) is a read-only sensor — "
+                f"you cannot close it programmatically. "
+                f"Check if someone is home using GetLiveContext. "
+                f"If home, this is likely expected behaviour; tell the user they can "
+                f"close it manually or tap 'Snooze 24h' / 'Snooze Always' on the alert "
+                f"if this is routine. Do NOT attempt to arm the alarm."
+            )
+    else:
+        action_clause = (
+            "If still active, use your Home Assistant tools to perform "
+            "the suggested action now."
+        )
+
     return (
         f"Sentinel security alert — {finding.severity} severity, "
         f"{finding.confidence:.0%} confidence, detected at {detected_at_str}. "
@@ -367,8 +391,7 @@ def _build_ask_prompt(finding: AnomalyFinding) -> str:
         f"Suggested remediation: {suggested}. "
         f"Use GetLiveContext to check whether the alert condition is still active "
         f"(state may have changed since detection).{camera_clause} "
-        f"If still active, use your Home Assistant tools to perform "
-        f"the suggested action now. "
+        f"{action_clause} "
         f"If the condition has since resolved, explicitly acknowledge what Sentinel "
         f"detected at {detected_at_str} and confirm it has resolved. "
         f"Do not ask clarifying questions — proceed autonomously. "

--- a/custom_components/home_generative_agent/sentinel/dynamic_rules.py
+++ b/custom_components/home_generative_agent/sentinel/dynamic_rules.py
@@ -217,7 +217,8 @@ def _eval_alarm_disarmed_open_entry(
             "entry_entity_id": entry_id,
             "entry_state": entry.get("state"),
             "alarm_state": alarm.get("state"),
-            "last_changed": entry.get("last_changed"),
+            "entry_last_changed": entry.get("last_changed"),
+            "alarm_last_changed": alarm.get("last_changed"),
         }
         findings.append(_build_finding(rule, [alarm_id, entry_id], evidence))
     return findings

--- a/custom_components/home_generative_agent/sentinel/notifier.py
+++ b/custom_components/home_generative_agent/sentinel/notifier.py
@@ -782,6 +782,10 @@ def _build_subtitle(finding: AnomalyFinding) -> str:
             raw_name = _friendly_entity(finding.triggering_entities[0])
         appliance = _strip_power_suffix(raw_name).title()
         return f"{appliance} finished" if appliance else "Appliance cycle complete"
+    if finding.evidence.get("template_id") == "alarm_disarmed_open_entry":
+        entry_id = str(finding.evidence.get("entry_entity_id") or "")
+        entry_name = _friendly_entity(entry_id) if entry_id else "Entry"
+        return f"{entry_name} open, alarm disarmed"
     if finding.evidence.get("template_id") in {
         "baseline_deviation",
         "time_of_day_anomaly",
@@ -841,6 +845,27 @@ def _alarm_disarmed_mobile_message(finding: AnomalyFinding) -> str:
 
     cta = " Arm the alarm or view the camera."
     return (activity_phrase + alarm_phrase + cta)[:MAX_MOBILE_MESSAGE_CHARS].rstrip()
+
+
+def _alarm_disarmed_open_entry_mobile_message(finding: AnomalyFinding) -> str:
+    """Deterministic mobile copy for alarm_disarmed_open_entry dynamic rule."""
+    ev = finding.evidence
+    entry_id = str(ev.get("entry_entity_id") or "")
+    entry_name = _friendly_entity(entry_id) if entry_id else "An entry"
+
+    alarm_last_changed = ev.get("alarm_last_changed")
+    if alarm_last_changed:
+        parsed = dt_util.parse_datetime(str(alarm_last_changed))
+        if parsed is not None:
+            time_str = dt_util.as_local(parsed).strftime("%-I:%M %p")
+            alarm_phrase = f"Alarm disarmed since {time_str}."
+        else:
+            alarm_phrase = "Alarm is disarmed."
+    else:
+        alarm_phrase = "Alarm is disarmed."
+
+    msg = f"{entry_name} is open. {alarm_phrase} Close it or snooze if expected."
+    return msg[:MAX_MOBILE_MESSAGE_CHARS].rstrip()
 
 
 def _baseline_deviation_mobile_message(finding: AnomalyFinding) -> str:
@@ -912,18 +937,27 @@ def _entity_staleness_mobile_message(finding: AnomalyFinding) -> str:
     return msg[:MAX_MOBILE_MESSAGE_CHARS].rstrip()
 
 
+_TEMPLATE_MOBILE_FORMATTERS: dict[
+    str,
+    Any,
+] = {
+    "alarm_disarmed_open_entry": _alarm_disarmed_open_entry_mobile_message,
+    "baseline_deviation": _baseline_deviation_mobile_message,
+    "time_of_day_anomaly": _baseline_deviation_mobile_message,
+    "entity_staleness": _entity_staleness_mobile_message,
+}
+
+
 def _mobile_message(explanation: str | None, finding: AnomalyFinding) -> str:
     if finding.type == "alarm_disarmed_during_external_threat":
         return _alarm_disarmed_mobile_message(finding)
     if finding.type == "appliance_power_duration":
         return _appliance_power_duration_mobile_message(finding)
-    if finding.evidence.get("template_id") in {
-        "baseline_deviation",
-        "time_of_day_anomaly",
-    }:
-        return _baseline_deviation_mobile_message(finding)
-    if finding.evidence.get("template_id") == "entity_staleness":
-        return _entity_staleness_mobile_message(finding)
+    formatter = _TEMPLATE_MOBILE_FORMATTERS.get(
+        str(finding.evidence.get("template_id") or "")
+    )
+    if formatter:
+        return formatter(finding)
     if explanation:
         text = _normalize_text(explanation)
         if text and len(text) <= MAX_MOBILE_MESSAGE_CHARS:

--- a/tests/custom_components/home_generative_agent/test_notify_actions.py
+++ b/tests/custom_components/home_generative_agent/test_notify_actions.py
@@ -748,4 +748,53 @@ def test_entity_staleness_execute_prompt_non_person() -> None:
     )
     prompt = _build_entity_staleness_execute_prompt(finding)
     assert "Front Door Battery" in prompt
+
+
+# ---------------------------------------------------------------------------
+# _build_ask_prompt — alarm_disarmed_open_entry branch
+# ---------------------------------------------------------------------------
+
+
+def _make_open_entry_finding(entry_id: str) -> AnomalyFinding:
+    return AnomalyFinding(
+        anomaly_id="oe-ask-1",
+        type="alarm_disarmed_open_entry_alarm_control_panel_home_alarm",
+        severity="high",
+        confidence=0.6,
+        triggering_entities=["alarm_control_panel.home_alarm", entry_id],
+        evidence={
+            "template_id": "alarm_disarmed_open_entry",
+            "alarm_entity_id": "alarm_control_panel.home_alarm",
+            "entry_entity_id": entry_id,
+            "entry_state": "on",
+            "alarm_state": "disarmed",
+            "alarm_last_changed": "2025-01-01T22:15:00+00:00",
+        },
+        suggested_actions=["close_entry"],
+        is_sensitive=True,
+    )
+
+
+def test_ask_prompt_open_entry_binary_sensor_forbids_arming() -> None:
+    """For read-only binary_sensor entries the prompt must not suggest arming."""
+    finding = _make_open_entry_finding("binary_sensor.family_room_right_window")
+    prompt = _build_ask_prompt(finding)
+    assert "Do NOT attempt to arm the alarm" in prompt
+
+
+def test_ask_prompt_open_entry_binary_sensor_advises_manual_close() -> None:
+    """Prompt tells agent to direct user to close manually or snooze."""
+    finding = _make_open_entry_finding("binary_sensor.family_room_right_window")
+    prompt = _build_ask_prompt(finding)
+    assert "manually" in prompt
+    assert "Snooze" in prompt
+
+
+def test_ask_prompt_open_entry_cover_uses_close_action() -> None:
+    """For a cover.* entry the prompt should direct agent to close the cover."""
+    finding = _make_open_entry_finding("cover.garage_door")
+    prompt = _build_ask_prompt(finding)
+    assert "close" in prompt.lower()
+    assert "cover.garage_door" in prompt
+    assert "Do NOT attempt to arm the alarm" not in prompt
     assert "home" not in prompt.lower() or "not_home" not in prompt

--- a/tests/custom_components/home_generative_agent/test_sentinel_notifier.py
+++ b/tests/custom_components/home_generative_agent/test_sentinel_notifier.py
@@ -24,8 +24,10 @@ from custom_components.home_generative_agent.sentinel.notifier import (
     MAX_MOBILE_MESSAGE_CHARS,
     SentinelNotifier,
     _alarm_disarmed_mobile_message,
+    _alarm_disarmed_open_entry_mobile_message,
     _appliance_power_duration_mobile_message,
     _build_actions,
+    _build_subtitle,
     _entity_staleness_mobile_message,
     _friendly_type,
     _mobile_message,
@@ -1686,3 +1688,71 @@ async def test_daily_digest_callback_dispatches_coroutine() -> None:
         await hass.drain_tasks()
 
     run_mock.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# alarm_disarmed_open_entry — mobile message and subtitle
+# ---------------------------------------------------------------------------
+
+
+def _open_entry_finding(
+    entry_id: str = "binary_sensor.family_room_right_window",
+    alarm_last_changed: str | None = "2025-01-01T22:15:00+00:00",
+    entry_last_changed: str | None = "2025-01-01T21:00:00+00:00",
+) -> AnomalyFinding:
+    return AnomalyFinding(
+        anomaly_id="oe1",
+        type="alarm_disarmed_open_entry_alarm_control_panel_home_alarm",
+        severity="high",
+        confidence=0.6,
+        triggering_entities=["alarm_control_panel.home_alarm", entry_id],
+        evidence={
+            "template_id": "alarm_disarmed_open_entry",
+            "alarm_entity_id": "alarm_control_panel.home_alarm",
+            "entry_entity_id": entry_id,
+            "entry_state": "on",
+            "alarm_state": "disarmed",
+            "entry_last_changed": entry_last_changed,
+            "alarm_last_changed": alarm_last_changed,
+        },
+        suggested_actions=["close_entry"],
+        is_sensitive=True,
+    )
+
+
+def test_alarm_disarmed_open_entry_mobile_message_with_alarm_time() -> None:
+    """Mobile copy shows entry name and the alarm disarm time, not the entry timestamp."""
+    finding = _open_entry_finding(alarm_last_changed="2025-01-01T22:15:00+00:00")
+    msg = _alarm_disarmed_open_entry_mobile_message(finding)
+    assert "Family Room Right Window" in msg
+    assert "disarmed since" in msg
+    assert "close" in msg.lower() or "snooze" in msg.lower()
+    assert len(msg) <= MAX_MOBILE_MESSAGE_CHARS
+
+
+def test_alarm_disarmed_open_entry_mobile_message_no_alarm_time() -> None:
+    """Falls back gracefully when alarm_last_changed is absent."""
+    finding = _open_entry_finding(alarm_last_changed=None)
+    msg = _alarm_disarmed_open_entry_mobile_message(finding)
+    assert "Family Room Right Window" in msg
+    assert "disarmed" in msg
+    assert len(msg) <= MAX_MOBILE_MESSAGE_CHARS
+
+
+def test_alarm_disarmed_open_entry_mobile_message_no_llm_fallback() -> None:
+    """Template-id dispatch routes to deterministic builder, not the LLM explanation."""
+    finding = _open_entry_finding()
+    llm_explanation = "The alarm is disarmed and the window is open."
+    msg = _mobile_message(llm_explanation, finding)
+    # Deterministic copy must be used — LLM text should NOT appear verbatim.
+    assert "window is open" not in msg
+    assert "Family Room Right Window" in msg
+
+
+def test_alarm_disarmed_open_entry_subtitle() -> None:
+    """Subtitle shows entry name and rule context, not raw rule id."""
+    finding = _open_entry_finding()
+    subtitle = _build_subtitle(finding)
+    assert "Family Room Right Window" in subtitle
+    assert "open" in subtitle.lower()
+    assert "alarm disarmed" in subtitle.lower()


### PR DESCRIPTION
## Summary

- **Clearer notifications**: replace the raw rule-id-derived title ("Alarm disarmed open entry alarm control panel home alarm") with a dedicated subtitle ("Family Room Right Window open, alarm disarmed") and a focused mobile message that shows the actual alarm disarm time (e.g. "Alarm disarmed since 10:15 PM") rather than the window sensor's last-changed timestamp
- **Correct timing**: `_eval_alarm_disarmed_open_entry` now stores `alarm_last_changed` separately from `entry_last_changed` in evidence, so the notification always reflects when the alarm was actually disarmed
- **Better Ask Agent response**: the handoff prompt now distinguishes read-only `binary_sensor` entries (cannot be closed programmatically) from actuatable `cover.*` entities; for sensors it explicitly forbids arming the alarm as a substitute and instead tells the agent to check occupancy and direct the user to close manually or snooze if the open window is expected

## Test plan

- [x] Trigger the `alarm_disarmed_open_entry` rule with a window open and alarm disarmed — confirm subtitle reads "Family Room Right Window open, alarm disarmed" and body shows the correct disarm clock time
- [x] Tap "Ask Agent" — confirm reply does not attempt to arm the alarm; instead confirms whether the condition is still active and advises the user to close the window manually or snooze
- [x] Confirm all 1251 existing tests still pass (`make test`)
- [x] Confirm lint passes (`make lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)