### PR TITLE
v3.14.32 fix: Sentinel LLM layers survive provider errors (closes #465)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.14.32] - 2026-07-13
+
+### Fixed
+
+- **Sentinel Discovery no longer dies silently on LLM provider errors** — a provider error during the discovery LLM call (e.g. `ollama.ResponseError` when the configured model isn't pulled, or an httpx transport failure while the Ollama server restarts) escaped the narrow exception handling and permanently killed the discovery background loop; no proposals were ever produced again until an integration reload, with the error only surfacing if the task was cancelled mid-call at unload. Provider errors are now caught and logged (rate-limited, with recovery messages), and the discovery loop itself is additionally guarded so no unexpected error in any cycle stage can end it — mirroring the snapshot-worker resilience fix from #473. The same narrow-catch escape is fixed in LLM triage (which now truly fails open to notify on any exception, as documented) and LLM explanations (which degrade to the deterministic fallback text). Discovery audit payloads now also record the actually-configured model name (previously always `unknown` for bound models), making model misconfiguration diagnosable from the Sentinel audit trail. Note: discovery was already using the configured chat model — the model selection reported in the issue could not be reproduced, but the silent-failure mode it described is real and fixed. Closes [#465](https://github.com/goruck/home-generative-agent/issues/465).
+
 ## [3.14.31] - 2026-07-13
 
 ### Fixed

--- a/custom_components/home_generative_agent/explain/llm_explain.py
+++ b/custom_components/home_generative_agent/explain/llm_explain.py
@@ -73,7 +73,10 @@ class LLMExplainer:
                 _EXPLAIN_LLM_TIMEOUT_S,
             )
             return None
-        except (ValueError, TypeError, RuntimeError) as err:
+        except Exception as err:  # noqa: BLE001
+            # Provider errors (e.g. ollama.ResponseError, httpx transport
+            # failures) do not subclass the families above; explanations are
+            # best-effort, so any failure degrades to None (issue #465).
             LOGGER.warning("LLM explanation failed: %s", err)
             return None
 

--- a/custom_components/home_generative_agent/manifest.json
+++ b/custom_components/home_generative_agent/manifest.json
@@ -34,5 +34,5 @@
     "langchain-google-genai==3.1.0",
     "langchain-anthropic==1.4.3"
   ],
-  "version": "3.14.31"
+  "version": "3.14.32"
 }

--- a/custom_components/home_generative_agent/sentinel/discovery_engine.py
+++ b/custom_components/home_generative_agent/sentinel/discovery_engine.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import logging
 import re
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, cast
 
 import voluptuous as vol
@@ -182,7 +183,22 @@ class SentinelDiscoveryEngine:
             self._options.get(CONF_SENTINEL_DISCOVERY_INTERVAL_SECONDS), default=3600
         )
         while not self._stop_event.is_set():
-            await self._run_once_guarded()
+            try:
+                await self._run_once_guarded()
+            except Exception:  # noqa: BLE001
+                # A dead loop silently disables discovery until the
+                # integration reloads (issue #465); drop the cycle and
+                # keep the loop alive.
+                self._log_limiter.warning(
+                    "cycle_error",
+                    "Discovery cycle failed unexpectedly; will retry next interval.",
+                    exc_info=True,
+                )
+            else:
+                self._log_limiter.recovered(
+                    "cycle_error",
+                    "Discovery cycle recovered after %d failed cycle(s).",
+                )
             try:
                 await asyncio.wait_for(self._stop_event.wait(), timeout=interval)
             except TimeoutError:
@@ -344,7 +360,11 @@ class SentinelDiscoveryEngine:
                 _DISCOVERY_LLM_TIMEOUT_S,
             )
             return
