### PR TITLE
fix(sentinel): correct HA-startup timestamp resets for alarm, lock, and power sensors

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -18,6 +18,7 @@ ignore = [
 [lint.per-file-ignores]
 "tests/**/*.py" = [
     "ANN001", # Allow untyped pytest fixture args
+    "ANN201", # Allow untyped pytest fixture return types
     "ARG002", # Allow unused args in test doubles
     "D102",   # Test helper methods do not require docstrings
     "D103",   # Test functions do not require docstrings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.14.24] - 2026-06-24
+
+### Fixed
+
+- **Sentinel notifications showed HA restart time instead of actual state-change time** — when Home Assistant restarts, entities re-report their current state with a new `last_changed` stamped at startup time. Three Sentinel rule categories were computing falsely short durations as a result ("Alarm disarmed since 5:16 AM", "Garage door lock unlocked for about 15 minutes", "Dishwasher running for 5 minutes" — all actually much older). Fixes:
+  - New `alarm_enrichment.py`: queries 30 days of HA recorder history (date-range query, replaces count-based `get_last_state_changes`), walks newest-to-oldest skipping `unavailable`/`unknown` transient states, finds the true `armed_*→disarmed` transition, and corrects `last_changed` before rule evaluation. Falls back to the oldest within-window disarmed record when the armed record has been purged from the DB; clears `last_changed` to `""` (suppressing the misleading timestamp) when the alarm has been disarmed for more than the 30-day lookback window.
+  - New `lock_enrichment.py`: same recorder-based pattern for unlocked lock entities. Finds the last `non-unlocked→unlocked` transition (handles `locked`, `locking`, `unlocking`, `jammed` as anchors); uses the oldest within-window record as a fallback for purged records; clears `last_changed` to `""` when the lock has been open for more than 30 days.
+  - New `power_enrichment.py`: for power sensors currently drawing more than 10 W, finds the last `off→on` transition in 30-day history. Handles both W and kW units. Leaves `last_changed` unchanged (rather than clearing) when no useful transition can be determined.
+  - `engine.py`: calls all three enrichments in sequence after snapshot build, before rule evaluation.
+  - `dynamic_rules.py`: lock evidence now uses `lock.get("last_changed") or None` so an empty-string `last_changed` (set by enrichment when the lock has been open >30 days) propagates as `None` to LLM context.
+
+- **Disarm notifications showed time-only for old disarms** — notifications like "Alarm disarmed since 1:46 PM" were ambiguous when the disarm occurred on a previous day. `notifier.py` now uses a `_format_disarm_since()` helper that prepends the date ("14 Jun at 1:46 PM") when the disarm was on a different calendar day, and shows time-only for same-day disarms.
+
 ## [3.14.23] - 2026-06-19
 
 ### Fixed

--- a/custom_components/home_generative_agent/manifest.json
+++ b/custom_components/home_generative_agent/manifest.json
@@ -34,5 +34,5 @@
     "langchain-google-genai==3.1.0",
     "langchain-anthropic==1.4.3"
   ],
-  "version": "3.14.23"
+  "version": "3.14.24"
 }

--- a/custom_components/home_generative_agent/sentinel/alarm_enrichment.py
+++ b/custom_components/home_generative_agent/sentinel/alarm_enrichment.py
@@ -1,0 +1,162 @@
+"""Alarm entity history enrichment for accurate disarm timestamps."""
+
+from __future__ import annotations
+
+import functools
+import logging
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components.recorder import history as recorder_history
+from homeassistant.helpers.recorder import DATA_INSTANCE
+from homeassistant.helpers.recorder import get_instance as get_recorder_instance
+from homeassistant.util import dt as dt_util
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+    from custom_components.home_generative_agent.snapshot.schema import (
+        FullStateSnapshot,
+    )
+
+_LOGGER = logging.getLogger(__name__)
+
+_DISARMED = "disarmed"
+# How far back to search for an armed→disarmed transition.  Using a date-range
+# query (not count-based) so HA includes a synthetic start-of-period state via
+# include_start_time_state=True, which acts as an "armed" anchor even when the
+# actual record has been purged from the short-term DB.
+_LOOKBACK_DAYS = 30
+# HA sets these transient states when an integration loses/lacks connectivity.
+# They are not intentional alarm state changes and must be ignored when
+# searching for the armed→disarmed transition.
+_TRANSIENT_STATES = frozenset({"unavailable", "unknown"})
+
+
+def _find_true_disarm(
+    state_list: list[Any], start_time: datetime
+) -> tuple[Any | None, bool]:
+    """
+    Return (true_disarm_state, should_clear) from ascending state history.
+
+    Walk newest-to-oldest, skip transient connectivity states, look for the
+    armed→disarmed transition.  If none is found, fall back to using the oldest
+    surviving record when it is genuinely within the window (i.e. last_changed >
+    start_time, so it is not a synthetic start-state injected by HA).  If even
+    that fails, return (None, True) to signal that last_changed should be cleared.
+    """
+    prev = None
+    for state in reversed(state_list):
+        if state.state in _TRANSIENT_STATES:
+            continue
+        if prev is not None and state.state != _DISARMED and prev.state == _DISARMED:
+            return prev, False
+        prev = state
+
+    # No transition found.
+    # If the oldest non-transient record is within the window its "armed"
+    # predecessor was purged from the short-term DB but the disarm itself
+    # survived — use it as the best available approximation.
+    # If it is at or before start_time, include_start_time_state injected it as
+    # a synthetic anchor, meaning the alarm was disarmed before the window.
+    first = next((s for s in state_list if s.state not in _TRANSIENT_STATES), None)
+    if (
+        first is not None
+        and first.state == _DISARMED
+        and dt_util.as_utc(first.last_changed) > start_time
+    ):
+        return first, False
+    return None, True
+
+
+async def async_enrich_alarm_last_changed(
+    hass: HomeAssistant, snapshot: FullStateSnapshot
+) -> None:
+    """Correct last_changed for disarmed alarm entities reset by HA startup."""
+    if DATA_INSTANCE not in getattr(hass, "data", {}):
+        return
+
+    disarmed_alarms = [
+        e
+        for e in snapshot["entities"]
+        if e["domain"] == "alarm_control_panel" and e["state"] == _DISARMED
+    ]
+    if not disarmed_alarms:
+        return
+
+    instance = get_recorder_instance(hass)
+    now = dt_util.utcnow()
+    start_time = now - timedelta(days=_LOOKBACK_DAYS)
+
+    for alarm_entity in disarmed_alarms:
+        entity_id = alarm_entity["entity_id"]
+        try:
+            # Use a date-range query with include_start_time_state=True so that
+            # HA inserts a synthetic record showing the state at the start of
+            # the window.  This acts as an "armed" anchor even when the actual
+            # transition record was purged by the recorder's short-term DB.
+            states = await instance.async_add_executor_job(
+                functools.partial(
+                    recorder_history.state_changes_during_period,
+                    hass,
+                    start_time,
+                    now,
+                    entity_id,
+                    no_attributes=False,
+                    descending=False,
+                    limit=None,
+                    include_start_time_state=True,
+                )
+            )
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug(
+                "Could not query recorder history for alarm entity %s", entity_id
+            )
+            continue
+
+        state_list = states.get(entity_id) or []
+
+        _LOGGER.debug(
+            "Alarm %s history (%d records, %d-day window): %s",
+            entity_id,
+            len(state_list),
+            _LOOKBACK_DAYS,
+            [
+                (s.state, dt_util.as_local(s.last_changed).isoformat())
+                for s in state_list
+            ],
+        )
+
+        if len(state_list) < 2:  # noqa: PLR2004
+            continue
+
+        true_disarm_state, should_clear = _find_true_disarm(state_list, start_time)
+
+        if should_clear:
+            _LOGGER.debug(
+                "Alarm %s: no armed→disarmed transition in %d-day window; "
+                "clearing last_changed to suppress misleading HA restart time",
+                entity_id,
+                _LOOKBACK_DAYS,
+            )
+            alarm_entity["last_changed"] = ""
+            continue
+
+        if true_disarm_state is None:
+            continue
+
+        true_last_changed = dt_util.as_utc(true_disarm_state.last_changed).isoformat()
+        if true_last_changed != alarm_entity["last_changed"]:
+            _LOGGER.debug(
+                "Alarm %s: corrected last_changed %s → %s",
+                entity_id,
+                alarm_entity["last_changed"],
+                true_last_changed,
+            )
+            alarm_entity["last_changed"] = true_last_changed
+        else:
+            _LOGGER.debug(
+                "Alarm %s: last_changed %s already correct, no update needed",
+                entity_id,
+                alarm_entity["last_changed"],
+            )

--- a/custom_components/home_generative_agent/sentinel/dynamic_rules.py
+++ b/custom_components/home_generative_agent/sentinel/dynamic_rules.py
@@ -218,7 +218,7 @@ def _eval_alarm_disarmed_open_entry(
             "entry_state": entry.get("state"),
             "alarm_state": alarm.get("state"),
             "entry_last_changed": entry.get("last_changed"),
-            "alarm_last_changed": alarm.get("last_changed"),
+            "alarm_last_changed": alarm.get("last_changed") or None,
         }
         findings.append(_build_finding(rule, [alarm_id, entry_id], evidence))
     return findings
@@ -350,7 +350,7 @@ def _eval_unlocked_lock_when_home(
         "lock_entity_id": lock_id,
         "lock_state": lock.get("state"),
         "anyone_home": snapshot["derived"]["anyone_home"],
-        "last_changed": lock.get("last_changed"),
+        "last_changed": lock.get("last_changed") or None,
     }
     return [_build_finding(rule, [lock_id], evidence)]
 
@@ -728,7 +728,7 @@ def _eval_unlocked_lock_while_away(
         "lock_entity_id": lock_id,
         "lock_state": lock.get("state"),
         "anyone_home": snapshot["derived"]["anyone_home"],
-        "last_changed": lock.get("last_changed"),
+        "last_changed": lock.get("last_changed") or None,
     }
     return [_build_finding(rule, [lock_id], evidence)]
 

--- a/custom_components/home_generative_agent/sentinel/engine.py
+++ b/custom_components/home_generative_agent/sentinel/engine.py
@@ -56,14 +56,17 @@ from custom_components.home_generative_agent.snapshot.builder import (
     async_build_full_state_snapshot,
 )
 
+from .alarm_enrichment import async_enrich_alarm_last_changed
 from .baseline import CYCLICAL_LOAD_HINTS
 from .correlator import SentinelCorrelator
 from .dynamic_rules import evaluate_dynamic_rules
 from .execution import (
     SentinelExecutionService,
 )
+from .lock_enrichment import async_enrich_lock_last_changed
 from .logging_utils import RepeatingLogLimiter
 from .models import AnomalyFinding, CompoundFinding
+from .power_enrichment import async_enrich_power_last_changed
 from .rules.alarm_disarmed_external_threat import AlarmDisarmedDuringExternalThreatRule
 from .rules.appliance_power_duration import AppliancePowerDurationRule
 from .rules.camera_entry_unsecured import CameraEntryUnsecuredRule
@@ -449,7 +452,7 @@ class SentinelEngine:
             self.run_stats["scheduler"] = self._trigger_scheduler.stats
             async_dispatcher_send(self._hass, SIGNAL_SENTINEL_RUN_COMPLETE)
 
-    async def _run_once(self, trigger_source: str = "poll") -> None:  # noqa: PLR0912
+    async def _run_once(self, trigger_source: str = "poll") -> None:  # noqa: PLR0912, PLR0915
         try:
             snapshot = await async_build_full_state_snapshot(self._hass)
         except (ValueError, TypeError, KeyError):
@@ -462,6 +465,9 @@ class SentinelEngine:
             "snapshot_build",
             "Sentinel snapshot build recovered after %d failed cycle(s).",
         )
+        await async_enrich_alarm_last_changed(self._hass, snapshot)
+        await async_enrich_lock_last_changed(self._hass, snapshot)
+        await async_enrich_power_last_changed(self._hass, snapshot)
 
         # Force Level 0 when suppression state is in read-only mode (version
         # mismatch after a downgrade).

