### PR TITLE
Defer video analyzer startup tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.14.31] - 2026-07-13
+
+### Fixed
+
+- **Video analyzer no longer delays Home Assistant startup when cameras are already active** — motion/recording snapshot loops could start during HGA config-entry setup, so Home Assistant counted long-lived `_motion_snapshot_loop()` tasks and in-flight `camera.snapshot` calls as startup work. On busy camera systems this produced bootstrap warnings and delayed startup until HA timed out waiting on those tasks. The video analyzer now starts after `EVENT_HOMEASSISTANT_STARTED`, and its snapshot loops/workers are created as HA background tasks so they do not block startup accounting. Runtime motion/recording behavior after startup is unchanged.
+
 ## [3.14.30] - 2026-07-13
 
 ### Fixed

--- a/custom_components/home_generative_agent/__init__.py
+++ b/custom_components/home_generative_agent/__init__.py
@@ -2709,7 +2709,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: HGAConfigEntry) -> bool:
         hass.async_create_task(_log_ollama_server_info(hass, ollama_probe_urls))
 
     if options.get(CONF_VIDEO_ANALYZER_MODE) != "disable":
-        video_analyzer.start()
+        if hass.is_running:
+            video_analyzer.start()
+        else:
+
+            def _start_video_analyzer(_event: object) -> None:
+                hass.loop.call_soon_threadsafe(video_analyzer.start)
+
+            hass.bus.async_listen_once(
+                EVENT_HOMEASSISTANT_STARTED, _start_video_analyzer
+            )
     if options.get(CONF_SENTINEL_ENABLED, RECOMMENDED_SENTINEL_ENABLED):
         if hass.is_running:
             sentinel.start()

--- a/custom_components/home_generative_agent/core/video_analyzer.py
+++ b/custom_components/home_generative_agent/core/video_analyzer.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from pathlib import Path
 from time import monotonic
-from typing import TYPE_CHECKING, Final, Literal
+from typing import TYPE_CHECKING, Any, Final, Literal, cast
 from urllib.parse import urljoin
 
 import aiofiles
@@ -84,7 +84,7 @@ from .video_helpers import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable
+    from collections.abc import Callable, Coroutine, Iterable
 
     from homeassistant.core import Event, HomeAssistant
 
@@ -253,10 +253,10 @@ class VideoAnalyzer:
         self.entry = entry
         self._snapshot_queues: dict[str, asyncio.Queue[_SnapshotItem]] = {}
         self._retention_deques: dict[str, deque[Path]] = {}
-        self._active_queue_tasks: dict[str, asyncio.Task] = {}
+        self._active_queue_tasks: dict[str, asyncio.Task[Any]] = {}
         self._initialized_dirs: set[str] = set()
-        self._active_motion_cameras: dict[str, asyncio.Task] = {}
-        self._active_recording_cameras: dict[str, asyncio.Task] = {}
+        self._active_motion_cameras: dict[str, asyncio.Task[Any]] = {}
+        self._active_recording_cameras: dict[str, asyncio.Task[Any]] = {}
         # Frames captured during a motion/recording window, held out of the
         # live worker queue until the event ends and they flush as one batch.
         self._event_snapshot_buffers: dict[str, deque[Path]] = {}
@@ -374,9 +374,23 @@ class VideoAnalyzer:
         if camera_id not in self._snapshot_queues:
             queue: asyncio.Queue[_SnapshotItem] = asyncio.Queue(maxsize=_QUEUE_MAXSIZE)
             self._snapshot_queues[camera_id] = queue
-            task = self.hass.async_create_task(self._snapshot_worker(camera_id))
+            task = self._create_background_task(
+                self._snapshot_worker(camera_id),
+                f"hga video snapshot worker {camera_id}",
+            )
             self._active_queue_tasks[camera_id] = task
         return self._snapshot_queues[camera_id]
+
+    def _create_background_task(
+        self,
+        target: Coroutine[Any, Any, object],
+        name: str,
+    ) -> asyncio.Task[Any]:
+        """Create a task that must not hold Home Assistant startup open."""
+        task = self.hass.async_create_background_task(target, name)
+        if not isinstance(task, asyncio.Task):
+            target.close()
+        return cast("asyncio.Task[Any]", task)
 
     async def _get_batch(
         self,
@@ -1466,8 +1480,9 @@ class VideoAnalyzer:
                 rec_task.cancel()
             if camera_id not in self._active_motion_cameras:
                 LOGGER.debug("Motion ON: Starting snapshot loop for %s", camera_id)
-                task = self.hass.async_create_task(
+                task = self._create_background_task(
                     self._motion_snapshot_loop(camera_id),
+                    f"hga video motion snapshot loop {camera_id}",
                 )
                 self._active_motion_cameras[camera_id] = task
 
@@ -1476,7 +1491,10 @@ class VideoAnalyzer:
             task = self._active_motion_cameras.pop(camera_id, None)
             if task and not task.done():
                 task.cancel()
-                self.hass.async_create_task(self._process_snapshot_queue(camera_id))
+                self._create_background_task(
+                    self._process_snapshot_queue(camera_id),
+                    f"hga video process motion queue {camera_id}",
+                )
 
     @callback
     def _get_recording_cameras(self) -> list[str]:
@@ -1528,15 +1546,19 @@ class VideoAnalyzer:
                 LOGGER.debug(
                     "[%s] Recording started: starting snapshot loop", entity_id
                 )
-                task = self.hass.async_create_task(
-                    self._motion_snapshot_loop(entity_id)
+                task = self._create_background_task(
+                    self._motion_snapshot_loop(entity_id),
+                    f"hga video recording snapshot loop {entity_id}",
                 )
                 self._active_recording_cameras[entity_id] = task
         elif was_recording and not is_recording:
             task = self._active_recording_cameras.pop(entity_id, None)
             if task and not task.done():
                 task.cancel()
-            self.hass.async_create_task(self._process_snapshot_queue(entity_id))
+            self._create_background_task(
+                self._process_snapshot_queue(entity_id),
+                f"hga video process recording queue {entity_id}",
+            )
 
     def start(self) -> None:
         """Start the video analyzer."""
@@ -1594,7 +1616,7 @@ class VideoAnalyzer:
             LOGGER.warning("VideoAnalyzer not started.")
             return
 
-        tasks_to_await: list[asyncio.Task] = []
+        tasks_to_await: list[asyncio.Task[Any]] = []
 
         for task_dict in (
             self._active_motion_cameras,

--- a/custom_components/home_generative_agent/manifest.json
+++ b/custom_components/home_generative_agent/manifest.json
@@ -34,5 +34,5 @@
     "langchain-google-genai==3.1.0",
     "langchain-anthropic==1.4.3"
   ],
-  "version": "3.14.30"
+  "version": "3.14.31"
 }


### PR DESCRIPTION
## Summary
- defer VideoAnalyzer startup until Home Assistant has fired EVENT_HOMEASSISTANT_STARTED
- create video analyzer loops/workers as Home Assistant background tasks so they do not block startup accounting
- keep motion/recording snapshot processing behavior unchanged after startup

## Validation
- hga/bin/ruff check custom_components/home_generative_agent/core/video_analyzer.py custom_components/home_generative_agent/__init__.py
- hga/bin/pyright custom_components/home_generative_agent/core/video_analyzer.py custom_components/home_generative_agent/__init__.py
- make test (1329 passed)