### PR TITLE
v3.14.29 feat: add gemma3:4b as tested Ollama VLM option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.14.29] - 2026-07-13
+
+### Added
+
+- **`gemma3:4b` is now a selectable Ollama VLM for Camera Image Analysis** — listed alongside `qwen2.5vl:7b` and `qwen3-vl:8b` in the VLM model dropdown. Tested for caption stability: across repeated captions of identical frames it reproduces the same core scene with only cosmetic wording differences, which is what the semantic notification dedup in `notify_on_anomaly` mode depends on. A lighter option than the 7B/8B models for smaller GPUs (requires Ollama 0.6+; on iGPUs consider lowering the VLM context size, since the 32k default dominates memory use regardless of model size). Docs updated to reflect that a stable 4B model is now a viable choice. Closes [#469](https://github.com/goruck/home-generative-agent/issues/469). Credit to @andymcmanus for the caption-consistency benchmarking on an AMD Radeon 780M iGPU that motivated this.
+
 ## [3.14.28] - 2026-07-12
 
 ### Added

--- a/custom_components/home_generative_agent/const.py
+++ b/custom_components/home_generative_agent/const.py
@@ -394,7 +394,7 @@ RECOMMENDED_MAX_MESSAGES_IN_CONTEXT = 60
 
 # ---------------- VLM (vision) ----------------
 VLM_TOP_P = 1.0
-VLM_OLLAMA_SUPPORTED = Literal["qwen2.5vl:7b", "qwen3-vl:8b"]
+VLM_OLLAMA_SUPPORTED = Literal["qwen2.5vl:7b", "qwen3-vl:8b", "gemma3:4b"]
 VLM_OPENAI_SUPPORTED = Literal["gpt-5-nano", "gpt-4.1", "gpt-4.1-nano"]
 VLM_GEMINI_SUPPORTED = Literal[
     "gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite"

--- a/custom_components/home_generative_agent/manifest.json
+++ b/custom_components/home_generative_agent/manifest.json
@@ -34,5 +34,5 @@
     "langchain-google-genai==3.1.0",
     "langchain-anthropic==1.4.3"
   ],
-  "version": "3.14.28"
+  "version": "3.14.29"
 }

--- a/docs/camera-entities.md
+++ b/docs/camera-entities.md
@@ -196,7 +196,7 @@ Active only in `notify_on_anomaly` mode. Repeated low-value notifications are su
 
 Semantic deduplication in `notify_on_anomaly` mode depends on the VLM producing **consistent captions** for the same scene. If two snapshots of an unchanged porch are described differently, the similarity score will be low and every frame will appear novel — resulting in a notification per snapshot.
 
-Small models like `moondream` are too inconsistent for reliable dedup. Use at minimum a **7B-class vision model** such as `qwen2.5vl:7b` (recommended) or `llava:7b`. The default Ollama VLM model is `qwen3-vl:8b`.
+Small models like `moondream` are too inconsistent for reliable dedup. Use a model with tested caption stability: `gemma3:4b` (the smallest tested option — reproduces the same core scene across repeated captions of identical frames) or a **7B-class vision model** such as `qwen2.5vl:7b`. The default Ollama VLM model is `qwen3-vl:8b`.
 
 If you are using `always_notify` mode, VLM consistency affects caption quality but not notification volume.
 

--- a/docs/constants.md
+++ b/docs/constants.md
@@ -91,7 +91,7 @@ This document covers the named constants that affect integration behaviour, orga
 
 | Constant | Allowed values |
 |---|---|
-| `VLM_OLLAMA_SUPPORTED` | `qwen2.5vl:7b`, `qwen3-vl:8b` |
+| `VLM_OLLAMA_SUPPORTED` | `qwen2.5vl:7b`, `qwen3-vl:8b`, `gemma3:4b` |
 | `VLM_OPENAI_SUPPORTED` | `gpt-5-nano`, `gpt-4.1`, `gpt-4.1-nano` |
 | `VLM_GEMINI_SUPPORTED` | `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite` |
 | `VLM_ANTHROPIC_SUPPORTED` | `claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5-20251001` |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -72,6 +72,7 @@ Run models locally for lower cost and latency.
   ollama pull qwen3:1.7b         # summarization (lighter)
   ollama pull qwen3-vl:8b        # vision (VLM)
   ollama pull qwen2.5vl:7b       # vision alternative