--- a/custom_components/home_generative_agent/sentinel/lock_enrichment.py
+++ b/custom_components/home_generative_agent/sentinel/lock_enrichment.py
@@ -1,0 +1,148 @@
+"""Lock entity history enrichment for accurate unlock timestamps."""
+
+from __future__ import annotations
+
+import functools
+import logging
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components.recorder import history as recorder_history
+from homeassistant.helpers.recorder import DATA_INSTANCE
+from homeassistant.helpers.recorder import get_instance as get_recorder_instance
+from homeassistant.util import dt as dt_util
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+    from custom_components.home_generative_agent.snapshot.schema import (
+        FullStateSnapshot,
+    )
+
+_LOGGER = logging.getLogger(__name__)
+
+_UNLOCKED = "unlocked"
+_LOOKBACK_DAYS = 30
+# Connectivity-loss states injected by HA during startup/reconnect — not
+# intentional lock operations; skip when searching for the transition.
+_TRANSIENT_STATES = frozenset({"unavailable", "unknown"})
+
+
+def _find_true_unlock(
+    state_list: list[Any], start_time: datetime
+) -> tuple[Any | None, bool]:
+    """
+    Return (true_unlock_state, should_clear) from ascending state history.
+
+    Walk newest-to-oldest, skip transient connectivity states, look for the
+    locked→unlocked transition.  If none is found, fall back to using the oldest
+    surviving record when it is genuinely within the window (last_changed >
+    start_time), meaning the preceding locked record was purged from the DB.
+    If even that fails, return (None, True) to clear last_changed.
+    """
+    prev = None
+    for state in reversed(state_list):
+        if state.state in _TRANSIENT_STATES:
+            continue
+        if prev is not None and state.state != _UNLOCKED and prev.state == _UNLOCKED:
+            return prev, False
+        prev = state
+
+    # No transition found.
+    first = next((s for s in state_list if s.state not in _TRANSIENT_STATES), None)
+    if (
+        first is not None
+        and first.state == _UNLOCKED
+        and dt_util.as_utc(first.last_changed) > start_time
+    ):
+        return first, False
+    return None, True
+
+
+async def async_enrich_lock_last_changed(
+    hass: HomeAssistant, snapshot: FullStateSnapshot
+) -> None:
+    """Correct last_changed for unlocked lock entities reset by HA startup."""
+    if DATA_INSTANCE not in getattr(hass, "data", {}):
+        return
+
+    unlocked_locks = [
+        e
+        for e in snapshot["entities"]
+        if e["domain"] == "lock" and e["state"] == _UNLOCKED
+    ]
+    if not unlocked_locks:
+        return
+
+    instance = get_recorder_instance(hass)
+    now = dt_util.utcnow()
+    start_time = now - timedelta(days=_LOOKBACK_DAYS)
+
+    for lock_entity in unlocked_locks:
+        entity_id = lock_entity["entity_id"]
+        try:
+            states = await instance.async_add_executor_job(
+                functools.partial(
+                    recorder_history.state_changes_during_period,
+                    hass,
+                    start_time,
+                    now,
+                    entity_id,
+                    no_attributes=False,
+                    descending=False,
+                    limit=None,
+                    include_start_time_state=True,
+                )
+            )
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug(
+                "Could not query recorder history for lock entity %s", entity_id
+            )
+            continue
+
+        state_list = states.get(entity_id) or []
+
+        _LOGGER.debug(
+            "Lock %s history (%d records, %d-day window): %s",
+            entity_id,
+            len(state_list),
+            _LOOKBACK_DAYS,
+            [
+                (s.state, dt_util.as_local(s.last_changed).isoformat())
+                for s in state_list
+            ],
+        )
+
+        if len(state_list) < 2:  # noqa: PLR2004
+            continue
+
+        true_unlock_state, should_clear = _find_true_unlock(state_list, start_time)
+
+        if should_clear:
+            _LOGGER.debug(
+                "Lock %s: no locked→unlocked transition in %d-day window; "
+                "clearing last_changed to suppress misleading HA restart time",
+                entity_id,
+                _LOOKBACK_DAYS,
+            )
+            lock_entity["last_changed"] = ""
+            continue
+
+        if true_unlock_state is None:
+            continue
+
+        true_last_changed = dt_util.as_utc(true_unlock_state.last_changed).isoformat()
+        if true_last_changed != lock_entity["last_changed"]:
+            _LOGGER.debug(
+                "Lock %s: corrected last_changed %s → %s",
+                entity_id,
+                lock_entity["last_changed"],
+                true_last_changed,
+            )
+            lock_entity["last_changed"] = true_last_changed
+        else:
+            _LOGGER.debug(
+                "Lock %s: last_changed %s already correct, no update needed",
+                entity_id,
+                lock_entity["last_changed"],
+            )

--- a/custom_components/home_generative_agent/sentinel/notifier.py
+++ b/custom_components/home_generative_agent/sentinel/notifier.py
@@ -810,6 +810,21 @@ def _fallback_message(finding: AnomalyFinding) -> str:
     return f"{summary}: {entity}. {_severity_action_hint(finding.severity)}"
 
 
+def _format_disarm_since(parsed: datetime) -> str:
+    """
+    Return a human-readable 'since …' string for a disarm timestamp.
+
+    Shows time-only when the disarm was today; prepends the date otherwise so
+    a disarm from days ago is not mistaken for earlier today.
+    """
+    local = dt_util.as_local(parsed)
+    local_now = dt_util.now()
+    time_str = local.strftime("%-I:%M %p")
+    if local.date() == local_now.date():
+        return time_str
+    return local.strftime(f"%-d %b at {time_str}")
+
+
 def _alarm_disarmed_mobile_message(finding: AnomalyFinding) -> str:
     """Deterministic mobile copy for alarm_disarmed_during_external_threat."""
     ev = finding.evidence
@@ -838,8 +853,9 @@ def _alarm_disarmed_mobile_message(finding: AnomalyFinding) -> str:
     if last_changed:
         parsed = dt_util.parse_datetime(str(last_changed))
         if parsed is not None:
-            time_str = dt_util.as_local(parsed).strftime("%-I:%M %p")
-            alarm_phrase = f" The alarm has been disarmed since {time_str}."
+            alarm_phrase = (
+                f" The alarm has been disarmed since {_format_disarm_since(parsed)}."
+            )
     if not alarm_phrase:
         alarm_phrase = " The alarm is currently disarmed."
 
@@ -857,8 +873,7 @@ def _alarm_disarmed_open_entry_mobile_message(finding: AnomalyFinding) -> str:
     if alarm_last_changed:
         parsed = dt_util.parse_datetime(str(alarm_last_changed))
         if parsed is not None:
-            time_str = dt_util.as_local(parsed).strftime("%-I:%M %p")
-            alarm_phrase = f"Alarm disarmed since {time_str}."
+            alarm_phrase = f"Alarm disarmed since {_format_disarm_since(parsed)}."
         else:
             alarm_phrase = "Alarm is disarmed."
     else:

--- a/custom_components/home_generative_agent/sentinel/power_enrichment.py
+++ b/custom_components/home_generative_agent/sentinel/power_enrichment.py
@@ -1,0 +1,170 @@
+"""Power sensor history enrichment for accurate appliance 'on since' timestamps."""
+
+from __future__ import annotations
+
+import functools
+import logging
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components.recorder import history as recorder_history
+from homeassistant.helpers.recorder import DATA_INSTANCE
+from homeassistant.helpers.recorder import get_instance as get_recorder_instance
+from homeassistant.util import dt as dt_util
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+    from custom_components.home_generative_agent.snapshot.schema import (
+        FullStateSnapshot,
+    )
+
+_LOGGER = logging.getLogger(__name__)
+
+_LOOKBACK_DAYS = 30
+# Below this wattage the appliance is effectively off.  Used when walking
+# recorder history to locate the last off→on transition.
+_POWER_OFF_W = 10.0
+# Connectivity-loss states — skip when searching for the power transition.
+_TRANSIENT_STATES = frozenset({"unavailable", "unknown"})
+
+
+def _parse_float(raw: str) -> float | None:
+    try:
+        return float(raw)
+    except (ValueError, TypeError):
+        return None
+
+
+def _find_true_on_since(
+    state_list: list[Any],
+    off_threshold_native: float,
+    start_time: datetime,
+) -> Any | None:
+    """
+    Return the state when the sensor last transitioned from off to on.
+
+    Walk newest-to-oldest, skip transients.  The first reading at or below
+    off_threshold_native marks the boundary of the current 'on' episode; the
+    state immediately after it (newer) is the true start.
+
+    If no 'off' reading exists in the window, the oldest within-window record
+    is returned as the best available approximation (the sensor has been on
+    since before the window, but it is still more accurate than a restart-reset
+    last_changed).  Returns None when nothing useful can be determined.
+    """
+    prev = None
+    for state in reversed(state_list):
+        if state.state in _TRANSIENT_STATES:
+            continue
+        val = _parse_float(state.state)
+        if val is None:
+            continue
+        if val <= off_threshold_native:
+            # 'Off' reading found — prev is the true on-start (may be None if
+            # the first non-transient record is already below threshold).
+            return prev
+        prev = state
+
+    # No 'off' reading in window.  Use oldest within-window 'on' record.
+    first = next(
+        (
+            s
+            for s in state_list
+            if s.state not in _TRANSIENT_STATES and _parse_float(s.state) is not None
+        ),
+        None,
+    )
+    if first is not None and dt_util.as_utc(first.last_changed) > start_time:
+        return first
+    return None
+
+
+async def async_enrich_power_last_changed(
+    hass: HomeAssistant, snapshot: FullStateSnapshot
+) -> None:
+    """
+    Correct last_changed for power sensors reset by HA startup.
+
+    When HA restarts, a power sensor re-reports its current wattage, creating a
+    new last_changed at startup time.  The appliance duration rule then computes
+    a falsely short duration and fires too late (or not at all).  This function
+    queries the recorder to find when the sensor last crossed from off to on and
+    corrects last_changed before rules evaluate.
+    """
+    if DATA_INSTANCE not in getattr(hass, "data", {}):
+        return
+
+    power_entities = [
+        e
+        for e in snapshot["entities"]
+        if e["domain"] == "sensor"
+        and (
+            e["attributes"].get("device_class") == "power"
+            or e["attributes"].get("unit_of_measurement") in {"W", "kW"}
+        )
+    ]
+    if not power_entities:
+        return
+
+    instance = get_recorder_instance(hass)
+    now = dt_util.utcnow()
+    start_time = now - timedelta(days=_LOOKBACK_DAYS)
+
+    for power_entity in power_entities:
+        entity_id = power_entity["entity_id"]
+        unit = str(power_entity["attributes"].get("unit_of_measurement") or "W")
+
+        current_val = _parse_float(power_entity["state"])
+        if current_val is None:
+            continue
+        current_w = current_val * 1000.0 if unit == "kW" else current_val
+        if current_w <= _POWER_OFF_W:
+            continue  # appliance is off — nothing to correct
+
+        off_threshold_native = _POWER_OFF_W / (1000.0 if unit == "kW" else 1.0)
+
+        try:
+            states = await instance.async_add_executor_job(
+                functools.partial(
+                    recorder_history.state_changes_during_period,
+                    hass,
+                    start_time,
+                    now,
+                    entity_id,
+                    no_attributes=False,
+                    descending=False,
+                    limit=None,
+                    include_start_time_state=True,
+                )
+            )
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug(
+                "Could not query recorder history for power entity %s", entity_id
+            )
+            continue
+
+        state_list = states.get(entity_id) or []
+
+        if len(state_list) < 2:  # noqa: PLR2004
+            continue
+
+        true_on_state = _find_true_on_since(
+            state_list, off_threshold_native, start_time
+        )
+        if true_on_state is None:
+            continue
+
+        true_last_changed = dt_util.as_utc(true_on_state.last_changed).isoformat()
+        if true_last_changed != power_entity["last_changed"]:
+            _LOGGER.debug(
+                "Power sensor %s: corrected last_changed %s → %s "
+                "(true on-since; %s at %.1f %s)",
+                entity_id,
+                power_entity["last_changed"],
+                true_last_changed,
+                true_on_state.state,
+                current_w,
+                "W",
+            )
+            power_entity["last_changed"] = true_last_changed

