### PR TITLE
v3.14.34 fix: surface camera snapshot capture failures with cause, metric, and escalation (#464)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.14.34] - 2026-07-14
+
+### Fixed
+
+- **Camera snapshot failures are no longer silent or undiagnosable** — when a snapshot never landed on disk, the only evidence was a generic "Snapshot failed to appear on disk" warning: the `camera.snapshot` service was dispatched fire-and-forget, so the actual error (camera unavailable, write failure, disallowed path) vanished, and the analysis for that event was dropped with no metric or escalation. The service is now called blocking under a 15-second budget, producing three distinguishable diagnostics — the service call failed (logged with the underlying error), the call timed out (camera unresponsive), or the call succeeded but the file never appeared (points at a media mount/permissions problem). Failures count toward a new `snapshot_failures` field in the hourly per-camera metrics line, and three consecutive failures on the same camera escalate the log from WARNING to ERROR so a camera that stops producing snapshots is visible instead of quietly dark. A per-camera in-flight guard also prevents the 1.5s recording poll from stacking overlapping snapshot calls on a slow or wedged camera. The two root causes suspected in the original report were fixed in 3.14.30 (un-pulled Ollama VLM killing the snapshot worker) and 3.14.31 (startup race after reload); this closes the remaining observability gap. Thanks [@andymcmanus](https://github.com/andymcmanus) for the detailed report. Closes [#464](https://github.com/goruck/home-generative-agent/issues/464).
+
 ## [3.14.33] - 2026-07-14
 
 ### Fixed

--- a/custom_components/home_generative_agent/core/video_analyzer.py
+++ b/custom_components/home_generative_agent/core/video_analyzer.py
@@ -106,6 +106,10 @@ _VIDEO_QUEUE_BACKLOG_THRESHOLD: Final[int] = (
     2  # drop stale frames when queue exceeds this
 )
 _WORKER_ERROR_BACKOFF_SEC: Final[int] = 5  # pause after unexpected worker error
+# --- Snapshot capture (issue #464) ---
+_SNAPSHOT_SERVICE_TIMEOUT_SEC: Final[int] = 15  # camera.snapshot blocking-call budget
+_SNAPSHOT_APPEAR_ATTEMPTS: Final[int] = 10  # post-service file visibility polls (0.2s)
+_SNAPSHOT_FAILURE_ESCALATION: Final[int] = 3  # consecutive failures before ERROR log
 # --- Uniqueness gate tuning ---
 # Enabled at runtime via CONF_VIDEO_ANALYZER_UNIQUENESS_ENABLED option (default off).
 _UNIQUENESS_HAMMING_MAX: Final[int] = 4  # <= this => "too similar" (tune 4-10)
@@ -238,6 +242,7 @@ class _Metrics:
     analyzed: int = 0
     timeouts: int = 0
     semaphore_timeouts: int = 0
+    snapshot_failures: int = 0
     # PEP 585: deque is subscriptable; keep in a field to avoid shared default
     lat_ms: deque[float] = field(
         default_factory=lambda: deque(maxlen=_METRICS_LAT_HISTORY)
@@ -272,6 +277,12 @@ class VideoAnalyzer:
         ] = {}  # camera_id -> monotonic() of last accepted
         # Per-camera counters and latency samples
         self._metrics: dict[str, _Metrics] = defaultdict(_Metrics)
+        # camera_id -> consecutive capture failures (issue #464 escalation)
+        self._snapshot_fail_streak: dict[str, int] = {}
+        # Cameras with a capture in flight: the 1.5s recording poll doesn't
+        # wait for the previous tick, so a wedged camera holding the blocking
+        # camera.snapshot call must not accumulate overlapping calls.
+        self._snapshot_inflight: set[str] = set()
         self._metrics_job_cancel: Callable[[], None] | None = (
             None  # hourly report handle
         )
@@ -309,9 +320,29 @@ class VideoAnalyzer:
             m.timeouts += n
         elif key == "semaphore_timeout":
             m.semaphore_timeouts += n
+        elif key == "snapshot_failures":
+            m.snapshot_failures += n
         else:
             # ignore unknown keys silently to avoid noisy logs in prod
             return
+
+    def _record_snapshot_failure(self, camera_id: str, reason: str) -> None:
+        """
+        Count a failed snapshot capture and log it with its cause.
+
+        Repeated consecutive failures escalate from WARNING to ERROR so a
+        camera that silently stops producing snapshots is visible (issue #464).
+        """
+        self._m_inc(camera_id, "snapshot_failures")
+        streak = self._snapshot_fail_streak.get(camera_id, 0) + 1
+        self._snapshot_fail_streak[camera_id] = streak
+        log = LOGGER.error if streak >= _SNAPSHOT_FAILURE_ESCALATION else LOGGER.warning
+        log(
+            "[%s] Snapshot capture failed (%d consecutive): %s",
+            camera_id,
+            streak,
+            reason,
+        )
 
     def _m_add_latency(self, camera_id: str, ms: float) -> None:
         """Record a single latency sample in milliseconds."""
@@ -328,7 +359,7 @@ class VideoAnalyzer:
                 "[%s] Metrics (last interval): "
                 "captured=%d enqueued=%d skipped_duplicate=%d "
                 "dropped_stale=%d dropped_backlog=%d analyzed=%d "
-                "timeouts=%d semaphore_timeouts=%d "
+                "timeouts=%d semaphore_timeouts=%d snapshot_failures=%d "
                 "avg_latency_ms=%.1f p95_latency_ms=%.1f"
             )
             LOGGER.info(
@@ -342,6 +373,7 @@ class VideoAnalyzer:
                 m.analyzed,
                 m.timeouts,
                 m.semaphore_timeouts,
+                m.snapshot_failures,
                 avg_ms,
                 p95_ms,
             )
@@ -355,6 +387,7 @@ class VideoAnalyzer:
             m.analyzed = 0
             m.timeouts = 0
             m.semaphore_timeouts = 0
+            m.snapshot_failures = 0
             m.lat_ms.clear()
 
     def protect_notify_image(self, p: Path, ttl_sec: int = 1800) -> None:
@@ -1367,86 +1400,117 @@ class VideoAnalyzer:
     async def _take_single_snapshot(
         self, camera_id: str, now: datetime, *, hold_for_batch: bool = False
     ) -> Path | None:
+        if camera_id in self._snapshot_inflight:
+            LOGGER.debug(
+                "[%s] Skipping snapshot — previous capture still in flight.",
+                camera_id,
+            )
+            return None
+        self._snapshot_inflight.add(camera_id)
+        try:
+            return await self._capture_snapshot(
+                camera_id, now, hold_for_batch=hold_for_batch
+            )
+        finally:
+            self._snapshot_inflight.discard(camera_id)
+
+    async def _capture_snapshot(
+        self, camera_id: str, now: datetime, *, hold_for_batch: bool = False
+    ) -> Path | None:
         snapshot_dir = await self._get_snapshot_dir(camera_id)
         timestamp = dt_util.as_local(now).strftime("%Y%m%d_%H%M%S")
         path = snapshot_dir / f"snapshot_{timestamp}.jpg"
 
+        start_time = dt_util.utcnow()
+        LOGGER.debug("[%s] Initiating snapshot at %s", camera_id, start_time)
+
+        # Blocking call so platform errors (camera unavailable, disallowed
+        # path, write failure) surface here instead of vanishing in a
+        # fire-and-forget dispatch (issue #464).
         try:
-            start_time = dt_util.utcnow()
-            LOGGER.debug("[%s] Initiating snapshot at %s", camera_id, start_time)
-
-            await self.hass.services.async_call(
-                CAMERA_DOMAIN,
-                "snapshot",
-                {"entity_id": camera_id, "filename": str(path)},
-                blocking=False,
-            )
-            LOGGER.debug("[%s] Snapshot service call completed.", camera_id)
-
-            for i in range(50):
-                exists = await self.hass.async_add_executor_job(path.exists)
-                if exists:
-                    LOGGER.debug(
-                        "[%s] Snapshot appeared after %.2f s.",
-                        camera_id,
-                        (dt_util.utcnow() - start_time).total_seconds(),
-                    )
-                    break
-                await asyncio.sleep(0.2)
-                LOGGER.debug(
-                    "[%s] Waiting for snapshot to appear... attempt %d",
-                    camera_id,
-                    i + 1,
+            async with asyncio.timeout(_SNAPSHOT_SERVICE_TIMEOUT_SEC):
+                await self.hass.services.async_call(
+                    CAMERA_DOMAIN,
+                    "snapshot",
+                    {"entity_id": camera_id, "filename": str(path)},
+                    blocking=True,
                 )
-            else:
-                LOGGER.warning(
-                    "[%s] Snapshot failed to appear on disk after waiting: %s",
-                    camera_id,
-                    path,
-                )
-                return None
-
-            self._m_inc(camera_id, "captured")
-
-            # --- Uniqueness gate: skip near-duplicate frames unless heartbeat due ---
-            try:
-                should_enqueue = await self._is_unique_enough(camera_id, path)
-            except (OSError, FileNotFoundError, ValueError):
-                should_enqueue = True  # fail-open
-
-            if not should_enqueue:
-                self._m_inc(camera_id, "skipped_duplicate")
-                LOGGER.debug(
-                    "[%s] Skipping enqueue (near-duplicate): %s", camera_id, path
-                )
-                return None
-
-            if hold_for_batch:
-                # Motion/recording loop owns this camera: hold the frame until
-                # the event ends so the whole window flushes as one batch,
-                # instead of the live worker analyzing (and notifying) per frame.
-                buffer = self._event_snapshot_buffers.setdefault(
-                    camera_id, deque(maxlen=_QUEUE_MAXSIZE)
-                )
-                buffer.append(path)  # deque drops oldest when full
-            else:
-                queue = self._get_snapshot_queue(camera_id)
-                await put_with_backpressure(
-                    queue, _SnapshotItem(path=path, enqueued=monotonic())
-                )
-            self._m_inc(camera_id, "enqueued")
-            LOGGER.debug(
-                "[%s] Enqueue t=%s held=%s %s",
+        except TimeoutError:
+            self._record_snapshot_failure(
                 camera_id,
-                dt_util.utcnow().isoformat(),
-                hold_for_batch,
-                path,
+                f"camera.snapshot did not complete within "
+                f"{_SNAPSHOT_SERVICE_TIMEOUT_SEC}s "
+                f"(camera unresponsive or service wedged): {path}",
             )
+            return None
         except HomeAssistantError as err:
-            LOGGER.warning("Snapshot failed for %s: %s", camera_id, err)
+            self._record_snapshot_failure(
+                camera_id, f"camera.snapshot service call failed: {err}"
+            )
+            return None
+        LOGGER.debug("[%s] Snapshot service call completed.", camera_id)
+
+        # The service writes the file before returning, so it normally exists
+        # on the first check; poll briefly to absorb filesystem lag.
+        for i in range(_SNAPSHOT_APPEAR_ATTEMPTS):
+            exists = await self.hass.async_add_executor_job(path.exists)
+            if exists:
+                LOGGER.debug(
+                    "[%s] Snapshot appeared after %.2f s.",
+                    camera_id,
+                    (dt_util.utcnow() - start_time).total_seconds(),
+                )
+                break
+            await asyncio.sleep(0.2)
+            LOGGER.debug(
+                "[%s] Waiting for snapshot to appear... attempt %d",
+                camera_id,
+                i + 1,
+            )
         else:
-            return path
-        return None
+            self._record_snapshot_failure(
+                camera_id,
+                f"camera.snapshot succeeded but the file never appeared on "
+                f"disk (check the media mount and permissions): {path}",
+            )
+            return None
+
+        self._m_inc(camera_id, "captured")
+        self._snapshot_fail_streak.pop(camera_id, None)
+
+        # --- Uniqueness gate: skip near-duplicate frames unless heartbeat due ---
+        try:
+            should_enqueue = await self._is_unique_enough(camera_id, path)
+        except (OSError, FileNotFoundError, ValueError):
+            should_enqueue = True  # fail-open
+
+        if not should_enqueue:
+            self._m_inc(camera_id, "skipped_duplicate")
+            LOGGER.debug("[%s] Skipping enqueue (near-duplicate): %s", camera_id, path)
+            return None
+
+        if hold_for_batch:
+            # Motion/recording loop owns this camera: hold the frame until
+            # the event ends so the whole window flushes as one batch,
+            # instead of the live worker analyzing (and notifying) per frame.
+            buffer = self._event_snapshot_buffers.setdefault(
+                camera_id, deque(maxlen=_QUEUE_MAXSIZE)
+            )
+            buffer.append(path)  # deque drops oldest when full
+        else:
+            queue = self._get_snapshot_queue(camera_id)
+            await put_with_backpressure(
+                queue, _SnapshotItem(path=path, enqueued=monotonic())
+            )
+        self._m_inc(camera_id, "enqueued")
+        LOGGER.debug(
+            "[%s] Enqueue t=%s held=%s %s",
+            camera_id,
+            dt_util.utcnow().isoformat(),
+            hold_for_batch,
+            path,
+        )
+        return path
 
     async def _motion_snapshot_loop(self, camera_id: str) -> None:
         try:

--- a/custom_components/home_generative_agent/manifest.json
+++ b/custom_components/home_generative_agent/manifest.json
@@ -34,5 +34,5 @@
     "langchain-google-genai==3.1.0",
     "langchain-anthropic==1.4.3"
   ],
-  "version": "3.14.33"
+  "version": "3.14.34"
 }

--- a/tests/custom_components/home_generative_agent/test_video_analyzer_priority.py
+++ b/tests/custom_components/home_generative_agent/test_video_analyzer_priority.py
@@ -25,6 +25,9 @@ Covers (test plan items):
 - _resolve_camera_from_motion: direct match, VMD strip, _motion strip (Reolink + Ring-MQTT), no match, override precedence
 - Event lifecycle: motion-held snapshots are not analyzed until the OFF/exit
   flush, which processes the whole window as one ordered batch
+- Snapshot capture failure visibility (issue #464): camera.snapshot is called
+  blocking, service errors/timeouts/missing files are counted and logged with
+  a cause, and repeated consecutive failures escalate to ERROR then reset
 """
 
 from __future__ import annotations
@@ -41,6 +44,7 @@ from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from homeassistant.exceptions import HomeAssistantError
 from ollama import ResponseError as OllamaResponseError
 
 import custom_components.home_generative_agent as hga_mod
@@ -1178,3 +1182,201 @@ async def test_process_snapshot_swallows_ollama_response_error(
         )
 
     assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# Snapshot capture failure visibility (issue #464)
+# ---------------------------------------------------------------------------
+
+_VA_LOGGER = "custom_components.home_generative_agent.core.video_analyzer"
+
+
+@pytest.mark.asyncio
+async def test_snapshot_service_call_is_blocking(
+    va: VideoAnalyzer, tmp_path: Path
+) -> None:
+    """camera.snapshot is called blocking so platform errors surface."""
+    mock_dir = _prepare_snapshot_capture(va, tmp_path)
+    cast("MagicMock", va.hass).async_create_task = MagicMock(
+        side_effect=lambda coro: (coro.close(), MagicMock())[1]  # type: ignore[no-any-return]
+    )
+
+    with patch.object(va, "_get_snapshot_dir", new=mock_dir):
+        now = datetime(2025, 1, 1, 12, 0, 0, tzinfo=dt.UTC)
+        path = await va._take_single_snapshot("camera.test", now)  # type: ignore[attr-defined]
+
+    assert path is not None
+    call_kwargs = cast("MagicMock", va.hass.services.async_call).call_args.kwargs
+    assert call_kwargs["blocking"] is True
+
+
+@pytest.mark.asyncio
+async def test_snapshot_service_error_counted_and_logged(
+    va: VideoAnalyzer,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A failing camera.snapshot call is counted and logged with its cause."""
+    camera_id = "camera.test"
+    mock_dir = _prepare_snapshot_capture(va, tmp_path)
+    cast("MagicMock", va.hass).services.async_call = AsyncMock(
+        side_effect=HomeAssistantError("Camera is unavailable")
+    )
+
+    with (
+        patch.object(va, "_get_snapshot_dir", new=mock_dir),
+        caplog.at_level(logging.WARNING, logger=_VA_LOGGER),
+    ):
+        now = datetime(2025, 1, 1, 12, 0, 0, tzinfo=dt.UTC)
+        path = await va._take_single_snapshot(camera_id, now)  # type: ignore[attr-defined]
+
+    assert path is None
+    assert va._metrics[camera_id].snapshot_failures == 1  # type: ignore[attr-defined]
+    messages = [r.message for r in caplog.records]
+    assert any(
+        "service call failed" in m and "Camera is unavailable" in m for m in messages
+    )
+
+
+@pytest.mark.asyncio
+async def test_snapshot_service_timeout_counted_and_logged(
+    va: VideoAnalyzer,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A wedged camera.snapshot call times out, is counted, and is logged."""
+    camera_id = "camera.test"
+    mock_dir = _prepare_snapshot_capture(va, tmp_path)
+    monkeypatch.setattr(va_mod, "_SNAPSHOT_SERVICE_TIMEOUT_SEC", 0.01)
+
+    async def wedged_call(*_args: object, **_kwargs: object) -> None:
+        await asyncio.sleep(5)
+
+    cast("MagicMock", va.hass).services.async_call = wedged_call
+
+    with (
+        patch.object(va, "_get_snapshot_dir", new=mock_dir),
+        caplog.at_level(logging.WARNING, logger=_VA_LOGGER),
+    ):
+        now = datetime(2025, 1, 1, 12, 0, 0, tzinfo=dt.UTC)
+        path = await va._take_single_snapshot(camera_id, now)  # type: ignore[attr-defined]
+
+    assert path is None
+    assert va._metrics[camera_id].snapshot_failures == 1  # type: ignore[attr-defined]
+    assert any("did not complete" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_snapshot_missing_file_counted_and_logged(
+    va: VideoAnalyzer,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Service success without a file on disk is counted and diagnosed."""
+    camera_id = "camera.test"
+    mock_dir = _prepare_snapshot_capture(va, tmp_path)
+    # File never appears despite the service call succeeding.
+    cast("MagicMock", va.hass).async_add_executor_job = AsyncMock(return_value=False)
+    monkeypatch.setattr(va_mod, "_SNAPSHOT_APPEAR_ATTEMPTS", 1)
+
+    with (
+        patch.object(va, "_get_snapshot_dir", new=mock_dir),
+        caplog.at_level(logging.WARNING, logger=_VA_LOGGER),
+    ):
+        now = datetime(2025, 1, 1, 12, 0, 0, tzinfo=dt.UTC)
+        path = await va._take_single_snapshot(camera_id, now)  # type: ignore[attr-defined]
+
+    assert path is None
+    assert va._metrics[camera_id].snapshot_failures == 1  # type: ignore[attr-defined]
+    assert any("never appeared on disk" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_snapshot_failure_streak_escalates_then_resets(
+    va: VideoAnalyzer,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Three consecutive failures escalate to ERROR; a success resets the streak."""
+    camera_id = "camera.test"
+    mock_dir = _prepare_snapshot_capture(va, tmp_path)
+    mock_hass = cast("MagicMock", va.hass)
+    mock_hass.services.async_call = AsyncMock(side_effect=HomeAssistantError("down"))
+
+    with (
+        patch.object(va, "_get_snapshot_dir", new=mock_dir),
+        caplog.at_level(logging.WARNING, logger=_VA_LOGGER),
+    ):
+        base = datetime(2025, 1, 1, 12, 0, 0, tzinfo=dt.UTC)
+        for i in range(3):
+            await va._take_single_snapshot(  # type: ignore[attr-defined]
+                camera_id, base + dt.timedelta(seconds=i)
+            )
+
+    failure_levels = [
+        r.levelno for r in caplog.records if "Snapshot capture failed" in r.message
+    ]
+    assert failure_levels == [logging.WARNING, logging.WARNING, logging.ERROR]
+    assert va._snapshot_fail_streak[camera_id] == 3  # type: ignore[attr-defined]
+
+    # A subsequent successful capture resets the streak.
+    mock_hass.services.async_call = AsyncMock()
+    mock_hass.async_add_executor_job = AsyncMock(return_value=True)
+    mock_hass.async_create_task = MagicMock(
+        side_effect=lambda coro: (coro.close(), MagicMock())[1]  # type: ignore[no-any-return]
+    )
+    with patch.object(va, "_get_snapshot_dir", new=mock_dir):
+        path = await va._take_single_snapshot(  # type: ignore[attr-defined]
+            camera_id, datetime(2025, 1, 1, 12, 1, 0, tzinfo=dt.UTC)
+        )
+
+    assert path is not None
+    assert camera_id not in va._snapshot_fail_streak  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_snapshot_inflight_guard_prevents_overlap(
+    va: VideoAnalyzer, tmp_path: Path
+) -> None:
+    """A second capture for the same camera is skipped while one is in flight."""
+    camera_id = "camera.test"
+    mock_dir = _prepare_snapshot_capture(va, tmp_path)
+    mock_hass = cast("MagicMock", va.hass)
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def slow_call(*_args: object, **_kwargs: object) -> None:
+        started.set()
+        await release.wait()
+
+    mock_hass.services.async_call = slow_call
+    mock_hass.async_create_task = MagicMock(
+        side_effect=lambda coro: (coro.close(), MagicMock())[1]  # type: ignore[no-any-return]
+    )
+
+    with patch.object(va, "_get_snapshot_dir", new=mock_dir):
+        now = datetime(2025, 1, 1, 12, 0, 0, tzinfo=dt.UTC)
+        first = asyncio.create_task(
+            va._take_single_snapshot(camera_id, now)  # type: ignore[attr-defined]
+        )
+        await started.wait()
+
+        # Overlapping tick for the same camera: skipped, no second service call.
+        overlap = await va._take_single_snapshot(camera_id, now)  # type: ignore[attr-defined]
+        assert overlap is None
+
+        release.set()
+        path = await first
+
+    assert path is not None
+    assert camera_id not in va._snapshot_inflight  # type: ignore[attr-defined]
+
+    # Guard is released: a fresh capture goes through again.
+    mock_hass.services.async_call = AsyncMock()
+    with patch.object(va, "_get_snapshot_dir", new=mock_dir):
+        again = await va._take_single_snapshot(  # type: ignore[attr-defined]
+            camera_id, datetime(2025, 1, 1, 12, 0, 1, tzinfo=dt.UTC)
+        )
+    assert again is not None


### PR DESCRIPTION
## Summary

Fixes the remaining defect in #464: camera snapshot failures were **silent and undiagnosable**. The two root causes suspected by the reporter were already fixed (v3.14.30: un-pulled Ollama VLM killing the snapshot worker; v3.14.31: startup race after reload), but the observability gap the issue leads with was still in the code — `camera.snapshot` was dispatched with `blocking=False`, so when the service itself failed, the error vanished and all the user got was a bare `Snapshot failed to appear on disk` WARNING, with the analysis for that event dropped.

**Failure visibility** (`core/video_analyzer.py`, `_take_single_snapshot`):
- `camera.snapshot` is now called **blocking** under a 15s `asyncio.timeout`, producing three distinguishable diagnostics that directly answer the reporter's "was the write attempted and failed, or never attempted?" question:
  - service call failed → logged with the underlying `HomeAssistantError`
  - service call timed out → camera unresponsive or service wedged
  - service succeeded but file never appeared → media mount/permissions problem
- New `snapshot_failures` counter in the hourly per-camera metrics report.
- Per-camera consecutive-failure streak escalates WARNING → ERROR at 3 consecutive failures; a successful capture resets it. A camera that quietly stops producing snapshots is now loud.
- Post-service file poll cut from 10s to 2s — the blocking call already covers the write.

**Robustness (adversarial review finding):**
- Per-camera in-flight guard: the 1.5s recording poll (`async_track_time_interval`) doesn't wait for the previous tick, so a wedged camera holding the blocking call could stack overlapping `camera.snapshot` service calls and inflate the failure streak. Overlapping ticks for a camera with a capture in flight are now skipped.

## Test Coverage

6 new tests in `test_video_analyzer_priority.py`:
- `camera.snapshot` is called with `blocking=True`
- Service error is counted in `snapshot_failures` and logged with its cause
- Service timeout is counted and logged distinctly
- Service success with no file on disk is counted and diagnosed distinctly
- Three consecutive failures escalate WARNING → ERROR; a success resets the streak
- In-flight guard skips an overlapping capture and releases afterward

Full suite: **1364 passed**. `make lint` clean, pyright 0 errors.

## Pre-Landing Review

Codex adversarial review found the recording-poll overlap issue (fixed above, High). Two further findings assessed as pre-existing behavior, out of scope:
- `path.exists()` accepted as capture success without content validation (empty/corrupt file) — unchanged from prior behavior; timestamped paths make stale-file collision improbable, and the uniqueness gate deliberately fails open.
- Success-path unit tests mock the executor rather than writing real files — established pattern in this test file; the new tests target control flow.

## Plan Completion

No plan file — direct issue fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014oPJfkdFaMRVP2KTFdZSHm