+  ollama pull gemma3:4b          # vision alternative (lighter; needs Ollama 0.6+)
   ollama pull mxbai-embed-large  # embeddings
   ```
 

--- a/tests/custom_components/home_generative_agent/test_subentries.py
+++ b/tests/custom_components/home_generative_agent/test_subentries.py
@@ -834,6 +834,16 @@ def test_provider_capabilities_includes_openai_compatible() -> None:
         )
 
 
+def test_vlm_ollama_supported_models() -> None:
+    """Curated Ollama VLM options include the tested models (issue #469)."""
+    vlm_ollama = MODEL_CATEGORY_SPECS["vlm"]["providers"]["ollama"]
+    assert "qwen2.5vl:7b" in vlm_ollama
+    assert "qwen3-vl:8b" in vlm_ollama
+    assert "gemma3:4b" in vlm_ollama
+    recommended = MODEL_CATEGORY_SPECS["vlm"]["recommended_models"]["ollama"]
+    assert recommended in vlm_ollama
+
+
 # ---------------------------------------------------------------------------
 # Sentinel subentry — daily digest fields (Fix 4)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

**Camera Image Analysis**
- Adds `gemma3:4b` to `VLM_OLLAMA_SUPPORTED`, making it selectable in the VLM model dropdown. Based on @andymcmanus's benchmarking in #469: across 12 captions of two fixed frames (night/IR and daytime) on an AMD Radeon 780M iGPU, gemma3:4b reproduced the same core scene every time with only cosmetic wording differences, while moondream drifted on identical bytes. Caption stability is what the semantic notification dedup in `notify_on_anomaly` mode depends on.
- No special-casing needed elsewhere: the reasoning heuristic in `core/utils.py` correctly treats gemma3 as non-reasoning, model names are not enumerated in translations, and stored config values are never validated against the Literal (change is purely additive — no migration risk).

**Docs**
- `docs/camera-entities.md`: VLM quality guidance now names `gemma3:4b` as the smallest tested option (the previous "at minimum 7B-class" claim is contradicted by the issue's findings).
- `docs/installation.md`: added the pull command with an Ollama 0.6+ note.
- `docs/constants.md`: updated the `VLM_OLLAMA_SUPPORTED` allowed-values row.

## Test Coverage

No new code paths — the change adds one value to a Literal consumed by the existing model-category registry. Added `test_vlm_ollama_supported_models` guarding the curated list and the recommended-model invariant (adversarial review flagged that nothing previously pinned the dropdown contents).

Tests: 1320 → 1321 (+1 new). Full suite passes; `make lint` clean.

## Pre-Landing Review

No issues found. Enum-completeness trace: the only consumer keyed by model names outside `const.py` is the Ollama reasoning heuristic, which handles gemma3 correctly by fallthrough.

## Adversarial Review

Claude subagent + Codex (gpt-5.5) both ran. Substantive findings are all pre-existing and tracked in a follow-up issue (linked below) per maintainer decision:
1. An un-pulled Ollama model raises `ollama.ResponseError`, which escapes the `HomeAssistantError`-only catches and permanently kills that camera's snapshot worker (no respawn) — silent failure until reload.
2. The video path force-sends `think: false` even to non-thinking models, bypassing `reasoning_field()`.
3. When Ollama is reachable, the live dropdown lists all pulled models unfiltered by vision capability (e.g. text-only `gemma3:1b` selectable as VLM).

Verified non-issues: no config migration risk, no reasoning-tag collision, token counting falls back to approximate for unknown Ollama models.

## Plan Completion

No plan file — direct issue-to-PR change.

Closes #469

## Test plan
- [x] Full pytest suite passes (1321 passed)
- [x] `make lint` clean (ruff format + check, manifest requirements verified current)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014oPJfkdFaMRVP2KTFdZSHm