--- a/custom_components/home_generative_agent/sentinel/rules/alarm_disarmed_external_threat.py
+++ b/custom_components/home_generative_agent/sentinel/rules/alarm_disarmed_external_threat.py
@@ -105,7 +105,7 @@ class AlarmDisarmedDuringExternalThreatRule:
                 "alarm_entity_id": primary_alarm_id,
                 "alarm_state": _DISARMED_STATE,
                 "last_activity": activity.get("last_activity"),
-                "alarm_last_changed": primary_alarm["last_changed"],
+                "alarm_last_changed": primary_alarm["last_changed"] or None,
             }
             anomaly_id = build_anomaly_id(
                 self.rule_id, [primary_alarm_id, cam], id_evidence

--- a/tests/custom_components/home_generative_agent/test_alarm_enrichment.py
+++ b/tests/custom_components/home_generative_agent/test_alarm_enrichment.py
@@ -3,9 +3,9 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.helpers.recorder import DATA_INSTANCE
@@ -14,6 +14,8 @@ from custom_components.home_generative_agent.sentinel.alarm_enrichment import (
     async_enrich_alarm_last_changed,
 )
 from custom_components.home_generative_agent.snapshot.schema import validate_snapshot
+
+_NOW = datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)
 
 
 def _base_snapshot(**kwargs: Any) -> Any:
@@ -72,6 +74,12 @@ def _make_hass(recorder_states: list[MagicMock] | None = None) -> MagicMock:
     return hass
 
 
+@pytest.fixture(autouse=True)
+def freeze_utcnow():
+    with patch("homeassistant.util.dt.utcnow", return_value=_NOW):
+        yield
+
+
 @pytest.mark.asyncio
 async def test_no_recorder_skips_enrichment() -> None:
     """If recorder isn't loaded, enrichment is a no-op."""
@@ -104,11 +112,11 @@ async def test_no_disarmed_alarm_skips_enrichment() -> None:
 @pytest.mark.asyncio
 async def test_corrects_startup_reset_last_changed() -> None:
     """Alarm disarmed before HA startup (no unavailable) gets last_changed corrected."""
-    actual_disarm = datetime(2026, 6, 20, 10, 0, 0, tzinfo=UTC)
-    ha_startup = datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)
+    actual_disarm = _NOW - timedelta(days=1, hours=19, minutes=16)  # ~June 20 10:00
+    ha_startup = _NOW
 
     recorder_states = [
-        _mock_state("armed_away", datetime(2026, 6, 20, 9, 0, 0, tzinfo=UTC)),
+        _mock_state("armed_away", _NOW - timedelta(days=1, hours=20, minutes=16)),
         _mock_state("disarmed", actual_disarm),  # actual disarm
         _mock_state("disarmed", ha_startup),  # HA restart reset (no unavailable)
     ]
@@ -125,11 +133,11 @@ async def test_corrects_startup_reset_last_changed() -> None:
 @pytest.mark.asyncio
 async def test_corrects_startup_reset_via_unavailable() -> None:
     """Real-world case: HA restart sets unavailable then disarmed; finds true disarm."""
-    actual_disarm = datetime(2026, 6, 20, 10, 0, 0, tzinfo=UTC)
-    ha_startup = datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)
+    actual_disarm = _NOW - timedelta(days=1, hours=19, minutes=16)  # ~June 20 10:00
+    ha_startup = _NOW
 
     recorder_states = [
-        _mock_state("armed_away", datetime(2026, 6, 20, 9, 0, 0, tzinfo=UTC)),
+        _mock_state("armed_away", _NOW - timedelta(days=1, hours=20, minutes=16)),
         _mock_state("disarmed", actual_disarm),  # actual disarm days ago
         _mock_state(
             "unavailable", ha_startup
@@ -151,12 +159,12 @@ async def test_corrects_startup_reset_via_unavailable() -> None:
 @pytest.mark.asyncio
 async def test_multiple_restarts_with_unavailable() -> None:
     """Multiple HA restarts each producing unavailable→disarmed; finds original."""
-    original_disarm = datetime(2026, 6, 18, 14, 0, 0, tzinfo=UTC)
-    restart1 = datetime(2026, 6, 20, 8, 0, 0, tzinfo=UTC)
-    restart2 = datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)
+    original_disarm = _NOW - timedelta(days=3, hours=15, minutes=16)  # ~June 18 14:00
+    restart1 = _NOW - timedelta(days=1, hours=21, minutes=16)  # ~June 20 08:00
+    restart2 = _NOW
 
     recorder_states = [
-        _mock_state("armed_away", datetime(2026, 6, 18, 13, 0, 0, tzinfo=UTC)),
+        _mock_state("armed_away", _NOW - timedelta(days=3, hours=16, minutes=16)),
         _mock_state("disarmed", original_disarm),
         _mock_state("unavailable", restart1),
         _mock_state("disarmed", restart1),
@@ -176,11 +184,11 @@ async def test_multiple_restarts_with_unavailable() -> None:
 @pytest.mark.asyncio
 async def test_genuine_disarm_after_unavailable_not_changed() -> None:
     """Genuine armed→unavailable→disarmed sequence keeps the disarm time."""
-    disarm_time = datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)
+    disarm_time = _NOW
 
     recorder_states = [
-        _mock_state("armed_home", datetime(2026, 6, 21, 22, 0, 0, tzinfo=UTC)),
-        _mock_state("unavailable", datetime(2026, 6, 22, 5, 15, 0, tzinfo=UTC)),
+        _mock_state("armed_home", _NOW - timedelta(hours=7, minutes=16)),
+        _mock_state("unavailable", _NOW - timedelta(minutes=1)),
         _mock_state("disarmed", disarm_time),  # genuine disarm after brief outage
     ]
     hass = _make_hass(recorder_states)
@@ -196,10 +204,10 @@ async def test_genuine_disarm_after_unavailable_not_changed() -> None:
 @pytest.mark.asyncio
 async def test_no_change_when_disarm_is_genuine() -> None:
     """If the alarm really was just disarmed at startup time, no change is made."""
-    disarm_time = datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)
+    disarm_time = _NOW
 
     recorder_states = [
-        _mock_state("armed_home", datetime(2026, 6, 21, 22, 0, 0, tzinfo=UTC)),
+        _mock_state("armed_home", _NOW - timedelta(hours=7, minutes=16)),
         _mock_state("disarmed", disarm_time),  # genuine disarm = startup time
     ]
     hass = _make_hass(recorder_states)
@@ -215,17 +223,15 @@ async def test_no_change_when_disarm_is_genuine() -> None:
 @pytest.mark.asyncio
 async def test_multiple_ha_restarts_finds_original_disarm() -> None:
     """Multiple HA restarts produce multiple disarmed records; finds the first."""
-    original_disarm = datetime(2026, 6, 18, 14, 0, 0, tzinfo=UTC)
+    original_disarm = _NOW - timedelta(days=3, hours=15, minutes=16)  # ~June 18 14:00
 
     recorder_states = [
-        _mock_state("armed_away", datetime(2026, 6, 18, 13, 0, 0, tzinfo=UTC)),
+        _mock_state("armed_away", _NOW - timedelta(days=3, hours=16, minutes=16)),
         _mock_state("disarmed", original_disarm),
         _mock_state(
-            "disarmed", datetime(2026, 6, 20, 8, 0, 0, tzinfo=UTC)
+            "disarmed", _NOW - timedelta(days=1, hours=21, minutes=16)
         ),  # restart 1
-        _mock_state(
-            "disarmed", datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)
-        ),  # restart 2
+        _mock_state("disarmed", _NOW),  # restart 2
     ]
     hass = _make_hass(recorder_states)
 
@@ -242,7 +248,7 @@ async def test_insufficient_history_leaves_unchanged() -> None:
     """Fewer than 2 history records → snapshot left unchanged."""
     hass = _make_hass(
         recorder_states=[
-            _mock_state("disarmed", datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)),
+            _mock_state("disarmed", _NOW),
         ]
     )
 
@@ -273,11 +279,11 @@ async def test_recorder_error_leaves_unchanged() -> None:
 @pytest.mark.asyncio
 async def test_all_disarmed_within_window_uses_oldest() -> None:
     """All records disarmed within window: armed record purged, oldest used as best estimate."""
-    oldest_disarm = datetime(2026, 6, 18, 10, 0, 0, tzinfo=UTC)
+    oldest_disarm = _NOW - timedelta(days=3, hours=19, minutes=16)  # ~June 18 10:00
     recorder_states = [
         _mock_state("disarmed", oldest_disarm),
-        _mock_state("disarmed", datetime(2026, 6, 20, 8, 0, 0, tzinfo=UTC)),
-        _mock_state("disarmed", datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)),
+        _mock_state("disarmed", _NOW - timedelta(days=1, hours=21, minutes=16)),
+        _mock_state("disarmed", _NOW),
     ]
     hass = _make_hass(recorder_states)
 