-        except (ValueError, TypeError, RuntimeError) as err:
+        except Exception as err:  # noqa: BLE001
+            # Provider errors (e.g. ollama.ResponseError for an un-pulled
+            # model, httpx transport failures) do not subclass the usual
+            # ValueError/RuntimeError families; a narrow catch here let them
+            # escape and kill the discovery loop (issue #465).
             self._log_limiter.warning(
                 "llm_call",
                 "Discovery LLM call failed: %s",
@@ -372,7 +392,7 @@ class SentinelDiscoveryEngine:
 
         payload.setdefault("schema_version", DISCOVERY_SCHEMA_VERSION)
         payload.setdefault("generated_at", now)
-        payload.setdefault("model", str(getattr(self._model, "model", "unknown")))
+        payload.setdefault("model", _resolved_model_name(self._model))
 
         try:
             validated = cast("dict[str, Any]", DISCOVERY_OUTPUT_SCHEMA(payload))
@@ -659,6 +679,28 @@ def _singularize_token(token: str) -> str:
     if len(token) > _MIN_PLURAL_TOKEN_LENGTH and token.endswith("s"):
         return token[:-1]
     return token
+
+
+def _resolved_model_name(model: Any) -> str:
+    """
+    Best-effort name of the model a runnable will actually invoke.
+
+    Models arrive here as bound runnables (``.with_config(...)``) whose
+    effective model lives in the binding's configurable section; raw chat
+    models expose it as a ``model`` attribute. Recording the resolved name
+    in discovery payloads makes model misconfiguration diagnosable from the
+    audit trail (issue #465).
+    """
+    config = getattr(model, "config", None)
+    if isinstance(config, Mapping):
+        configurable = config.get("configurable")
+        if isinstance(configurable, Mapping):
+            for key in ("model", "model_name"):
+                name = configurable.get(key)
+                if name:
+                    return str(name)
+    name = getattr(model, "model", None)
+    return str(name) if name else "unknown"
 
 
 def _coerce_int(value: object | None, default: int) -> int:

--- a/custom_components/home_generative_agent/sentinel/discovery_engine.py
+++ b/custom_components/home_generative_agent/sentinel/discovery_engine.py
@@ -686,10 +686,12 @@ def _resolved_model_name(model: Any) -> str:
     Best-effort name of the model a runnable will actually invoke.
 
     Models arrive here as bound runnables (``.with_config(...)``) whose
-    effective model lives in the binding's configurable section; raw chat
-    models expose it as a ``model`` attribute. Recording the resolved name
-    in discovery payloads makes model misconfiguration diagnosable from the
-    audit trail (issue #465).
+    effective model lives in the binding's configurable section; fallback
+    wrappers (``FallbackChatModel``) carry an empty wrapper config and expose
+    the bound per-provider models via ``chain``, whose first member is the
+    primary selected at setup; raw chat models expose a ``model`` attribute.
+    Recording the resolved name in discovery payloads makes model
+    misconfiguration diagnosable from the audit trail (issue #465).
     """
     config = getattr(model, "config", None)
     if isinstance(config, Mapping):
@@ -699,6 +701,11 @@ def _resolved_model_name(model: Any) -> str:
                 name = configurable.get(key)
                 if name:
                     return str(name)
+    chain = getattr(model, "chain", None)
+    if isinstance(chain, list) and chain:
+        first = chain[0]
+        if isinstance(first, tuple) and first:
+            return _resolved_model_name(first[0])
     name = getattr(model, "model", None)
     return str(name) if name else "unknown"
 

--- a/custom_components/home_generative_agent/sentinel/triage.py
+++ b/custom_components/home_generative_agent/sentinel/triage.py
@@ -202,7 +202,11 @@ class SentinelTriageService:
                 triage_confidence=None,
                 summary="Triage timed out; defaulting to notify.",
             )
-        except (ValueError, TypeError, RuntimeError, OSError) as err:
+        except Exception as err:  # noqa: BLE001
+            # Fail-open must hold for *any* exception: provider errors such
+            # as ollama.ResponseError (un-pulled model) or httpx transport
+            # failures do not subclass the families above, and an escaped
+            # error here would abort finding processing (issue #465).
             self._log_limiter.warning(
                 "llm_call",
                 "Triage LLM call failed: %s; failing open to notify.",

--- a/tests/custom_components/home_generative_agent/test_sentinel_llm_error_resilience.py
+++ b/tests/custom_components/home_generative_agent/test_sentinel_llm_error_resilience.py
@@ -20,6 +20,7 @@ from ollama import ResponseError as OllamaResponseError
 from custom_components.home_generative_agent.const import (
     CONF_SENTINEL_DISCOVERY_INTERVAL_SECONDS,
 )
+from custom_components.home_generative_agent.core.fallback import FallbackChatModel
 from custom_components.home_generative_agent.explain.llm_explain import LLMExplainer
 from custom_components.home_generative_agent.sentinel.discovery_engine import (
     SentinelDiscoveryEngine,
@@ -217,6 +218,21 @@ def test_resolved_model_name_from_bound_runnable_config() -> None:
 def test_resolved_model_name_prefers_model_name_key_for_openai_style() -> None:
     bound = SimpleNamespace(config={"configurable": {"model_name": "gpt-4o-mini"}})
     assert _resolved_model_name(bound) == "gpt-4o-mini"
+
+
+def test_resolved_model_name_from_fallback_chain_primary() -> None:
+    """A FallbackChatModel's empty wrapper config must not hide the primary."""
+    primary = SimpleNamespace(config={"configurable": {"model": "qwen3:8b"}})
+    fallback = SimpleNamespace(config={"configurable": {"model": "gpt-4o-mini"}})
+    wrapper = FallbackChatModel(
+        [(primary, "edge", "provider-1"), (fallback, "cloud", "provider-2")]
+    )
+    assert _resolved_model_name(wrapper) == "qwen3:8b"
+
+
+def test_resolved_model_name_from_empty_fallback_chain() -> None:
+    wrapper = FallbackChatModel([])
+    assert _resolved_model_name(wrapper) == "unknown"
 
 
 def test_resolved_model_name_from_raw_chat_model_attribute() -> None:

--- a/tests/custom_components/home_generative_agent/test_sentinel_llm_error_resilience.py
+++ b/tests/custom_components/home_generative_agent/test_sentinel_llm_error_resilience.py
@@ -1,0 +1,228 @@
+# ruff: noqa: S101
+"""
+Sentinel LLM layers must survive provider errors (issue #465).
+
+``ollama.ResponseError`` (e.g. an un-pulled model returning 404) and httpx
+transport errors subclass ``Exception`` directly, not the ValueError /
+RuntimeError families the Sentinel layers used to catch.  An escaped error
+permanently killed the discovery loop and broke triage's fail-open contract.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from ollama import ResponseError as OllamaResponseError
+
+from custom_components.home_generative_agent.const import (
+    CONF_SENTINEL_DISCOVERY_INTERVAL_SECONDS,
+)
+from custom_components.home_generative_agent.explain.llm_explain import LLMExplainer
+from custom_components.home_generative_agent.sentinel.discovery_engine import (
+    SentinelDiscoveryEngine,
+    _resolved_model_name,
+)
+from custom_components.home_generative_agent.sentinel.models import AnomalyFinding
+from custom_components.home_generative_agent.sentinel.triage import (
+    TRIAGE_NOTIFY,
+    TRIAGE_REASON_ERROR,
+    SentinelTriageService,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+    from custom_components.home_generative_agent.sentinel.discovery_store import (
+        DiscoveryStore,
+    )
+    from custom_components.home_generative_agent.snapshot.schema import (
+        FullStateSnapshot,
+    )
+
+_SNAPSHOT: dict[str, Any] = {
+    "entities": [],
+    "camera_activity": [],
+    "derived": {"is_night": False, "now": "2026-01-01T00:00:00Z"},
+    "generated_at": "2026-01-01T00:00:00Z",
+}
+
+
+class _DummyStore:
+    async def async_get_latest(self, _limit: int) -> list[dict[str, Any]]:
+        return []
+
+    async def async_append(self, _payload: Any) -> None:
+        pass
+
+
+def _finding() -> AnomalyFinding:
+    return AnomalyFinding(
+        anomaly_id="test-id-1",
+        type="open_entry_while_away",
+        severity="medium",
+        confidence=0.8,
+        triggering_entities=["binary_sensor.front_door"],
+        evidence={},
+        suggested_actions=["lock_door"],
+        is_sensitive=False,
+    )
+
+
+def _triage_snapshot() -> FullStateSnapshot:
+    return cast(
+        "FullStateSnapshot",
+        {
+            "schema_version": 1,
+            "generated_at": "2026-01-01T00:00:00+00:00",
+            "entities": [],
+            "camera_activity": [],
+            "derived": {
+                "now": "2026-01-01T10:00:00+00:00",
+                "timezone": "UTC",
+                "is_night": False,
+                "anyone_home": False,
+                "people_home": [],
+                "people_away": [],
+                "last_motion_by_area": {},
+            },
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Discovery: provider error in the LLM call must not escape _run_once
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_discovery_run_once_survives_provider_error(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An ollama.ResponseError from the model call is logged, not raised."""
+    engine = SentinelDiscoveryEngine(
+        hass=hass,
+        options={},
+        model=object(),
+        store=cast("DiscoveryStore", _DummyStore()),
+    )
+
+    with (
+        patch.object(
+            engine,
+            "_existing_semantic_context",
+            new_callable=AsyncMock,
+            return_value=(set(), set(), set()),
+        ),
+        patch(
+            "custom_components.home_generative_agent.sentinel.discovery_engine.async_build_full_state_snapshot",
+            new_callable=AsyncMock,
+            return_value=dict(_SNAPSHOT),
+        ),
+        patch(
+            "custom_components.home_generative_agent.sentinel.discovery_engine.run_sentinel_model_call",
+            side_effect=OllamaResponseError("model 'gpt-oss' not found", 404),
+        ),
+    ):
+        await engine._run_once()
+
+    assert "Discovery LLM call failed" in caplog.text
+    assert "gpt-oss" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Discovery: the loop itself must survive any unexpected cycle error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_discovery_loop_survives_unexpected_cycle_error(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A cycle that raises must not end the loop; the next cycle still runs."""
+    engine = SentinelDiscoveryEngine(
+        hass=hass,
+        options={CONF_SENTINEL_DISCOVERY_INTERVAL_SECONDS: 0},
+        model=object(),
+        store=cast("DiscoveryStore", _DummyStore()),
+    )
+    calls = 0
+
+    async def _run_once() -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            msg = "model 'gpt-oss' not found"
+            raise OllamaResponseError(msg, 404)
+        engine._stop_event.set()
+
+    with patch.object(engine, "_run_once", side_effect=_run_once):
+        await engine._run_loop()
+
+    assert calls == 2, "Loop died after the first failing cycle"
+    assert "Discovery cycle failed unexpectedly" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Triage: fail-open must hold for provider errors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_triage_fails_open_on_provider_error() -> None:
+    """A provider error must produce a notify decision, not an exception."""
+    svc = SentinelTriageService(object())
+    with patch(
+        "custom_components.home_generative_agent.sentinel.triage.run_sentinel_model_call",
+        side_effect=OllamaResponseError("model 'gpt-oss' not found", 404),
+    ):
+        result = await svc.triage(_finding(), _triage_snapshot())
+
+    assert result.decision == TRIAGE_NOTIFY
+    assert result.reason_code == TRIAGE_REASON_ERROR
+
+
+# ---------------------------------------------------------------------------
+# Explain: provider errors degrade to None
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_explain_returns_none_on_provider_error() -> None:
+    """A provider error must return None instead of raising."""
+    explainer = LLMExplainer(object())
+    with patch(
+        "custom_components.home_generative_agent.explain.llm_explain.run_sentinel_model_call",
+        side_effect=OllamaResponseError("model 'gpt-oss' not found", 404),
+    ):
+        result = await explainer.async_explain(_finding())
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Discovery payload records the actually-configured model name
+# ---------------------------------------------------------------------------
+
+
+def test_resolved_model_name_from_bound_runnable_config() -> None:
+    """A with_config() binding exposes the effective model via configurable."""
+    bound = SimpleNamespace(config={"configurable": {"model": "qwen3:8b"}})
+    assert _resolved_model_name(bound) == "qwen3:8b"
+
+
+def test_resolved_model_name_prefers_model_name_key_for_openai_style() -> None:
+    bound = SimpleNamespace(config={"configurable": {"model_name": "gpt-4o-mini"}})
+    assert _resolved_model_name(bound) == "gpt-4o-mini"
+
+
+def test_resolved_model_name_from_raw_chat_model_attribute() -> None:
+    raw = SimpleNamespace(model="gpt-oss")
+    assert _resolved_model_name(raw) == "gpt-oss"
+
+
+def test_resolved_model_name_unknown_fallback() -> None:
+    assert _resolved_model_name(object()) == "unknown"


### PR DESCRIPTION
## Summary

Fixes #465 — Sentinel Discovery failed silently on every cycle, producing no proposals, with the error only surfacing when the integration was unloaded mid-call.

**Root cause:** provider errors such as `ollama.ResponseError` (un-pulled model → 404) and httpx transport failures subclass `Exception` directly, so the narrow `except (ValueError, TypeError, RuntimeError)` handlers in all three Sentinel LLM layers let them escape. This is the same bug class as #473 (snapshot-worker death, fixed in #474), on the Sentinel side:

- **Discovery** (`sentinel/discovery_engine.py`): an escaped provider error propagated out of `_run_once` and permanently killed the `_run_loop` background task — no proposals until reload. The LLM call now catches any exception (rate-limited warning + recovery log), and the loop iteration itself is additionally guarded so no unexpected error in any cycle stage can end the loop, mirroring the #474 worker pattern.
- **Triage** (`sentinel/triage.py`): the documented "fails open on any exception" contract now actually holds — an escaped provider error previously aborted finding processing in the engine.
- **Explain** (`explain/llm_explain.py`): any failure degrades to `None` / deterministic fallback text.

**Observability:** discovery audit payloads now record the actually-resolved model name from the bound runnable's configurable section via `_resolved_model_name()` (previously always `"unknown"` for bound models), so model misconfiguration is diagnosable from the Sentinel audit trail.

**Note on the issue's model-selection claim:** discovery already invokes the user's configured chat model — it receives the same `chat_model` binding as triage and explain, and the full resolution path (subentry resolver → provider construction → fallback chains) offers no route to the hardcoded `gpt-oss` default. The claim could not be reproduced; the silent-failure mode the issue describes is real and is what this PR fixes. A regression test locks in the model-name resolution behavior.

## Changes

- `sentinel/discovery_engine.py`: broad catch at the LLM call site; loop-iteration guard with rate-limited `cycle_error` logging + recovery message; `_resolved_model_name()` helper used for the audit payload's `model` field
- `sentinel/triage.py`: broaden the LLM-call catch so fail-open holds for any exception
- `explain/llm_explain.py`: broaden the LLM-call catch; explanations degrade to fallback text
- `tests/…/test_sentinel_llm_error_resilience.py`: 8 new tests — `_run_once` survives `ollama.ResponseError`, `_run_loop` survives a failing cycle and keeps running, triage fails open, explain returns `None`, and model-name resolution for bound/raw/unknown models
- CHANGELOG entry and version bump to 3.14.32

## Testing

- `make lint` clean
- `make test`: 1337 passed (8 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014oPJfkdFaMRVP2KTFdZSHm