@@ -298,27 +304,39 @@ async def test_real_world_armed_record_purged() -> None:
     include_start_time_state synthetic anchor were purged from the short-term DB.
     The oldest surviving record IS the actual disarm, and the fallback path uses it.
     """
-    actual_disarm = datetime(2026, 6, 14, 20, 46, 53, tzinfo=UTC)
+    actual_disarm = _NOW - timedelta(days=7, hours=8, minutes=29, seconds=7)
     recorder_states = [
         # Oldest surviving record — the actual disarm 8 days ago.
         _mock_state("disarmed", actual_disarm),
         # 11 subsequent HA-restart re-reports of "disarmed".
-        _mock_state("disarmed", datetime(2026, 6, 15, 12, 55, 35, tzinfo=UTC)),
-        _mock_state("disarmed", datetime(2026, 6, 15, 19, 28, 37, tzinfo=UTC)),
-        _mock_state("disarmed", datetime(2026, 6, 17, 2, 7, 0, tzinfo=UTC)),
-        _mock_state("disarmed", datetime(2026, 6, 18, 19, 28, 49, tzinfo=UTC)),
-        _mock_state("disarmed", datetime(2026, 6, 19, 12, 33, 50, tzinfo=UTC)),
-        _mock_state("disarmed", datetime(2026, 6, 19, 18, 25, 35, tzinfo=UTC)),
-        _mock_state("disarmed", datetime(2026, 6, 20, 5, 14, 18, tzinfo=UTC)),
-        _mock_state("disarmed", datetime(2026, 6, 20, 5, 16, 33, tzinfo=UTC)),
-        _mock_state("disarmed", datetime(2026, 6, 22, 13, 13, 48, tzinfo=UTC)),
-        _mock_state("disarmed", datetime(2026, 6, 22, 18, 41, 8, tzinfo=UTC)),
-        _mock_state("disarmed", datetime(2026, 6, 22, 19, 8, 19, tzinfo=UTC)),
+        _mock_state(
+            "disarmed", _NOW - timedelta(days=6, hours=16, minutes=20, seconds=25)
+        ),
+        _mock_state(
+            "disarmed", _NOW - timedelta(days=6, hours=9, minutes=47, seconds=23)
+        ),
+        _mock_state("disarmed", _NOW - timedelta(days=5, hours=3, minutes=9)),
+        _mock_state(
+            "disarmed", _NOW - timedelta(days=3, hours=9, minutes=47, seconds=11)
+        ),
+        _mock_state(
+            "disarmed", _NOW - timedelta(days=2, hours=16, minutes=42, seconds=10)
+        ),
+        _mock_state(
+            "disarmed", _NOW - timedelta(days=2, hours=10, minutes=50, seconds=25)
+        ),
+        _mock_state("disarmed", _NOW - timedelta(days=2, minutes=1, seconds=42)),
+        _mock_state(
+            "disarmed", _NOW - timedelta(days=1, hours=23, minutes=59, seconds=27)
+        ),
+        _mock_state("disarmed", _NOW - timedelta(minutes=3)),
+        _mock_state("disarmed", _NOW - timedelta(minutes=2)),
+        _mock_state("disarmed", _NOW - timedelta(minutes=1)),
     ]
     hass = _make_hass(recorder_states)
 
     snapshot = _base_snapshot()
-    snapshot["entities"] = [_alarm_entity(last_changed="2026-06-22T19:08:19+00:00")]
+    snapshot["entities"] = [_alarm_entity(last_changed="2026-06-22T05:15:00+00:00")]
 
     await async_enrich_alarm_last_changed(hass, snapshot)
 
@@ -328,28 +346,40 @@ async def test_real_world_armed_record_purged() -> None:
 @pytest.mark.asyncio
 async def test_real_world_with_armed_anchor_in_window() -> None:
     """Armed record still within recorder window: transition detection finds it directly."""
-    actual_disarm = datetime(2026, 6, 14, 20, 46, 53, tzinfo=UTC)
+    actual_disarm = _NOW - timedelta(days=7, hours=8, minutes=29, seconds=7)
     recorder_states = [
         # Armed record still in the short-term DB (not yet purged).
-        _mock_state("armed_away", datetime(2026, 5, 28, 18, 0, 0, tzinfo=UTC)),
+        _mock_state("armed_away", _NOW - timedelta(days=24, hours=11, minutes=16)),
         # Actual disarm 8 days ago — found via transition detection.
         _mock_state("disarmed", actual_disarm),
         # 10 subsequent HA-restart re-reports of "disarmed".
-        _mock_state("disarmed", datetime(2026, 6, 15, 12, 55, 35, tzinfo=UTC)),
-        _mock_state("disarmed", datetime(2026, 6, 15, 19, 28, 37, tzinfo=UTC)),
-        _mock_state("disarmed", datetime(2026, 6, 17, 2, 7, 0, tzinfo=UTC)),
-        _mock_state("disarmed", datetime(2026, 6, 18, 19, 28, 49, tzinfo=UTC)),
-        _mock_state("disarmed", datetime(2026, 6, 19, 12, 33, 50, tzinfo=UTC)),
-        _mock_state("disarmed", datetime(2026, 6, 20, 1, 25, 35, tzinfo=UTC)),
-        _mock_state("disarmed", datetime(2026, 6, 20, 12, 14, 18, tzinfo=UTC)),
-        _mock_state("disarmed", datetime(2026, 6, 20, 12, 16, 33, tzinfo=UTC)),
-        _mock_state("disarmed", datetime(2026, 6, 22, 13, 13, 48, tzinfo=UTC)),
-        _mock_state("disarmed", datetime(2026, 6, 23, 1, 41, 8, tzinfo=UTC)),
+        _mock_state(
+            "disarmed", _NOW - timedelta(days=6, hours=16, minutes=20, seconds=25)
+        ),
+        _mock_state(
+            "disarmed", _NOW - timedelta(days=6, hours=9, minutes=47, seconds=23)
+        ),
+        _mock_state("disarmed", _NOW - timedelta(days=5, hours=3, minutes=9)),
+        _mock_state(
+            "disarmed", _NOW - timedelta(days=3, hours=9, minutes=47, seconds=11)
+        ),
+        _mock_state(
+            "disarmed", _NOW - timedelta(days=2, hours=16, minutes=50, seconds=25)
+        ),
+        _mock_state(
+            "disarmed", _NOW - timedelta(days=1, hours=17, minutes=1, seconds=42)
+        ),
+        _mock_state(
+            "disarmed", _NOW - timedelta(days=1, hours=16, minutes=59, seconds=27)
+        ),
+        _mock_state("disarmed", _NOW - timedelta(minutes=3)),
+        _mock_state("disarmed", _NOW - timedelta(minutes=2)),
+        _mock_state("disarmed", _NOW - timedelta(minutes=1)),
     ]
     hass = _make_hass(recorder_states)
 
     snapshot = _base_snapshot()
-    snapshot["entities"] = [_alarm_entity(last_changed="2026-06-23T01:41:08+00:00")]
+    snapshot["entities"] = [_alarm_entity(last_changed="2026-06-22T05:15:00+00:00")]
 
     await async_enrich_alarm_last_changed(hass, snapshot)
 
@@ -361,9 +391,11 @@ async def test_all_disarmed_beyond_lookback_window() -> None:
     """Alarm disarmed longer than _LOOKBACK_DAYS: synthetic anchor is also disarmed."""
     recorder_states = [
         # Synthetic anchor — alarm was already disarmed before the window started.
-        _mock_state("disarmed", datetime(2026, 5, 1, 10, 0, 0, tzinfo=UTC)),
-        _mock_state("disarmed", datetime(2026, 5, 20, 8, 0, 0, tzinfo=UTC)),
-        _mock_state("disarmed", datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)),
+        _mock_state("disarmed", _NOW - timedelta(days=52)),  # before 30-day window
+        _mock_state(
+            "disarmed", _NOW - timedelta(days=33)
+        ),  # still outside 30-day window
+        _mock_state("disarmed", _NOW),
     ]
     hass = _make_hass(recorder_states)
 

--- a/tests/custom_components/home_generative_agent/test_alarm_enrichment.py
+++ b/tests/custom_components/home_generative_agent/test_alarm_enrichment.py
@@ -1,0 +1,375 @@
+# ruff: noqa: S101
+"""Tests for sentinel alarm history enrichment."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.helpers.recorder import DATA_INSTANCE
+
+from custom_components.home_generative_agent.sentinel.alarm_enrichment import (
+    async_enrich_alarm_last_changed,
+)
+from custom_components.home_generative_agent.snapshot.schema import validate_snapshot
+
+
+def _base_snapshot(**kwargs: Any) -> Any:
+    base: dict[str, Any] = {
+        "schema_version": 1,
+        "generated_at": "2026-06-22T05:16:00+00:00",
+        "entities": [],
+        "camera_activity": [],
+        "derived": {
+            "now": "2026-06-22T05:16:00+00:00",
+            "timezone": "UTC",
+            "is_night": False,
+            "anyone_home": True,
+            "people_home": [],
+            "people_away": [],
+            "last_motion_by_area": {},
+        },
+    }
+    base.update(kwargs)
+    return validate_snapshot(base)
+
+
+def _alarm_entity(
+    state: str = "disarmed", last_changed: str = "2026-06-22T05:16:00+00:00"
+) -> dict[str, Any]:
+    return {
+        "entity_id": "alarm_control_panel.home",
+        "domain": "alarm_control_panel",
+        "state": state,
+        "friendly_name": "Home Alarm",
+        "area": None,
+        "attributes": {},
+        "last_changed": last_changed,
+        "last_updated": last_changed,
+    }
+
+
+def _mock_state(state: str, last_changed: datetime) -> MagicMock:
+    s = MagicMock()
+    s.state = state
+    s.last_changed = last_changed
+    return s
+
+
+def _make_hass(recorder_states: list[MagicMock] | None = None) -> MagicMock:
+    """Return a mock hass with recorder available."""
+    hass = MagicMock()
+    instance = MagicMock()
+    if recorder_states is not None:
+        instance.async_add_executor_job = AsyncMock(
+            return_value={"alarm_control_panel.home": recorder_states}
+        )
+    else:
+        instance.async_add_executor_job = AsyncMock(return_value={})
+    hass.data = {DATA_INSTANCE: instance}
+    return hass
+
+
+@pytest.mark.asyncio
+async def test_no_recorder_skips_enrichment() -> None:
+    """If recorder isn't loaded, enrichment is a no-op."""
+    hass = MagicMock()
+    hass.data = {}  # no DATA_INSTANCE
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [_alarm_entity(last_changed="2026-06-22T05:16:00+00:00")]
+
+    await async_enrich_alarm_last_changed(hass, snapshot)
+
+    assert snapshot["entities"][0]["last_changed"] == "2026-06-22T05:16:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_no_disarmed_alarm_skips_enrichment() -> None:
+    """If no alarm is disarmed, no recorder query is made."""
+    hass = MagicMock()
+    instance = MagicMock()
+    instance.async_add_executor_job = AsyncMock()
+    hass.data = {DATA_INSTANCE: instance}
+
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [_alarm_entity(state="armed_away")]
+
+    await async_enrich_alarm_last_changed(hass, snapshot)
+
+    instance.async_add_executor_job.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_corrects_startup_reset_last_changed() -> None:
+    """Alarm disarmed before HA startup (no unavailable) gets last_changed corrected."""
+    actual_disarm = datetime(2026, 6, 20, 10, 0, 0, tzinfo=UTC)
+    ha_startup = datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)
+
+    recorder_states = [
+        _mock_state("armed_away", datetime(2026, 6, 20, 9, 0, 0, tzinfo=UTC)),
+        _mock_state("disarmed", actual_disarm),  # actual disarm
+        _mock_state("disarmed", ha_startup),  # HA restart reset (no unavailable)
+    ]
+    hass = _make_hass(recorder_states)
+
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [_alarm_entity(last_changed="2026-06-22T05:16:00+00:00")]
+
+    await async_enrich_alarm_last_changed(hass, snapshot)
+
+    assert snapshot["entities"][0]["last_changed"] == actual_disarm.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_corrects_startup_reset_via_unavailable() -> None:
+    """Real-world case: HA restart sets unavailable then disarmed; finds true disarm."""
+    actual_disarm = datetime(2026, 6, 20, 10, 0, 0, tzinfo=UTC)
+    ha_startup = datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)
+
+    recorder_states = [
+        _mock_state("armed_away", datetime(2026, 6, 20, 9, 0, 0, tzinfo=UTC)),
+        _mock_state("disarmed", actual_disarm),  # actual disarm days ago
+        _mock_state(
+            "unavailable", ha_startup
+        ),  # integration lost connection on restart
+        _mock_state(
+            "disarmed", ha_startup
+        ),  # integration reconnected → re-reports state
+    ]
+    hass = _make_hass(recorder_states)
+
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [_alarm_entity(last_changed="2026-06-22T05:16:00+00:00")]
+
+    await async_enrich_alarm_last_changed(hass, snapshot)
+
+    assert snapshot["entities"][0]["last_changed"] == actual_disarm.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_multiple_restarts_with_unavailable() -> None:
+    """Multiple HA restarts each producing unavailable→disarmed; finds original."""
+    original_disarm = datetime(2026, 6, 18, 14, 0, 0, tzinfo=UTC)
+    restart1 = datetime(2026, 6, 20, 8, 0, 0, tzinfo=UTC)
+    restart2 = datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)
+
+    recorder_states = [
+        _mock_state("armed_away", datetime(2026, 6, 18, 13, 0, 0, tzinfo=UTC)),
+        _mock_state("disarmed", original_disarm),
+        _mock_state("unavailable", restart1),
+        _mock_state("disarmed", restart1),
+        _mock_state("unavailable", restart2),
+        _mock_state("disarmed", restart2),
+    ]
+    hass = _make_hass(recorder_states)
+
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [_alarm_entity(last_changed="2026-06-22T05:16:00+00:00")]
+
+    await async_enrich_alarm_last_changed(hass, snapshot)
+
+    assert snapshot["entities"][0]["last_changed"] == original_disarm.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_genuine_disarm_after_unavailable_not_changed() -> None:
+    """Genuine armed→unavailable→disarmed sequence keeps the disarm time."""
+    disarm_time = datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)
+
+    recorder_states = [
+        _mock_state("armed_home", datetime(2026, 6, 21, 22, 0, 0, tzinfo=UTC)),
+        _mock_state("unavailable", datetime(2026, 6, 22, 5, 15, 0, tzinfo=UTC)),
+        _mock_state("disarmed", disarm_time),  # genuine disarm after brief outage
+    ]
+    hass = _make_hass(recorder_states)
+
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [_alarm_entity(last_changed="2026-06-22T05:16:00+00:00")]
+
+    await async_enrich_alarm_last_changed(hass, snapshot)
+
+    assert snapshot["entities"][0]["last_changed"] == "2026-06-22T05:16:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_no_change_when_disarm_is_genuine() -> None:
+    """If the alarm really was just disarmed at startup time, no change is made."""
+    disarm_time = datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)
+
+    recorder_states = [
+        _mock_state("armed_home", datetime(2026, 6, 21, 22, 0, 0, tzinfo=UTC)),
+        _mock_state("disarmed", disarm_time),  # genuine disarm = startup time
+    ]
+    hass = _make_hass(recorder_states)
+
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [_alarm_entity(last_changed="2026-06-22T05:16:00+00:00")]
+
+    await async_enrich_alarm_last_changed(hass, snapshot)
+
+    assert snapshot["entities"][0]["last_changed"] == "2026-06-22T05:16:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_multiple_ha_restarts_finds_original_disarm() -> None:
+    """Multiple HA restarts produce multiple disarmed records; finds the first."""
+    original_disarm = datetime(2026, 6, 18, 14, 0, 0, tzinfo=UTC)
+
+    recorder_states = [
+        _mock_state("armed_away", datetime(2026, 6, 18, 13, 0, 0, tzinfo=UTC)),
+        _mock_state("disarmed", original_disarm),
+        _mock_state(
+            "disarmed", datetime(2026, 6, 20, 8, 0, 0, tzinfo=UTC)
+        ),  # restart 1
+        _mock_state(
+            "disarmed", datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)
+        ),  # restart 2
+    ]
+    hass = _make_hass(recorder_states)
+
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [_alarm_entity(last_changed="2026-06-22T05:16:00+00:00")]
+
+    await async_enrich_alarm_last_changed(hass, snapshot)
+
+    assert snapshot["entities"][0]["last_changed"] == original_disarm.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_insufficient_history_leaves_unchanged() -> None:
+    """Fewer than 2 history records → snapshot left unchanged."""
+    hass = _make_hass(
+        recorder_states=[
+            _mock_state("disarmed", datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)),
+        ]
+    )
+
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [_alarm_entity(last_changed="2026-06-22T05:16:00+00:00")]
+
+    await async_enrich_alarm_last_changed(hass, snapshot)
+
+    assert snapshot["entities"][0]["last_changed"] == "2026-06-22T05:16:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_recorder_error_leaves_unchanged() -> None:
+    """If the recorder query fails, the snapshot is left unchanged."""
+    hass = MagicMock()
+    instance = MagicMock()
+    instance.async_add_executor_job = AsyncMock(side_effect=RuntimeError("db error"))
+    hass.data = {DATA_INSTANCE: instance}
+
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [_alarm_entity(last_changed="2026-06-22T05:16:00+00:00")]
+
+    await async_enrich_alarm_last_changed(hass, snapshot)
+
+    assert snapshot["entities"][0]["last_changed"] == "2026-06-22T05:16:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_all_disarmed_within_window_uses_oldest() -> None:
+    """All records disarmed within window: armed record purged, oldest used as best estimate."""
+    oldest_disarm = datetime(2026, 6, 18, 10, 0, 0, tzinfo=UTC)
+    recorder_states = [
+        _mock_state("disarmed", oldest_disarm),
+        _mock_state("disarmed", datetime(2026, 6, 20, 8, 0, 0, tzinfo=UTC)),
+        _mock_state("disarmed", datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)),
+    ]
+    hass = _make_hass(recorder_states)
+
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [_alarm_entity(last_changed="2026-06-22T05:16:00+00:00")]
+
+    await async_enrich_alarm_last_changed(hass, snapshot)
+
+    assert snapshot["entities"][0]["last_changed"] == oldest_disarm.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_real_world_armed_record_purged() -> None:
+    """
+    Mirrors the actual debug log: armed record purged, all 12 records are disarmed.
+
+    The alarm was disarmed 8 days ago; both the preceding "armed" record AND any
+    include_start_time_state synthetic anchor were purged from the short-term DB.
+    The oldest surviving record IS the actual disarm, and the fallback path uses it.
+    """
+    actual_disarm = datetime(2026, 6, 14, 20, 46, 53, tzinfo=UTC)
+    recorder_states = [
+        # Oldest surviving record — the actual disarm 8 days ago.
+        _mock_state("disarmed", actual_disarm),
+        # 11 subsequent HA-restart re-reports of "disarmed".
+        _mock_state("disarmed", datetime(2026, 6, 15, 12, 55, 35, tzinfo=UTC)),
+        _mock_state("disarmed", datetime(2026, 6, 15, 19, 28, 37, tzinfo=UTC)),
+        _mock_state("disarmed", datetime(2026, 6, 17, 2, 7, 0, tzinfo=UTC)),
+        _mock_state("disarmed", datetime(2026, 6, 18, 19, 28, 49, tzinfo=UTC)),
+        _mock_state("disarmed", datetime(2026, 6, 19, 12, 33, 50, tzinfo=UTC)),
+        _mock_state("disarmed", datetime(2026, 6, 19, 18, 25, 35, tzinfo=UTC)),
+        _mock_state("disarmed", datetime(2026, 6, 20, 5, 14, 18, tzinfo=UTC)),
+        _mock_state("disarmed", datetime(2026, 6, 20, 5, 16, 33, tzinfo=UTC)),
+        _mock_state("disarmed", datetime(2026, 6, 22, 13, 13, 48, tzinfo=UTC)),
+        _mock_state("disarmed", datetime(2026, 6, 22, 18, 41, 8, tzinfo=UTC)),
+        _mock_state("disarmed", datetime(2026, 6, 22, 19, 8, 19, tzinfo=UTC)),
+    ]
+    hass = _make_hass(recorder_states)
+
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [_alarm_entity(last_changed="2026-06-22T19:08:19+00:00")]
+
+    await async_enrich_alarm_last_changed(hass, snapshot)
+
+    assert snapshot["entities"][0]["last_changed"] == actual_disarm.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_real_world_with_armed_anchor_in_window() -> None:
+    """Armed record still within recorder window: transition detection finds it directly."""
+    actual_disarm = datetime(2026, 6, 14, 20, 46, 53, tzinfo=UTC)
+    recorder_states = [
+        # Armed record still in the short-term DB (not yet purged).
+        _mock_state("armed_away", datetime(2026, 5, 28, 18, 0, 0, tzinfo=UTC)),
+        # Actual disarm 8 days ago — found via transition detection.
+        _mock_state("disarmed", actual_disarm),
+        # 10 subsequent HA-restart re-reports of "disarmed".
+        _mock_state("disarmed", datetime(2026, 6, 15, 12, 55, 35, tzinfo=UTC)),
+        _mock_state("disarmed", datetime(2026, 6, 15, 19, 28, 37, tzinfo=UTC)),
+        _mock_state("disarmed", datetime(2026, 6, 17, 2, 7, 0, tzinfo=UTC)),
+        _mock_state("disarmed", datetime(2026, 6, 18, 19, 28, 49, tzinfo=UTC)),
+        _mock_state("disarmed", datetime(2026, 6, 19, 12, 33, 50, tzinfo=UTC)),
+        _mock_state("disarmed", datetime(2026, 6, 20, 1, 25, 35, tzinfo=UTC)),
+        _mock_state("disarmed", datetime(2026, 6, 20, 12, 14, 18, tzinfo=UTC)),
+        _mock_state("disarmed", datetime(2026, 6, 20, 12, 16, 33, tzinfo=UTC)),
+        _mock_state("disarmed", datetime(2026, 6, 22, 13, 13, 48, tzinfo=UTC)),
+        _mock_state("disarmed", datetime(2026, 6, 23, 1, 41, 8, tzinfo=UTC)),
+    ]
+    hass = _make_hass(recorder_states)
+
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [_alarm_entity(last_changed="2026-06-23T01:41:08+00:00")]
+
+    await async_enrich_alarm_last_changed(hass, snapshot)
+
+    assert snapshot["entities"][0]["last_changed"] == actual_disarm.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_all_disarmed_beyond_lookback_window() -> None:
+    """Alarm disarmed longer than _LOOKBACK_DAYS: synthetic anchor is also disarmed."""
+    recorder_states = [
+        # Synthetic anchor — alarm was already disarmed before the window started.
+        _mock_state("disarmed", datetime(2026, 5, 1, 10, 0, 0, tzinfo=UTC)),
+        _mock_state("disarmed", datetime(2026, 5, 20, 8, 0, 0, tzinfo=UTC)),
+        _mock_state("disarmed", datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)),
+    ]
+    hass = _make_hass(recorder_states)
+
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [_alarm_entity(last_changed="2026-06-22T05:16:00+00:00")]
+
+    await async_enrich_alarm_last_changed(hass, snapshot)
+
+    assert snapshot["entities"][0]["last_changed"] == ""

--- a/tests/custom_components/home_generative_agent/test_lock_enrichment.py
+++ b/tests/custom_components/home_generative_agent/test_lock_enrichment.py
@@ -1,0 +1,295 @@
+# ruff: noqa: S101
+"""Tests for sentinel lock history enrichment."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.helpers.recorder import DATA_INSTANCE
+
+from custom_components.home_generative_agent.sentinel.lock_enrichment import (
+    async_enrich_lock_last_changed,
+)
+from custom_components.home_generative_agent.snapshot.schema import validate_snapshot
+
+
+def _base_snapshot(**kwargs: Any) -> Any:
+    base: dict[str, Any] = {
+        "schema_version": 1,
+        "generated_at": "2026-06-22T05:16:00+00:00",
+        "entities": [],
+        "camera_activity": [],
+        "derived": {
+            "now": "2026-06-22T05:16:00+00:00",
+            "timezone": "UTC",
+            "is_night": False,
+            "anyone_home": True,
+            "people_home": [],
+            "people_away": [],
+            "last_motion_by_area": {},
+        },
+    }
+    base.update(kwargs)
+    return validate_snapshot(base)
+
+
+def _lock_entity(
+    state: str = "unlocked", last_changed: str = "2026-06-22T05:16:00+00:00"
+) -> dict[str, Any]:
+    return {
+        "entity_id": "lock.garage_door",
+        "domain": "lock",
+        "state": state,
+        "friendly_name": "Garage Door Lock",
+        "area": None,
+        "attributes": {},
+        "last_changed": last_changed,
+        "last_updated": last_changed,
+    }
+
+
+def _mock_state(state: str, last_changed: datetime) -> MagicMock:
+    s = MagicMock()
+    s.state = state
+    s.last_changed = last_changed
+    return s
+
+
+def _make_hass(recorder_states: list[MagicMock] | None = None) -> MagicMock:
+    hass = MagicMock()
+    instance = MagicMock()
+    if recorder_states is not None:
+        instance.async_add_executor_job = AsyncMock(
+            return_value={"lock.garage_door": recorder_states}
+        )
+    else:
+        instance.async_add_executor_job = AsyncMock(return_value={})
+    hass.data = {DATA_INSTANCE: instance}
+    return hass
+
+
+@pytest.mark.asyncio
+async def test_no_recorder_skips_enrichment() -> None:
+    """If recorder isn't loaded, enrichment is a no-op."""
+    hass = MagicMock()
+    hass.data = {}
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [_lock_entity(last_changed="2026-06-22T05:16:00+00:00")]
+
+    await async_enrich_lock_last_changed(hass, snapshot)
+
+    assert snapshot["entities"][0]["last_changed"] == "2026-06-22T05:16:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_no_unlocked_lock_skips_enrichment() -> None:
+    """If no lock is unlocked, no recorder query is made."""
+    hass = MagicMock()
+    instance = MagicMock()
+    instance.async_add_executor_job = AsyncMock()
+    hass.data = {DATA_INSTANCE: instance}
+
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [_lock_entity(state="locked")]
+
+    await async_enrich_lock_last_changed(hass, snapshot)
+
+    instance.async_add_executor_job.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_corrects_startup_reset_direct_unlock() -> None:
+    """Lock unlocked before HA startup (no unavailable) gets last_changed corrected."""
+    actual_unlock = datetime(2026, 6, 20, 10, 0, 0, tzinfo=UTC)
+    ha_startup = datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)
+
+    recorder_states = [
+        _mock_state("locked", datetime(2026, 6, 20, 9, 0, 0, tzinfo=UTC)),
+        _mock_state("unlocked", actual_unlock),
+        _mock_state("unlocked", ha_startup),  # HA restart re-report
+    ]
+    hass = _make_hass(recorder_states)
+
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [_lock_entity(last_changed="2026-06-22T05:16:00+00:00")]
+
+    await async_enrich_lock_last_changed(hass, snapshot)
+
+    assert snapshot["entities"][0]["last_changed"] == actual_unlock.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_corrects_startup_reset_via_unavailable() -> None:
+    """HA restart: unavailable → unlocked re-report; finds true unlock."""
+    actual_unlock = datetime(2026, 6, 20, 10, 0, 0, tzinfo=UTC)
+    ha_startup = datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)
+
+    recorder_states = [
+        _mock_state("locked", datetime(2026, 6, 20, 9, 0, 0, tzinfo=UTC)),
+        _mock_state("unlocked", actual_unlock),
+        _mock_state("unavailable", ha_startup),
+        _mock_state("unlocked", ha_startup),
+    ]
+    hass = _make_hass(recorder_states)
+
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [_lock_entity(last_changed="2026-06-22T05:16:00+00:00")]
+
+    await async_enrich_lock_last_changed(hass, snapshot)
+
+    assert snapshot["entities"][0]["last_changed"] == actual_unlock.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_unlocking_intermediate_state_handled() -> None:
+    """Locked → unlocking → unlocked sequence; true unlock identified correctly."""
+    actual_unlock = datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)
+
+    recorder_states = [
+        _mock_state("locked", datetime(2026, 6, 22, 5, 15, 0, tzinfo=UTC)),
+        _mock_state("unlocking", datetime(2026, 6, 22, 5, 15, 59, tzinfo=UTC)),
+        _mock_state("unlocked", actual_unlock),
+    ]
+    hass = _make_hass(recorder_states)
+
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [_lock_entity(last_changed="2026-06-22T05:16:00+00:00")]
+
+    await async_enrich_lock_last_changed(hass, snapshot)
+
+    # unlocking acts as the non-unlocked anchor; unlocked at actual_unlock is correct
+    assert snapshot["entities"][0]["last_changed"] == "2026-06-22T05:16:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_genuine_unlock_not_changed() -> None:
+    """Lock truly unlocked at startup time; no correction needed."""
+    unlock_time = datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)
+
+    recorder_states = [
+        _mock_state("locked", datetime(2026, 6, 21, 22, 0, 0, tzinfo=UTC)),
+        _mock_state("unlocked", unlock_time),
+    ]
+    hass = _make_hass(recorder_states)
+
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [_lock_entity(last_changed="2026-06-22T05:16:00+00:00")]
+
+    await async_enrich_lock_last_changed(hass, snapshot)
+
+    assert snapshot["entities"][0]["last_changed"] == "2026-06-22T05:16:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_multiple_restarts_finds_original_unlock() -> None:
+    """Multiple HA restarts all re-reporting unlocked; finds first unlock."""
+    original_unlock = datetime(2026, 6, 18, 14, 0, 0, tzinfo=UTC)
+
+    recorder_states = [
+        _mock_state("locked", datetime(2026, 6, 18, 13, 0, 0, tzinfo=UTC)),
+        _mock_state("unlocked", original_unlock),
+        _mock_state("unavailable", datetime(2026, 6, 20, 8, 0, 0, tzinfo=UTC)),
+        _mock_state("unlocked", datetime(2026, 6, 20, 8, 0, 0, tzinfo=UTC)),
+        _mock_state("unavailable", datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)),
+        _mock_state("unlocked", datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)),
+    ]
+    hass = _make_hass(recorder_states)
+
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [_lock_entity(last_changed="2026-06-22T05:16:00+00:00")]
+
+    await async_enrich_lock_last_changed(hass, snapshot)
+
+    assert snapshot["entities"][0]["last_changed"] == original_unlock.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_armed_record_purged_uses_oldest_within_window() -> None:
+    """All records unlocked, locked record purged: uses oldest as best estimate."""
+    oldest_unlock = datetime(2026, 6, 14, 20, 46, 53, tzinfo=UTC)
+
+    recorder_states = [
+        _mock_state("unlocked", oldest_unlock),
+        _mock_state("unlocked", datetime(2026, 6, 15, 12, 0, 0, tzinfo=UTC)),
+        _mock_state("unlocked", datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)),
+    ]
+    hass = _make_hass(recorder_states)
+
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [_lock_entity(last_changed="2026-06-22T05:16:00+00:00")]
+
+    await async_enrich_lock_last_changed(hass, snapshot)
+
+    assert snapshot["entities"][0]["last_changed"] == oldest_unlock.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_all_unlocked_beyond_window_clears_last_changed() -> None:
+    """Synthetic anchor also unlocked (lock open > 30 days): clears last_changed."""
+    recorder_states = [
+        _mock_state(
+            "unlocked", datetime(2026, 5, 1, 10, 0, 0, tzinfo=UTC)
+        ),  # before window
+        _mock_state("unlocked", datetime(2026, 5, 20, 8, 0, 0, tzinfo=UTC)),
+        _mock_state("unlocked", datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)),
+    ]
+    hass = _make_hass(recorder_states)
+
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [_lock_entity(last_changed="2026-06-22T05:16:00+00:00")]
+
+    await async_enrich_lock_last_changed(hass, snapshot)
+
+    assert snapshot["entities"][0]["last_changed"] == ""
+
+
+@pytest.mark.asyncio
+async def test_insufficient_history_leaves_unchanged() -> None:
+    """Fewer than 2 history records → snapshot unchanged."""
+    hass = _make_hass(
+        recorder_states=[
+            _mock_state("unlocked", datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)),
+        ]
+    )
+
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [_lock_entity(last_changed="2026-06-22T05:16:00+00:00")]
+
+    await async_enrich_lock_last_changed(hass, snapshot)
+
+    assert snapshot["entities"][0]["last_changed"] == "2026-06-22T05:16:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_recorder_error_leaves_unchanged() -> None:
+    """Recorder query failure leaves snapshot unchanged."""
+    hass = MagicMock()
+    instance = MagicMock()
+    instance.async_add_executor_job = AsyncMock(side_effect=RuntimeError("db error"))
+    hass.data = {DATA_INSTANCE: instance}
+
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [_lock_entity(last_changed="2026-06-22T05:16:00+00:00")]
+
+    await async_enrich_lock_last_changed(hass, snapshot)
+
+    assert snapshot["entities"][0]["last_changed"] == "2026-06-22T05:16:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_locked_entity_not_enriched() -> None:
+    """Locked (not unlocked) entities are skipped entirely."""
+    hass = MagicMock()
+    instance = MagicMock()
+    instance.async_add_executor_job = AsyncMock()
+    hass.data = {DATA_INSTANCE: instance}
+
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [_lock_entity(state="locked")]
+
+    await async_enrich_lock_last_changed(hass, snapshot)
+
+    instance.async_add_executor_job.assert_not_called()

--- a/tests/custom_components/home_generative_agent/test_lock_enrichment.py
+++ b/tests/custom_components/home_generative_agent/test_lock_enrichment.py
@@ -3,9 +3,9 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.helpers.recorder import DATA_INSTANCE
@@ -14,6 +14,8 @@ from custom_components.home_generative_agent.sentinel.lock_enrichment import (
     async_enrich_lock_last_changed,
 )
 from custom_components.home_generative_agent.snapshot.schema import validate_snapshot
+
+_NOW = datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)
 
 
 def _base_snapshot(**kwargs: Any) -> Any:
@@ -71,6 +73,12 @@ def _make_hass(recorder_states: list[MagicMock] | None = None) -> MagicMock:
     return hass
 
 
+@pytest.fixture(autouse=True)
+def freeze_utcnow():
+    with patch("homeassistant.util.dt.utcnow", return_value=_NOW):
+        yield
+
+
 @pytest.mark.asyncio
 async def test_no_recorder_skips_enrichment() -> None:
     """If recorder isn't loaded, enrichment is a no-op."""
@@ -103,11 +111,11 @@ async def test_no_unlocked_lock_skips_enrichment() -> None:
 @pytest.mark.asyncio
 async def test_corrects_startup_reset_direct_unlock() -> None:
     """Lock unlocked before HA startup (no unavailable) gets last_changed corrected."""
-    actual_unlock = datetime(2026, 6, 20, 10, 0, 0, tzinfo=UTC)
-    ha_startup = datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)
+    actual_unlock = _NOW - timedelta(days=1, hours=19, minutes=16)  # ~June 20 10:00
+    ha_startup = _NOW
 
     recorder_states = [
-        _mock_state("locked", datetime(2026, 6, 20, 9, 0, 0, tzinfo=UTC)),
+        _mock_state("locked", _NOW - timedelta(days=1, hours=20, minutes=16)),
         _mock_state("unlocked", actual_unlock),
         _mock_state("unlocked", ha_startup),  # HA restart re-report
     ]
@@ -124,11 +132,11 @@ async def test_corrects_startup_reset_direct_unlock() -> None:
 @pytest.mark.asyncio
 async def test_corrects_startup_reset_via_unavailable() -> None:
     """HA restart: unavailable → unlocked re-report; finds true unlock."""
-    actual_unlock = datetime(2026, 6, 20, 10, 0, 0, tzinfo=UTC)
-    ha_startup = datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)
+    actual_unlock = _NOW - timedelta(days=1, hours=19, minutes=16)  # ~June 20 10:00
+    ha_startup = _NOW
 
     recorder_states = [
-        _mock_state("locked", datetime(2026, 6, 20, 9, 0, 0, tzinfo=UTC)),
+        _mock_state("locked", _NOW - timedelta(days=1, hours=20, minutes=16)),
         _mock_state("unlocked", actual_unlock),
         _mock_state("unavailable", ha_startup),
         _mock_state("unlocked", ha_startup),
@@ -146,11 +154,11 @@ async def test_corrects_startup_reset_via_unavailable() -> None:
 @pytest.mark.asyncio
 async def test_unlocking_intermediate_state_handled() -> None:
     """Locked → unlocking → unlocked sequence; true unlock identified correctly."""
-    actual_unlock = datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)
+    actual_unlock = _NOW
 
     recorder_states = [
-        _mock_state("locked", datetime(2026, 6, 22, 5, 15, 0, tzinfo=UTC)),
-        _mock_state("unlocking", datetime(2026, 6, 22, 5, 15, 59, tzinfo=UTC)),
+        _mock_state("locked", _NOW - timedelta(minutes=1)),
+        _mock_state("unlocking", _NOW - timedelta(seconds=1)),
         _mock_state("unlocked", actual_unlock),
     ]
     hass = _make_hass(recorder_states)
@@ -167,10 +175,10 @@ async def test_unlocking_intermediate_state_handled() -> None:
 @pytest.mark.asyncio
 async def test_genuine_unlock_not_changed() -> None:
     """Lock truly unlocked at startup time; no correction needed."""
-    unlock_time = datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)
+    unlock_time = _NOW
 
     recorder_states = [
-        _mock_state("locked", datetime(2026, 6, 21, 22, 0, 0, tzinfo=UTC)),
+        _mock_state("locked", _NOW - timedelta(hours=7, minutes=16)),
         _mock_state("unlocked", unlock_time),
     ]
     hass = _make_hass(recorder_states)
@@ -186,15 +194,15 @@ async def test_genuine_unlock_not_changed() -> None:
 @pytest.mark.asyncio
 async def test_multiple_restarts_finds_original_unlock() -> None:
     """Multiple HA restarts all re-reporting unlocked; finds first unlock."""
-    original_unlock = datetime(2026, 6, 18, 14, 0, 0, tzinfo=UTC)
+    original_unlock = _NOW - timedelta(days=3, hours=15, minutes=16)  # ~June 18 14:00
 
     recorder_states = [
-        _mock_state("locked", datetime(2026, 6, 18, 13, 0, 0, tzinfo=UTC)),
+        _mock_state("locked", _NOW - timedelta(days=3, hours=16, minutes=16)),
         _mock_state("unlocked", original_unlock),
-        _mock_state("unavailable", datetime(2026, 6, 20, 8, 0, 0, tzinfo=UTC)),
-        _mock_state("unlocked", datetime(2026, 6, 20, 8, 0, 0, tzinfo=UTC)),
-        _mock_state("unavailable", datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)),
-        _mock_state("unlocked", datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)),
+        _mock_state("unavailable", _NOW - timedelta(days=1, hours=21, minutes=16)),
+        _mock_state("unlocked", _NOW - timedelta(days=1, hours=21, minutes=16)),
+        _mock_state("unavailable", _NOW),
+        _mock_state("unlocked", _NOW),
     ]
     hass = _make_hass(recorder_states)
 
@@ -209,12 +217,12 @@ async def test_multiple_restarts_finds_original_unlock() -> None:
 @pytest.mark.asyncio
 async def test_armed_record_purged_uses_oldest_within_window() -> None:
     """All records unlocked, locked record purged: uses oldest as best estimate."""
-    oldest_unlock = datetime(2026, 6, 14, 20, 46, 53, tzinfo=UTC)
+    oldest_unlock = _NOW - timedelta(days=7, hours=8, minutes=29, seconds=7)
 
     recorder_states = [
         _mock_state("unlocked", oldest_unlock),
-        _mock_state("unlocked", datetime(2026, 6, 15, 12, 0, 0, tzinfo=UTC)),
-        _mock_state("unlocked", datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)),
+        _mock_state("unlocked", _NOW - timedelta(days=6, hours=17, minutes=16)),
+        _mock_state("unlocked", _NOW),
     ]
     hass = _make_hass(recorder_states)
 
@@ -230,11 +238,11 @@ async def test_armed_record_purged_uses_oldest_within_window() -> None:
 async def test_all_unlocked_beyond_window_clears_last_changed() -> None:
     """Synthetic anchor also unlocked (lock open > 30 days): clears last_changed."""
     recorder_states = [
+        _mock_state("unlocked", _NOW - timedelta(days=52)),  # before 30-day window
         _mock_state(
-            "unlocked", datetime(2026, 5, 1, 10, 0, 0, tzinfo=UTC)
-        ),  # before window
-        _mock_state("unlocked", datetime(2026, 5, 20, 8, 0, 0, tzinfo=UTC)),
-        _mock_state("unlocked", datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)),
+            "unlocked", _NOW - timedelta(days=33)
+        ),  # still outside 30-day window
+        _mock_state("unlocked", _NOW),
     ]
     hass = _make_hass(recorder_states)
 
@@ -251,7 +259,7 @@ async def test_insufficient_history_leaves_unchanged() -> None:
     """Fewer than 2 history records → snapshot unchanged."""
     hass = _make_hass(
         recorder_states=[
-            _mock_state("unlocked", datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)),
+            _mock_state("unlocked", _NOW),
         ]
     )
 

--- a/tests/custom_components/home_generative_agent/test_power_enrichment.py
+++ b/tests/custom_components/home_generative_agent/test_power_enrichment.py
@@ -3,9 +3,9 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.helpers.recorder import DATA_INSTANCE
@@ -14,6 +14,8 @@ from custom_components.home_generative_agent.sentinel.power_enrichment import (
     async_enrich_power_last_changed,
 )
 from custom_components.home_generative_agent.snapshot.schema import validate_snapshot
+
+_NOW = datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)
 
 
 def _base_snapshot(**kwargs: Any) -> Any:
@@ -73,6 +75,12 @@ def _make_hass(recorder_states: list[MagicMock] | None = None) -> MagicMock:
     return hass
 
 
+@pytest.fixture(autouse=True)
+def freeze_utcnow():
+    with patch("homeassistant.util.dt.utcnow", return_value=_NOW):
+        yield
+
+
 @pytest.mark.asyncio
 async def test_no_recorder_skips_enrichment() -> None:
     """If recorder isn't loaded, enrichment is a no-op."""
@@ -105,15 +113,14 @@ async def test_off_sensor_skips_enrichment() -> None:
 @pytest.mark.asyncio
 async def test_corrects_startup_reset() -> None:
     """Power sensor 'on' since before restart: corrects last_changed to true on-time."""
-    true_on_time = datetime(2026, 6, 22, 3, 0, 0, tzinfo=UTC)
-    ha_startup = datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)
+    true_on_time = _NOW - timedelta(hours=2, minutes=16)  # ~June 22 03:00
 
     recorder_states = [
-        _mock_state("0.5", datetime(2026, 6, 22, 2, 59, 0, tzinfo=UTC)),  # off
+        _mock_state("0.5", _NOW - timedelta(hours=2, minutes=17)),  # off
         _mock_state("1498.5", true_on_time),  # appliance turned on
-        _mock_state("1501.2", datetime(2026, 6, 22, 4, 0, 0, tzinfo=UTC)),
-        _mock_state("unavailable", ha_startup),
-        _mock_state("1500.1", ha_startup),  # restart re-report
+        _mock_state("1501.2", _NOW - timedelta(hours=1, minutes=16)),
+        _mock_state("unavailable", _NOW),
+        _mock_state("1500.1", _NOW),  # restart re-report
     ]
     hass = _make_hass(recorder_states)
 
@@ -128,12 +135,10 @@ async def test_corrects_startup_reset() -> None:
 @pytest.mark.asyncio
 async def test_genuine_on_since_startup_not_changed() -> None:
     """Appliance genuinely started at HA startup: no correction needed."""
-    startup_and_on = datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)
+    startup_and_on = _NOW
 
     recorder_states = [
-        _mock_state(
-            "0.5", datetime(2026, 6, 22, 5, 15, 0, tzinfo=UTC)
-        ),  # off before startup
+        _mock_state("0.5", _NOW - timedelta(minutes=1)),  # off before startup
         _mock_state("1498.5", startup_and_on),  # actually started at startup
     ]
     hass = _make_hass(recorder_states)
@@ -149,15 +154,15 @@ async def test_genuine_on_since_startup_not_changed() -> None:
 @pytest.mark.asyncio
 async def test_multiple_restarts_finds_true_on_time() -> None:
     """Multiple HA restarts after appliance started: finds original on-time."""
-    true_on_time = datetime(2026, 6, 22, 1, 0, 0, tzinfo=UTC)
+    true_on_time = _NOW - timedelta(hours=4, minutes=16)  # ~June 22 01:00
 
     recorder_states = [
-        _mock_state("0.0", datetime(2026, 6, 22, 0, 59, 0, tzinfo=UTC)),
+        _mock_state("0.0", _NOW - timedelta(hours=4, minutes=17)),
         _mock_state("1498.5", true_on_time),
-        _mock_state("unavailable", datetime(2026, 6, 22, 3, 0, 0, tzinfo=UTC)),
-        _mock_state("1500.0", datetime(2026, 6, 22, 3, 0, 0, tzinfo=UTC)),
-        _mock_state("unavailable", datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)),
-        _mock_state("1499.5", datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)),
+        _mock_state("unavailable", _NOW - timedelta(hours=2, minutes=16)),
+        _mock_state("1500.0", _NOW - timedelta(hours=2, minutes=16)),
+        _mock_state("unavailable", _NOW),
+        _mock_state("1499.5", _NOW),
     ]
     hass = _make_hass(recorder_states)
 
@@ -172,13 +177,13 @@ async def test_multiple_restarts_finds_true_on_time() -> None:
 @pytest.mark.asyncio
 async def test_kw_unit_sensor_corrected() -> None:
     """kW-unit sensor: off threshold applied in native kW units."""
-    true_on_time = datetime(2026, 6, 22, 3, 0, 0, tzinfo=UTC)
+    true_on_time = _NOW - timedelta(hours=2, minutes=16)  # ~June 22 03:00
 
     recorder_states = [
-        _mock_state("0.001", datetime(2026, 6, 22, 2, 59, 0, tzinfo=UTC)),  # 1W — off
+        _mock_state("0.001", _NOW - timedelta(hours=2, minutes=17)),  # 1W — off
         _mock_state("1.498", true_on_time),  # 1498W — on
-        _mock_state("unavailable", datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)),
-        _mock_state("1.500", datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)),
+        _mock_state("unavailable", _NOW),
+        _mock_state("1.500", _NOW),
     ]
     hass = _make_hass(recorder_states)
 
@@ -197,12 +202,12 @@ async def test_kw_unit_sensor_corrected() -> None:
 @pytest.mark.asyncio
 async def test_all_on_within_window_uses_oldest() -> None:
     """No off reading in window: uses oldest within-window record as best estimate."""
-    oldest_on = datetime(2026, 6, 16, 10, 0, 0, tzinfo=UTC)
+    oldest_on = _NOW - timedelta(days=5, hours=19, minutes=16)  # ~June 16 10:00
 
     recorder_states = [
         _mock_state("1498.5", oldest_on),
-        _mock_state("1501.0", datetime(2026, 6, 18, 8, 0, 0, tzinfo=UTC)),
-        _mock_state("1499.8", datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)),
+        _mock_state("1501.0", _NOW - timedelta(days=3, hours=21, minutes=16)),
+        _mock_state("1499.8", _NOW),
     ]
     hass = _make_hass(recorder_states)
 
@@ -218,11 +223,9 @@ async def test_all_on_within_window_uses_oldest() -> None:
 async def test_all_on_beyond_window_leaves_unchanged() -> None:
     """Synthetic anchor also on (appliance on > lookback): last_changed left unchanged."""
     recorder_states = [
-        _mock_state(
-            "1498.5", datetime(2026, 5, 1, 0, 0, 0, tzinfo=UTC)
-        ),  # well before 30-day window
-        _mock_state("1500.0", datetime(2026, 6, 18, 8, 0, 0, tzinfo=UTC)),
-        _mock_state("1499.8", datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)),
+        _mock_state("1498.5", _NOW - timedelta(days=52)),  # before 30-day window
+        _mock_state("1500.0", _NOW - timedelta(days=3, hours=21, minutes=16)),
+        _mock_state("1499.8", _NOW),
     ]
     hass = _make_hass(recorder_states)
 
@@ -256,7 +259,7 @@ async def test_insufficient_history_leaves_unchanged() -> None:
     """Fewer than 2 history records → snapshot unchanged."""
     hass = _make_hass(
         recorder_states=[
-            _mock_state("1498.5", datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)),
+            _mock_state("1498.5", _NOW),
         ]
     )
 

--- a/tests/custom_components/home_generative_agent/test_power_enrichment.py
+++ b/tests/custom_components/home_generative_agent/test_power_enrichment.py
@@ -1,0 +1,295 @@
+# ruff: noqa: S101
+"""Tests for sentinel power sensor history enrichment."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.helpers.recorder import DATA_INSTANCE
+
+from custom_components.home_generative_agent.sentinel.power_enrichment import (
+    async_enrich_power_last_changed,
+)
+from custom_components.home_generative_agent.snapshot.schema import validate_snapshot
+
+
+def _base_snapshot(**kwargs: Any) -> Any:
+    base: dict[str, Any] = {
+        "schema_version": 1,
+        "generated_at": "2026-06-22T05:16:00+00:00",
+        "entities": [],
+        "camera_activity": [],
+        "derived": {
+            "now": "2026-06-22T05:16:00+00:00",
+            "timezone": "UTC",
+            "is_night": False,
+            "anyone_home": True,
+            "people_home": [],
+            "people_away": [],
+            "last_motion_by_area": {},
+        },
+    }
+    base.update(kwargs)
+    return validate_snapshot(base)
+
+
+def _power_entity(
+    state: str = "1498.5",
+    unit: str = "W",
+    last_changed: str = "2026-06-22T05:16:00+00:00",
+) -> dict[str, Any]:
+    return {
+        "entity_id": "sensor.dishwasher_power",
+        "domain": "sensor",
+        "state": state,
+        "friendly_name": "Dishwasher Power",
+        "area": None,
+        "attributes": {"device_class": "power", "unit_of_measurement": unit},
+        "last_changed": last_changed,
+        "last_updated": last_changed,
+    }
+
+
+def _mock_state(state: str, last_changed: datetime) -> MagicMock:
+    s = MagicMock()
+    s.state = state
+    s.last_changed = last_changed
+    return s
+
+
+def _make_hass(recorder_states: list[MagicMock] | None = None) -> MagicMock:
+    hass = MagicMock()
+    instance = MagicMock()
+    if recorder_states is not None:
+        instance.async_add_executor_job = AsyncMock(
+            return_value={"sensor.dishwasher_power": recorder_states}
+        )
+    else:
+        instance.async_add_executor_job = AsyncMock(return_value={})
+    hass.data = {DATA_INSTANCE: instance}
+    return hass
+
+
+@pytest.mark.asyncio
+async def test_no_recorder_skips_enrichment() -> None:
+    """If recorder isn't loaded, enrichment is a no-op."""
+    hass = MagicMock()
+    hass.data = {}
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [_power_entity(last_changed="2026-06-22T05:16:00+00:00")]
+
+    await async_enrich_power_last_changed(hass, snapshot)
+
+    assert snapshot["entities"][0]["last_changed"] == "2026-06-22T05:16:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_off_sensor_skips_enrichment() -> None:
+    """Power sensor below off threshold is not queried."""
+    hass = MagicMock()
+    instance = MagicMock()
+    instance.async_add_executor_job = AsyncMock()
+    hass.data = {DATA_INSTANCE: instance}
+
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [_power_entity(state="2.0")]  # effectively off
+
+    await async_enrich_power_last_changed(hass, snapshot)
+
+    instance.async_add_executor_job.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_corrects_startup_reset() -> None:
+    """Power sensor 'on' since before restart: corrects last_changed to true on-time."""
+    true_on_time = datetime(2026, 6, 22, 3, 0, 0, tzinfo=UTC)
+    ha_startup = datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)
+
+    recorder_states = [
+        _mock_state("0.5", datetime(2026, 6, 22, 2, 59, 0, tzinfo=UTC)),  # off
+        _mock_state("1498.5", true_on_time),  # appliance turned on
+        _mock_state("1501.2", datetime(2026, 6, 22, 4, 0, 0, tzinfo=UTC)),
+        _mock_state("unavailable", ha_startup),
+        _mock_state("1500.1", ha_startup),  # restart re-report
+    ]
+    hass = _make_hass(recorder_states)
+
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [_power_entity(last_changed="2026-06-22T05:16:00+00:00")]
+
+    await async_enrich_power_last_changed(hass, snapshot)
+
+    assert snapshot["entities"][0]["last_changed"] == true_on_time.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_genuine_on_since_startup_not_changed() -> None:
+    """Appliance genuinely started at HA startup: no correction needed."""
+    startup_and_on = datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)
+
+    recorder_states = [
+        _mock_state(
+            "0.5", datetime(2026, 6, 22, 5, 15, 0, tzinfo=UTC)
+        ),  # off before startup
+        _mock_state("1498.5", startup_and_on),  # actually started at startup
+    ]
+    hass = _make_hass(recorder_states)
+
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [_power_entity(last_changed="2026-06-22T05:16:00+00:00")]
+
+    await async_enrich_power_last_changed(hass, snapshot)
+
+    assert snapshot["entities"][0]["last_changed"] == "2026-06-22T05:16:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_multiple_restarts_finds_true_on_time() -> None:
+    """Multiple HA restarts after appliance started: finds original on-time."""
+    true_on_time = datetime(2026, 6, 22, 1, 0, 0, tzinfo=UTC)
+
+    recorder_states = [
+        _mock_state("0.0", datetime(2026, 6, 22, 0, 59, 0, tzinfo=UTC)),
+        _mock_state("1498.5", true_on_time),
+        _mock_state("unavailable", datetime(2026, 6, 22, 3, 0, 0, tzinfo=UTC)),
+        _mock_state("1500.0", datetime(2026, 6, 22, 3, 0, 0, tzinfo=UTC)),
+        _mock_state("unavailable", datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)),
+        _mock_state("1499.5", datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)),
+    ]
+    hass = _make_hass(recorder_states)
+
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [_power_entity(last_changed="2026-06-22T05:16:00+00:00")]
+
+    await async_enrich_power_last_changed(hass, snapshot)
+
+    assert snapshot["entities"][0]["last_changed"] == true_on_time.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_kw_unit_sensor_corrected() -> None:
+    """kW-unit sensor: off threshold applied in native kW units."""
+    true_on_time = datetime(2026, 6, 22, 3, 0, 0, tzinfo=UTC)
+
+    recorder_states = [
+        _mock_state("0.001", datetime(2026, 6, 22, 2, 59, 0, tzinfo=UTC)),  # 1W — off
+        _mock_state("1.498", true_on_time),  # 1498W — on
+        _mock_state("unavailable", datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)),
+        _mock_state("1.500", datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)),
+    ]
+    hass = _make_hass(recorder_states)
+
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [
+        _power_entity(
+            state="1.500", unit="kW", last_changed="2026-06-22T05:16:00+00:00"
+        )
+    ]
+
+    await async_enrich_power_last_changed(hass, snapshot)
+
+    assert snapshot["entities"][0]["last_changed"] == true_on_time.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_all_on_within_window_uses_oldest() -> None:
+    """No off reading in window: uses oldest within-window record as best estimate."""
+    oldest_on = datetime(2026, 6, 16, 10, 0, 0, tzinfo=UTC)
+
+    recorder_states = [
+        _mock_state("1498.5", oldest_on),
+        _mock_state("1501.0", datetime(2026, 6, 18, 8, 0, 0, tzinfo=UTC)),
+        _mock_state("1499.8", datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)),
+    ]
+    hass = _make_hass(recorder_states)
+
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [_power_entity(last_changed="2026-06-22T05:16:00+00:00")]
+
+    await async_enrich_power_last_changed(hass, snapshot)
+
+    assert snapshot["entities"][0]["last_changed"] == oldest_on.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_all_on_beyond_window_leaves_unchanged() -> None:
+    """Synthetic anchor also on (appliance on > lookback): last_changed left unchanged."""
+    recorder_states = [
+        _mock_state(
+            "1498.5", datetime(2026, 5, 1, 0, 0, 0, tzinfo=UTC)
+        ),  # well before 30-day window
+        _mock_state("1500.0", datetime(2026, 6, 18, 8, 0, 0, tzinfo=UTC)),
+        _mock_state("1499.8", datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)),
+    ]
+    hass = _make_hass(recorder_states)
+
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [_power_entity(last_changed="2026-06-22T05:16:00+00:00")]
+
+    await async_enrich_power_last_changed(hass, snapshot)
+
+    # Cannot determine true on-since beyond lookback window; leave unchanged
+    assert snapshot["entities"][0]["last_changed"] == "2026-06-22T05:16:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_recorder_error_leaves_unchanged() -> None:
+    """Recorder query failure leaves snapshot unchanged."""
+    hass = MagicMock()
+    instance = MagicMock()
+    instance.async_add_executor_job = AsyncMock(side_effect=RuntimeError("db error"))
+    hass.data = {DATA_INSTANCE: instance}
+
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [_power_entity(last_changed="2026-06-22T05:16:00+00:00")]
+
+    await async_enrich_power_last_changed(hass, snapshot)
+
+    assert snapshot["entities"][0]["last_changed"] == "2026-06-22T05:16:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_insufficient_history_leaves_unchanged() -> None:
+    """Fewer than 2 history records → snapshot unchanged."""
+    hass = _make_hass(
+        recorder_states=[
+            _mock_state("1498.5", datetime(2026, 6, 22, 5, 16, 0, tzinfo=UTC)),
+        ]
+    )
+
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [_power_entity(last_changed="2026-06-22T05:16:00+00:00")]
+
+    await async_enrich_power_last_changed(hass, snapshot)
+
+    assert snapshot["entities"][0]["last_changed"] == "2026-06-22T05:16:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_non_power_sensor_not_enriched() -> None:
+    """Non-power sensor domain is not enriched."""
+    hass = MagicMock()
+    instance = MagicMock()
+    instance.async_add_executor_job = AsyncMock()
+    hass.data = {DATA_INSTANCE: instance}
+
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [
+        {
+            "entity_id": "sensor.temperature",
+            "domain": "sensor",
+            "state": "21.5",
+            "friendly_name": "Temperature",
+            "area": None,
+            "attributes": {"device_class": "temperature", "unit_of_measurement": "°C"},
+            "last_changed": "2026-06-22T05:16:00+00:00",
+            "last_updated": "2026-06-22T05:16:00+00:00",
+        }
+    ]
+
+    await async_enrich_power_last_changed(hass, snapshot)
+
+    instance.async_add_executor_job.assert_not_called()


### PR DESCRIPTION
## Problem

When Home Assistant restarts, entities re-report their current state with a new `last_changed` stamped at startup time rather than when the state actually changed. Three Sentinel notification categories were computing falsely short durations as a result:

- **Alarm panel**: "Alarm disarmed since 5:16 AM" — when it was actually disarmed 8 days ago
- **Lock**: "Garage door lock has been unlocked for about 15 minutes" — when it had been unlocked for days
- **Appliance power sensors**: "Dishwasher has been running for 5 minutes" — when it started 2 hours ago

Additionally, disarm timestamps showed time-only ("1:46 PM") without a date — confusing when the disarm was days ago.

## Solution

**Recorder-based enrichment** queries 30 days of HA recorder history before rule evaluation, finds the true state-change transition, and corrects `last_changed` in the snapshot.

### New files

- **`sentinel/alarm_enrichment.py`** — Refactored with 30-day date-range query (replacing count-based `get_last_state_changes`). Finds the last `armed_*→disarmed` transition, skipping `unavailable`/`unknown` transient states. Falls back to oldest within-window disarmed record when the armed record was purged from the DB; clears `last_changed` to `""` when even the oldest record predates the 30-day window (alarm has been disarmed >30 days).

- **`sentinel/lock_enrichment.py`** — Same pattern for unlocked lock entities. Finds the last `non-unlocked→unlocked` transition (handles `locked`, `locking`, `unlocking`, `jammed` as anchors). Same fallback/clear logic.

- **`sentinel/power_enrichment.py`** — For power sensors currently above 10 W, finds the last `off→on` transition. Handles both W and kW units. Leaves `last_changed` unchanged (rather than clearing) when no useful transition can be found.

### Modified files

- **`sentinel/engine.py`** — Calls all three enrichments in sequence after snapshot build, before rule evaluation.

- **`sentinel/notifier.py`** — Adds `_format_disarm_since()` helper that prepends a date ("14 Jun at 1:46 PM") when the disarm was on a different calendar day than today, shows time-only for same-day disarms.

- **`sentinel/dynamic_rules.py`** — Lock evidence uses `lock.get("last_changed") or None` so an empty-string `last_changed` (set by enrichment when lock has been open >30 days) propagates as `None` to LLM context rather than an empty string.

## Test plan

- [x] 37 new/updated tests across three test files (14 alarm, 12 lock, 11 power)
- [x] Covers: no-recorder skip, transient-state handling, startup re-report correction, genuine at-startup transitions (no change), multiple restarts, kW unit conversion, all-on/all-disarmed within window (fallback to oldest), beyond 30-day window (fallback/clear), purged records, recorder errors, insufficient history
- [x] `make lint` clean
- [x] Full test suite passes (1295 tests)
- [x] Verified in production — debug logs confirm all three enrichments correctly identifying true transition timestamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)