### PR TITLE
v3.19.0 fix: localizable Basic/Advanced setup step + Czech translation (#494)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.19.0] - 2026-07-19
+
+### Added
+
+- **Czech translation** — the entire configuration UI (setup flows, Sentinel options, error messages, selectors) is now available in Czech. The new `cs` translation has full key parity with the English source, verified by tests that also guard every translation file against key drift, placeholder mismatches, and formatting Home Assistant would reject. Contributed by [@hruba202](https://github.com/hruba202). Closes [#494](https://github.com/goruck/home-generative-agent/issues/494).
+
+### Fixed
+
+- **The Basic/Advanced setup step can now actually be localized** — the "Basic setup"/"Advanced setup" choice labels and the "already configured — Basic setup will overwrite your settings" warning on the Feature and Sentinel setup screens were hardcoded English strings in Python, so they stayed English in every language even though the title and description on the very same form translated correctly. The labels now go through Home Assistant's standard selector translation mechanism (each language's frontend shows its own labels), and the warning text is loaded from the integration's translation files following the server-configured language, falling back to English if a translation is missing. Reported, diagnosed, and drafted by [@hruba202](https://github.com/hruba202) in [#494](https://github.com/goruck/home-generative-agent/issues/494).
+
 ## [3.18.2] - 2026-07-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ You can now open the HA Assist panel and start talking to your home.
 | [Sentinel](docs/sentinel.md) | Anomaly detection pipeline, built-in rules, triage, baseline, blueprints, notification quiet hours, services API, health sensor |
 | [Camera Entities](docs/camera-entities.md) | Image and sensor entities, dashboards, automations, proactive video analysis, face recognition |
 | [Architecture](docs/architecture.md) | LangGraph agent, model tiers, context management, streaming, latency, tools |
-| [Contributing](docs/contributing.md) | Dev setup, Makefile reference, dependency workflow |
+| [Contributing](docs/contributing.md) | Dev setup, Makefile reference, dependency workflow, translations |
 
 ## More Examples
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ You can now open the HA Assist panel and start talking to your home.
 | Guide | Contents |
 | --- | --- |
 | [Installation](docs/installation.md) | HACS install, manual install, optional apps (Ollama, face recognition) |
-| [Configuration](docs/configuration.md) | Model providers, features, Tool Retrieval (RAG), LLM API, STT, YAML mode, Critical Action PIN |
+| [Configuration](docs/configuration.md) | Model providers, features, Tool Retrieval (RAG), LLM API, STT, YAML mode, Critical Action PIN, UI languages (en/cs/ru/tr) |
 | [Sentinel](docs/sentinel.md) | Anomaly detection pipeline, built-in rules, triage, baseline, blueprints, notification quiet hours, services API, health sensor |
 | [Camera Entities](docs/camera-entities.md) | Image and sensor entities, dashboards, automations, proactive video analysis, face recognition |
 | [Architecture](docs/architecture.md) | LangGraph agent, model tiers, context management, streaming, latency, tools |

--- a/custom_components/home_generative_agent/flows/feature_subentry_flow.py
+++ b/custom_components/home_generative_agent/flows/feature_subentry_flow.py
@@ -70,6 +70,7 @@ from ..core.utils import (  # noqa: TID252
     list_ollama_models,
     validate_db_uri,
 )
+from .localization import async_common_translation
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -282,27 +283,25 @@ class FeatureSubentryFlow(ConfigSubentryFlow):
                 s.subentry_type == SUBENTRY_TYPE_FEATURE
                 for s in entry.subentries.values()
             )
-            overwrite_warning = (
-                "\n\n⚠️ Features are already configured. "
-                "Choosing **Basic setup** will overwrite your current "
-                "provider assignments with recommended defaults."
-                if has_existing
-                else ""
-            )
+            overwrite_warning = ""
+            if has_existing:
+                # Separator lives here: hassfest forbids leading whitespace
+                # in translation values.
+                overwrite_warning = "\n\n" + await async_common_translation(
+                    self.hass,
+                    "feature_overwrite_warning",
+                    "⚠️ Features are already configured. "
+                    "Choosing **Basic setup** will overwrite your current "
+                    "provider assignments with recommended defaults.",
+                )
             return self.async_show_form(
                 step_id="setup_mode",
                 data_schema=vol.Schema(
                     {
                         vol.Required("setup_mode", default="basic"): SelectSelector(
                             SelectSelectorConfig(
-                                options=[
-                                    SelectOptionDict(
-                                        label="Basic setup", value="basic"
-                                    ),
-                                    SelectOptionDict(
-                                        label="Advanced setup", value="advanced"
-                                    ),
-                                ],
+                                options=["basic", "advanced"],
+                                translation_key="setup_mode",
                                 mode=SelectSelectorMode.LIST,
                                 sort=False,
                                 custom_value=False,

--- a/custom_components/home_generative_agent/flows/localization.py
+++ b/custom_components/home_generative_agent/flows/localization.py
@@ -1,0 +1,32 @@
+"""Shared localization helpers for config subentry flows."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.translation import async_get_translations
+
+from ..const import DOMAIN  # noqa: TID252
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+async def async_common_translation(hass: HomeAssistant, key: str, fallback: str) -> str:
+    """
+    Return a translated string from the integration's "common" section.
+
+    Flow handlers only know the server-configured language, not the
+    browsing user's frontend language, so the returned text follows the
+    server locale. Languages without the key fall back to English via the
+    translation cache; `fallback` covers a missing key or load failure
+    (a corrupt translation file raises from the loader).
+    """
+    try:
+        translations = await async_get_translations(
+            hass, hass.config.language, "common", {DOMAIN}
+        )
+    except HomeAssistantError:
+        return fallback
+    return translations.get(f"component.{DOMAIN}.common.{key}", fallback)

--- a/custom_components/home_generative_agent/flows/sentinel_subentry_flow.py
+++ b/custom_components/home_generative_agent/flows/sentinel_subentry_flow.py
@@ -92,6 +92,7 @@ from ..core.utils import (  # noqa: TID252
     list_mobile_notify_services,
     valid_exclusion_entry,
 )
+from .localization import async_common_translation
 
 
 def _camera_entry_links_json(payload: dict[str, Any]) -> str:
@@ -586,27 +587,25 @@ class SentinelSubentryFlow(ConfigSubentryFlow):
                 s.subentry_type == SUBENTRY_TYPE_SENTINEL
                 for s in entry.subentries.values()
             )
-            overwrite_warning = (
-                "\n\n⚠️ Sentinel is already configured. "
-                "Choosing **Basic setup** will overwrite your current "
-                "settings with recommended defaults."
-                if has_existing
-                else ""
-            )
+            overwrite_warning = ""
+            if has_existing:
+                # Separator lives here: hassfest forbids leading whitespace
+                # in translation values.
+                overwrite_warning = "\n\n" + await async_common_translation(
+                    self.hass,
+                    "sentinel_overwrite_warning",
+                    "⚠️ Sentinel is already configured. "
+                    "Choosing **Basic setup** will overwrite your current "
+                    "settings with recommended defaults.",
+                )
             return self.async_show_form(
                 step_id="setup_mode",
                 data_schema=vol.Schema(
                     {
                         vol.Required("setup_mode", default="basic"): SelectSelector(
                             SelectSelectorConfig(
-                                options=[
-                                    SelectOptionDict(
-                                        label="Basic setup", value="basic"
-                                    ),
-                                    SelectOptionDict(
-                                        label="Advanced setup", value="advanced"
-                                    ),
-                                ],
+                                options=["basic", "advanced"],
+                                translation_key="setup_mode",
                                 mode=SelectSelectorMode.LIST,
                                 sort=False,
                                 custom_value=False,

--- a/custom_components/home_generative_agent/manifest.json
+++ b/custom_components/home_generative_agent/manifest.json
@@ -34,5 +34,5 @@
     "langchain-google-genai==3.1.0",
     "langchain-anthropic==1.4.3"
   ],
-  "version": "3.18.2"
+  "version": "3.19.0"
 }

--- a/custom_components/home_generative_agent/strings.json
+++ b/custom_components/home_generative_agent/strings.json
@@ -1,4 +1,8 @@
 {
+  "common": {
+    "feature_overwrite_warning": "⚠️ Features are already configured. Choosing **Basic setup** will overwrite your current provider assignments with recommended defaults.",
+    "sentinel_overwrite_warning": "⚠️ Sentinel is already configured. Choosing **Basic setup** will overwrite your current settings with recommended defaults."
+  },
   "config": {
     "step": {
       "user": {
@@ -291,6 +295,12 @@
     }
   },
   "selector": {
+    "setup_mode": {
+      "options": {
+        "basic": "Basic setup",
+        "advanced": "Advanced setup"
+      }
+    },
     "db_params": {
       "fields": {
         "key": {

--- a/custom_components/home_generative_agent/translations/cs.json
+++ b/custom_components/home_generative_agent/translations/cs.json
@@ -1,0 +1,361 @@
+{
+  "common": {
+    "feature_overwrite_warning": "⚠️ Funkce jsou již nakonfigurovány. Výběr **základního nastavení** přepíše vaše stávající přiřazení poskytovatelů doporučenými výchozími hodnotami.",
+    "sentinel_overwrite_warning": "⚠️ Sentinel je již nakonfigurován. Výběr **základního nastavení** přepíše vaše stávající nastavení doporučenými výchozími hodnotami."
+  },
+  "config": {
+    "step": {
+      "user": {
+        "title": "Home Generative Agent",
+        "description": "Vytvářejí se výchozí funkce. Poté spusťte **Nastavení** pro povolení/konfiguraci funkcí a databáze a následně přidejte **Poskytovatele modelu**."
+      }
+    },
+    "error": {
+      "cannot_connect": "Ke službě se nelze připojit. Zkontrolujte klíče/URL a zkuste to znovu.",
+      "invalid_auth": "Neplatný API klíč.",
+      "invalid_pin": "PIN musí mít 4-10 číslic.",
+      "unknown": "Neočekávaná chyba."
+    }
+  },
+  "config_subentries": {
+    "database": {
+      "entry_type": "service",
+      "abort": {
+        "reconfigure_successful": "Konfigurace databáze byla úspěšně aktualizována."
+      },
+      "initiate_flow": {
+        "reconfigure": "Přenastavit databázi",
+        "user": "Nastavit databázi"
+      },
+      "step": {
+        "set_options": {
+          "title": "Nastavení databáze",
+          "description": "Zadejte potřebné parametry pro databázi",
+          "data": {
+            "username": "Uživatelské jméno databáze",
+            "password": "Heslo databáze",
+            "host": "Hostitel databáze",
+            "port": "Port databáze (volitelné)",
+            "db_name": "Název databáze",
+            "db_params": "Parametry připojení databáze (volitelné)"
+          }
+        }
+      },
+      "error": {
+        "cannot_connect": "Nelze se připojit k databázi. Zkontrolujte nastavení databáze a zkuste to znovu.",
+        "invalid_auth": "Neplatná autorizace.",
+        "invalid_uri": "URI se nepodařilo vygenerovat.",
+        "unknown": "Neočekávaná chyba."
+      }
+    },
+    "model_provider": {
+      "entry_type": "service",
+      "abort": {
+        "reconfigure_successful": "Poskytovatel modelu byl aktualizován."
+      },
+      "initiate_flow": {
+        "reconfigure": "Přenastavit poskytovatele modelu",
+        "user": "Přidat poskytovatele modelu"
+      },
+      "step": {
+        "deployment": {
+          "title": "Nasazení",
+          "description": "Vyberte, kde tento poskytovatel běží.",
+          "data": {
+            "deployment": "Nasazení"
+          }
+        },
+        "provider": {
+          "title": "Poskytovatel",
+          "description": "Vyberte typ a název poskytovatele.",
+          "data": {
+            "provider_type": "Poskytovatel",
+            "name": "Název poskytovatele"
+          }
+        },
+        "settings": {
+          "title": "Nastavení poskytovatele",
+          "description": "Konfigurujte koncový bod nebo přihlašovací údaje poskytovatele.",
+          "data": {
+            "base_url": "Základní URL",
+            "api_key": "API klíč",
+            "gemini_api_key": "Gemini API klíč",
+            "anthropic_api_key": "Anthropic API klíč"
+          },
+          "data_description": {
+            "api_key": "Vyžadováno pro OpenAI. Pro poskytovatele kompatibilní s OpenAI ponechte prázdné nebo zadejte 'none', pokud koncový bod nevyžaduje autentizaci."
+          }
+        }
+      },
+      "error": {
+        "cannot_connect": "K poskytovateli se nelze připojit.",
+        "invalid_auth": "Neplatné přihlašovací údaje.",
+        "unknown": "Neočekávaná chyba."
+      }
+    },
+    "stt_provider": {
+      "entry_type": "service",
+      "abort": {
+        "reconfigure_successful": "Poskytovatel STT byl aktualizován."
+      },
+      "initiate_flow": {
+        "reconfigure": "Přenastavit poskytovatele STT",
+        "user": "Přidat poskytovatele STT"
+      },
+      "step": {
+        "provider": {
+          "title": "Poskytovatel převodu řeči na text (STT)",
+          "description": "Vyberte typ a název poskytovatele.",
+          "data": {
+            "provider_type": "Poskytovatel",
+            "name": "Název poskytovatele"
+          }
+        },
+        "credentials": {
+          "title": "Přihlašovací údaje",
+          "description": "Vyberte způsob autentizace poskytovatele STT.",
+          "data": {
+            "openai_provider_subentry_id": "Znovu použít poskytovatele OpenAI",
+            "api_key": "OpenAI API klíč"
+          }
+        },
+        "model": {
+          "title": "Model a pokročilé možnosti",
+          "description": "Vyberte model a volitelná pokročilá nastavení.",
+          "data": {
+            "model_name": "Model",
+            "language": "Jazyk (volitelné)",
+            "prompt": "Prompt (volitelné)",
+            "temperature": "Teplota (volitelné)",
+            "translate": "Přeložit do angličtiny",
+            "response_format": "Formát odpovědi"
+          }
+        }
+      },
+      "error": {
+        "cannot_connect": "K poskytovateli se nelze připojit.",
+        "invalid_auth": "Neplatné přihlašovací údaje.",
+        "invalid_model": "Vyberte platný model.",
+        "not_supported": "Poskytovatel zatím není podporován.",
+        "unknown": "Neočekávaná chyba."
+      }
+    },
+    "sentinel": {
+      "entry_type": "service",
+      "abort": {
+        "reconfigure_successful": "Konfigurace Sentinel byla aktualizována."
+      },
+      "error": {
+        "invalid_camera_entry_links": "Musí se jednat o objekt JSON mapující ID entit kamer na seznamy ID entit vstupů, např. {{\"camera.driveway\": [\"lock.front_door\"]}}.",
+        "invalid_pin": "PIN musí mít 4-10 číslic.",
+        "quiet_hours_incomplete": "Nastavte čas začátku i konce nočního klidu (nebo obojí nastavte na Zakázáno).",
+        "invalid_quiet_hours": "Časy nočního klidu musí být v místních hodinách mezi 0 a 23.",
+        "invalid_rule_entity_exclusions": "Musí se jednat o objekt JSON mapující typ anomálie (nebo \"*\" pro všechny typy) na seznamy ID entit nebo vzory glob (pouze zástupné znaky * a ?, malá písmena ID entit), každý musí obsahovat tečku a alespoň jeden doslovný znak, např. {{\"appliance_power_duration\": [\"sensor.ac_power\"], \"camera_entry_unsecured\": [\"camera.map_*\"]}}. Položky odpovídající všemu, jako například \"*\" nebo \"*.*\", nejsou povoleny — místo toho použijte klíč typu \"*\"."
+      },
+      "initiate_flow": {
+        "reconfigure": "Přenastavit Sentinel",
+        "user": "Konfigurovat Sentinel"
+      },
+      "step": {
+        "setup_mode": {
+          "title": "Nastavení Sentinel",
+          "description": "Vyberte, jak chcete Sentinel monitorování nakonfigurovat.{overwrite_warning}",
+          "data": {
+            "setup_mode": "Typ nastavení"
+          }
+        },
+        "basic_settings": {
+          "title": "Sentinel",
+          "description": "Konfigurujte základní nastavení Sentinel. Všechny ostatní možnosti využívají doporučené výchozí hodnoty.",
+          "data": {
+            "sentinel_enabled": "Povolit upozornění na anomálie",
+            "sentinel_daily_digest_enabled": "Povolit denní souhrn oznámení",
+            "sentinel_daily_digest_time": "Čas denního souhrnu (HH:MM:SS)",
+            "critical_action_pin": "PIN pro zvýšení úrovně (volitelné, 4-10 číslic)",
+            "notify_service": "Oznamovací služba (volitelné)"
+          }
+        },
+        "settings": {
+          "title": "Sentinel",
+          "description": "Konfigurujte proaktivní monitorování a zjišťování Sentinel.",
+          "data": {
+            "sentinel_enabled": "Povolit upozornění na anomálie",
+            "sentinel_interval_seconds": "Interval Sentinel (sekundy)",
+            "sentinel_cooldown_minutes": "Doba vychladnutí Sentinel podle typu (minuty)",
+            "sentinel_entity_cooldown_minutes": "Doba vychladnutí Sentinel podle entity (minuty)",
+            "sentinel_pending_prompt_ttl_minutes": "TTL čekajícího promptu (minuty)",
+            "sentinel_discovery_enabled": "Povolit zjišťování (vyžaduje upozornění na anomálie)",
+            "sentinel_discovery_interval_seconds": "Interval zjišťování (sekundy)",
+            "sentinel_discovery_max_records": "Max. počet uchovávaných záznamů zjišťování",
+            "sentinel_baseline_enabled": "Povolit sběr základní úrovně (vyžaduje upozornění na anomálie)",
+            "sentinel_baseline_update_interval_minutes": "Interval aktualizace základní úrovně (minuty)",
+            "sentinel_baseline_freshness_threshold_seconds": "Práh aktuálnosti základní úrovně (sekundy)",
+            "sentinel_baseline_weekly_patterns": "Povolit základní úrovně podle dnů v týdnu (snižuje falešná pozitiva o víkendech)",
+            "sentinel_baseline_dow_min_samples": "Minimální počet vzorků pro den v týdnu (týdny dat na slot)",
+            "sentinel_baseline_min_samples": "Minimální počet vzorků před spuštěním upozornění na odchylku",
+            "sentinel_baseline_sustained_minutes": "Filtr cyklické zátěže: minuty nad prahem před upozorněním (0 = vypnuto)",
+            "sentinel_appliance_power_threshold_w": "Pravidlo výkonu spotřebiče: práh výkonu (W)",
+            "sentinel_appliance_duration_min": "Pravidlo výkonu spotřebiče: doba trvání před upozorněním (minuty)",
+            "explain_enabled": "Povolit LLM vysvětlení pro nálezy Sentinel",
+            "sentinel_require_pin_for_level_increase": "Vyžadovat PIN pro zvýšení úrovně autonomie",
+            "sentinel_daily_digest_enabled": "Povolit denní souhrn oznámení",
+            "sentinel_daily_digest_time": "Čas denního souhrnu (HH:MM:SS)",
+            "sentinel_quiet_hours_start": "Začátek nočního klidu (potlačí vybrané závažnosti)",
+            "sentinel_quiet_hours_end": "Konec nočního klidu",
+            "sentinel_quiet_hours_severities": "Závažnosti potlačené během nočního klidu",
+            "sentinel_camera_entry_links": "Odkazy na vstupy kamer (JSON, volitelné)",
+            "sentinel_rule_entity_exclusions": "Vyloučení entit z pravidel (JSON, volitelné)",
+            "critical_action_pin": "Sentinel PIN pro zvýšení úrovně (volitelné)",
+            "notify_service": "Sentinel oznamovací služba (volitelné)"
+          }
+        }
+      }
+    },
+    "feature": {
+      "entry_type": "service",
+      "abort": {
+        "reconfigure_successful": "Funkce byla aktualizována.",
+        "setup_complete": "Nastavení dokončeno.",
+        "no_provider_for_basic_setup": "Není nakonfigurován žádný poskytovatel modelu. Nejprve přidejte **Poskytovatele modelu** a poté zkuste nastavení znovu."
+      },
+      "error": {
+        "no_providers": "Nejsou nakonfigurováni žádní poskytovatelé modelů.",
+        "cannot_connect": "Nelze se připojit k databázi. Zkontrolujte nastavení a zkuste to znovu.",
+        "invalid_auth": "Neplatná autorizace.",
+        "invalid_uri": "URI se nepodařilo vygenerovat.",
+        "unknown": "Neočekávaná chyba."
+      },
+      "initiate_flow": {
+        "reconfigure": "Přenastavit funkci",
+        "user": "Nastavení"
+      },
+      "step": {
+        "setup_mode": {
+          "title": "Nastavení",
+          "description": "Vyberte typ nastavení. Základní nastavení povolí všechny funkce s doporučenými výchozími hodnotami. Pokročilé nastavení vám dává plnou kontrolu nad každou funkcí.{overwrite_warning}",
+          "data": {
+            "setup_mode": "Typ nastavení"
+          }
+        },
+        "setup_status": {
+          "title": "Nastavení dokončeno",
+          "description": "Nastavení je hotovo.\n\n**Povolené funkce:** {features_enabled}{skipped_section}\n\n**Databáze:** {database_status}\n\n**Další kroky:**\n- Spusťte **Konfigurovat Sentinel** pro povolení monitorování anomálií.\n- Přidejte **Poskytovatele STT** pro hlasový vstup.\n- Přejděte do **Nastavení → Hlasoví asistenti** a přidejte Home Generative Agent jako svého hlasového asistenta."
+        },
+        "feature_enable": {
+          "title": "Nastavení funkcí",
+          "description": "**Konverzace** je vždy povolena. Níže povolte nebo zakažte volitelné funkce.",
+          "data": {
+            "camera_image_analysis": "Analýza obrazu z kamery",
+            "conversation_summary": "Souhrn konverzace",
+            "embedding": "Embeddings"
+          },
+          "data_description": {
+            "embedding": "Embedding model pro sémantickou paměť a vyhledávání nástrojů. Pokud je vypnuto, poskytovatel je vybrán automaticky (poskytovatel konverzace, pokud podporuje embeddings)."
+          }
+        },
+        "feature_provider": {
+          "title": "Vyberte poskytovatele modelu",
+          "description": "Vyberte poskytovatele modelu pro {feature_name}.",
+          "data": {
+            "model_provider_id": "Poskytovatel modelu"
+          }
+        },
+        "feature_model": {
+          "title": "{feature_name}",
+          "description": "Konfigurujte nastavení modelu pro tuto funkci. {provider_notice}",
+          "data": {
+            "model_name": "Model",
+            "fallback_provider_ids": "Záložní poskytovatelé",
+            "temperature": "Teplota",
+            "keepalive_s": "Ollama keepalive (sekundy nebo Nikdy neuvolňovat (-1))",
+            "context_size": "Ollama velikost kontextu (tokeny)",
+            "reasoning": "Ollama uvažování (reasoning)"
+          },
+          "data_description": {
+            "fallback_provider_ids": "Seřazený seznam záložních poskytovatelů. První dostupný poskytovatel se použije, pokud primární selže."
+          }
+        },
+        "database": {
+          "title": "Nastavení databáze",
+          "description": "Zadejte potřebné parametry pro databázi.",
+          "data": {
+            "username": "Uživatelské jméno databáze",
+            "password": "Heslo databáze",
+            "host": "Hostitel databáze",
+            "port": "Port databáze (volitelné)",
+            "db_name": "Název databáze",
+            "db_params": "Parametry připojení databáze (volitelné)"
+          }
+        },
+        "instructions": {
+          "title": "Přidat poskytovatele modelu",
+          "description": "Zatím není nakonfigurován žádný poskytovatel modelu. Přidejte jej v sekci **Poskytovatel modelu**."
+        }
+      }
+    }
+  },
+  "selector": {
+    "db_params": {
+      "fields": {
+        "key": {
+          "name": "Klíč",
+          "description": "Název parametru připojení (například: sslmode, connect_timeout)"
+        },
+        "value": {
+          "name": "Hodnota",
+          "description": "Hodnota parametru připojení (například: disable, 30)"
+        }
+      }
+    },
+    "setup_mode": {
+      "options": {
+        "basic": "Základní nastavení",
+        "advanced": "Pokročilé nastavení"
+      }
+    }
+  },
+  "exceptions": {
+    "invalid_config_entry": {
+      "message": "Byla poskytnuta neplatná konfigurační položka. Získáno: {config_entry}"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Možnosti Home Generative Agent",
+        "description": "Konfigurujte globální chování a prompty.",
+        "data": {
+          "face_api_url": "URL API pro rozpoznávání obličejů (volitelné)",
+          "prompt": "Instrukce",
+          "llm_hass_api": "Ovládat Home Assistant",
+          "video_analyzer_mode": "Režim video analyzátoru",
+          "video_analyzer_uniqueness_enabled": "Povolit filtr snímků dHash (perceptuální hash)",
+          "video_analyzer_motion_camera_map": "Pohybový senzor → přepsání kamery (volitelné)",
+          "notify_service": "Oznamovací služba video analyzátoru (volitelné)",
+          "face_recognition": "Povolit rozpoznávání obličejů",
+          "manage_context_with_tokens": "Metoda správy kontextu",
+          "max_tokens_in_context": "Max. tokenů v kontextu chatu",
+          "max_messages_in_context": "Max. zpráv v kontextu chatu",
+          "critical_action_pin_enabled": "Vyžadovat PIN pro kritické akce",
+          "critical_action_pin": "PIN pro kritické akce (vyžadován pro odemknutí/zabezpečení/otevření citlivých zařízení)",
+          "schema_first_yaml": "JSON podle schématu pro požadavky YAML",
+          "stt_filters_section": "Filtry řečového vstupu",
+          "stt_hallucination_patterns": "Ignorované podřetězce STT",
+          "stt_hallucination_exact_patterns": "Ignorované přesné fráze STT",
+          "tool_retrieval_limit": "Limit načítání nástrojů",
+          "tool_relevance_threshold": "Práh relevance nástrojů"
+        },
+        "data_description": {
+          "prompt": "Instruujte LLM, jak má odpovídat. Může to být šablona.",
+          "schema_first_yaml": "Pokud je povoleno, požadavky YAML jsou zodpovídány striktním JSON, který je následně převeden na YAML.",
+          "stt_hallucination_patterns": "Jeden podřetězec na řádek. Pokud přepis STT obsahuje jakoukoli položku, je ignorován před spuštěním LLM. Shoda nerozlišuje malá a velká písmena.",
+          "stt_hallucination_exact_patterns": "Jedna fráze na řádek. Pokud se celý přepis STT rovná jakékoli položce, je ignorován před spuštěním LLM. Shoda nerozlišuje malá a velká písmena.",
+          "tool_retrieval_limit": "Maximální počet nástrojů k načtení na základě sémantické podobnosti s dotazem uživatele.",
+          "tool_relevance_threshold": "Minimální skóre sémantické podobnosti (0.0 až 1.0) vyžadované pro načtení nástroje.",
+          "video_analyzer_uniqueness_enabled": "Přeskočit vizuálně téměř identické snímky před analýzou VLM. Varování: povolení této funkce odstraní kontext pohybu mezi snímky, který souhrnný model používá k popisu pohybu. Povolte pouze v případě, že statická scéna generuje nadměrné duplikáty a akceptujete ztrátu kontinuity pohybu.",
+          "video_analyzer_motion_camera_map": "Jedno přepsání na řádek: binary_sensor.X_motion: camera.Y — použijte, když automatické rozpoznávání vybere špatnou kameru. Ponechte prázdné pro spoléhání na rozpoznávání založené na zařízení a názvu."
+        }
+      }
+    }
+  }
+}

--- a/custom_components/home_generative_agent/translations/en.json
+++ b/custom_components/home_generative_agent/translations/en.json
@@ -1,4 +1,8 @@
 {
+  "common": {
+    "feature_overwrite_warning": "⚠️ Features are already configured. Choosing **Basic setup** will overwrite your current provider assignments with recommended defaults.",
+    "sentinel_overwrite_warning": "⚠️ Sentinel is already configured. Choosing **Basic setup** will overwrite your current settings with recommended defaults."
+  },
   "config": {
     "step": {
       "user": {
@@ -291,6 +295,12 @@
     }
   },
   "selector": {
+    "setup_mode": {
+      "options": {
+        "basic": "Basic setup",
+        "advanced": "Advanced setup"
+      }
+    },
     "db_params": {
       "fields": {
         "key": {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,7 @@
 
 Configuration is done entirely in the Home Assistant UI using subentry flows. A *subentry* is a discrete, independently configured capability — for example a Model Provider, a Feature set, or Sentinel. Each subentry has its own settings and can be added, reconfigured, or removed without affecting others.
 
-The configuration UI is available in English, Czech, Russian, and Turkish, following your Home Assistant language setting. To contribute a new language, see [Translations](contributing.md#translations).
+The configuration UI is available in English, Czech, and Turkish, with a partial Russian translation. Text follows your Home Assistant language settings and falls back to English for untranslated strings. To contribute a new language, see [Translations](contributing.md#translations).
 
 - [Basic Setup](#basic-setup)
 - [Model Providers](#model-providers)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,6 +2,8 @@
 
 Configuration is done entirely in the Home Assistant UI using subentry flows. A *subentry* is a discrete, independently configured capability — for example a Model Provider, a Feature set, or Sentinel. Each subentry has its own settings and can be added, reconfigured, or removed without affecting others.
 
+The configuration UI is available in English, Czech, Russian, and Turkish, following your Home Assistant language setting. To contribute a new language, see [Translations](contributing.md#translations).
+
 - [Basic Setup](#basic-setup)
 - [Model Providers](#model-providers)
 - [Features](#features)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -6,6 +6,7 @@ Contributions are welcome! Please read the [Contribution guidelines](../CONTRIBU
 - [Makefile Reference](#makefile-reference)
 - [Deploying to Home Assistant](#deploying-to-home-assistant)
 - [Dependency Workflow](#dependency-workflow)
+- [Translations](#translations)
 
 ---
 
@@ -91,4 +92,22 @@ After changing `manifest.json`:
 make runtimedeps
 # or
 python scripts/gen_manifest_requirements.py
+```
+
+---
+
+## Translations
+
+The configuration UI is translated via the standard Home Assistant mechanism. `custom_components/home_generative_agent/strings.json` is the English source of truth; `translations/en.json` must be an exact copy of it. Localized files (currently `cs.json`, `ru.json`, `tr.json`) live alongside it.
+
+To add a language, copy `translations/en.json` to `translations/<code>.json` and translate the values. Rules, enforced by `tests/custom_components/home_generative_agent/test_translations.py`:
+
+- A translation file may lag behind `en.json` (Home Assistant falls back to English for missing keys) but must never contain keys that don't exist in `en.json`.
+- `{placeholder}` names on shared keys must match `en.json` exactly.
+- No value may have leading or trailing whitespace (hassfest rejects it).
+
+Run the checks with:
+
+```bash
+PYTHONPATH=$(pwd) hga/bin/pytest tests/custom_components/home_generative_agent/test_translations.py
 ```

--- a/tests/custom_components/home_generative_agent/test_subentries.py
+++ b/tests/custom_components/home_generative_agent/test_subentries.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 import pytest
@@ -13,6 +15,7 @@ from homeassistant.const import (
     CONF_PASSWORD,
     CONF_USERNAME,
 )
+from homeassistant.exceptions import HomeAssistantError
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 import custom_components.home_generative_agent as hga_component
@@ -2546,3 +2549,246 @@ async def test_sentinel_user_flow_with_duplicate_sentinels_updates_first(
         "must update, not create, when duplicates exist"
     )
     assert len(update_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Localized setup_mode step — translation lookup and selector (Issue #494)
+# ---------------------------------------------------------------------------
+
+
+def _load_en_translations() -> dict[str, Any]:
+    """Load the integration's English translation file."""
+    path = (
+        Path(__file__).parents[3]
+        / "custom_components"
+        / "home_generative_agent"
+        / "translations"
+        / "en.json"
+    )
+    with path.open(encoding="utf-8") as fp:
+        return json.load(fp)
+
+
+def _setup_mode_selector_config(result: Any) -> dict[str, Any]:
+    """Extract the SelectSelector config from a setup_mode form result."""
+    schema = result["data_schema"].schema
+    selector = next(value for key, value in schema.items() if str(key) == "setup_mode")
+    return selector.config
+
+
+def _patch_common_translations(
+    monkeypatch: pytest.MonkeyPatch, translations: dict[str, str]
+) -> list[tuple[Any, ...]]:
+    """Patch the localization translation loader; return recorded call args."""
+    calls: list[tuple[Any, ...]] = []
+
+    async def _fake_get_translations(*args: Any) -> dict[str, str]:
+        calls.append(args)
+        return translations
+
+    monkeypatch.setattr(
+        "custom_components.home_generative_agent.flows.localization."
+        "async_get_translations",
+        _fake_get_translations,
+    )
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_setup_mode_warning_survives_translation_load_failure(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A corrupt translation file (loader raises) degrades to the English text."""
+
+    async def _raise_load_error(*_args: Any) -> dict[str, str]:
+        msg = "corrupt translation file"
+        raise HomeAssistantError(msg)
+
+    monkeypatch.setattr(
+        "custom_components.home_generative_agent.flows.localization."
+        "async_get_translations",
+        _raise_load_error,
+    )
+    existing = DummySubentry(
+        "sent1",
+        SUBENTRY_TYPE_SENTINEL,
+        "Sentinel",
+        {CONF_SENTINEL_ENABLED: True},
+    )
+    entry = DummyEntry()
+    entry.subentries[existing.subentry_id] = existing
+    flow = _make_sentinel_flow_for_mode(hass, entry)
+
+    result = await flow.async_step_user()
+
+    expected = "\n\n" + _load_en_translations()["common"]["sentinel_overwrite_warning"]
+    placeholders = result.get("description_placeholders") or {}
+    assert placeholders.get("overwrite_warning") == expected
+
+
+@pytest.mark.asyncio
+async def test_feature_setup_mode_warning_falls_back_to_english(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Missing translations: the warning falls back to the en.json English text."""
+    _patch_common_translations(monkeypatch, {})
+    existing_feature = DummySubentry(
+        "feat1",
+        SUBENTRY_TYPE_FEATURE,
+        "Conversation",
+        {"feature_type": "conversation", "model_provider_id": "prov1"},
+    )
+    entry = DummyEntry()
+    entry.subentries[existing_feature.subentry_id] = existing_feature
+    flow = _make_feature_flow_for_basic(hass, entry)
+
+    result = await flow.async_step_user()
+
+    expected = "\n\n" + _load_en_translations()["common"]["feature_overwrite_warning"]
+    placeholders = result.get("description_placeholders") or {}
+    assert placeholders.get("overwrite_warning") == expected
+
+
+@pytest.mark.asyncio
+async def test_feature_setup_mode_warning_uses_translation(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Translation available: the overwrite warning comes from the loader."""
+    localized = "Lokalizovane varovani pro funkce."
+    key = f"component.{DOMAIN}.common.feature_overwrite_warning"
+    calls = _patch_common_translations(monkeypatch, {key: localized})
+
+    existing_feature = DummySubentry(
+        "feat1",
+        SUBENTRY_TYPE_FEATURE,
+        "Conversation",
+        {"feature_type": "conversation", "model_provider_id": "prov1"},
+    )
+    entry = DummyEntry()
+    entry.subentries[existing_feature.subentry_id] = existing_feature
+    flow = _make_feature_flow_for_basic(hass, entry)
+
+    result = await flow.async_step_user()
+
+    placeholders = result.get("description_placeholders") or {}
+    assert placeholders.get("overwrite_warning") == "\n\n" + localized
+    assert calls == [(hass, hass.config.language, "common", {DOMAIN})]
+
+
+@pytest.mark.asyncio
+async def test_feature_setup_mode_selector_uses_translation_key(
+    hass: HomeAssistant,
+) -> None:
+    """The setup_mode selector uses plain values with a translation key."""
+    entry = DummyEntry()
+    flow = _make_feature_flow_for_basic(hass, entry)
+
+    result = await flow.async_step_user()
+
+    config = _setup_mode_selector_config(result)
+    assert config["options"] == ["basic", "advanced"]
+    assert config["translation_key"] == "setup_mode"
+    assert config["mode"] == "list"
+    assert config["sort"] is False
+    assert config["custom_value"] is False
+
+
+@pytest.mark.asyncio
+async def test_feature_setup_mode_translation_hidden_without_existing(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No existing feature subentry: warning stays empty, loader never called."""
+    key = f"component.{DOMAIN}.common.feature_overwrite_warning"
+    calls = _patch_common_translations(monkeypatch, {key: "\n\nLokalizovane varovani."})
+    entry = DummyEntry()
+    flow = _make_feature_flow_for_basic(hass, entry)
+
+    result = await flow.async_step_user()
+
+    placeholders = result.get("description_placeholders") or {}
+    assert placeholders.get("overwrite_warning") == ""
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_sentinel_setup_mode_warning_falls_back_to_english(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Missing translations: the warning falls back to the en.json English text."""
+    _patch_common_translations(monkeypatch, {})
+    existing = DummySubentry(
+        "sent1",
+        SUBENTRY_TYPE_SENTINEL,
+        "Sentinel",
+        {CONF_SENTINEL_ENABLED: True},
+    )
+    entry = DummyEntry()
+    entry.subentries[existing.subentry_id] = existing
+    flow = _make_sentinel_flow_for_mode(hass, entry)
+
+    result = await flow.async_step_user()
+
+    expected = "\n\n" + _load_en_translations()["common"]["sentinel_overwrite_warning"]
+    placeholders = result.get("description_placeholders") or {}
+    assert placeholders.get("overwrite_warning") == expected
+
+
+@pytest.mark.asyncio
+async def test_sentinel_setup_mode_warning_uses_translation(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Translation available: the overwrite warning comes from the loader."""
+    localized = "Lokalizovane varovani pro Sentinel."
+    key = f"component.{DOMAIN}.common.sentinel_overwrite_warning"
+    calls = _patch_common_translations(monkeypatch, {key: localized})
+
+    existing = DummySubentry(
+        "sent1",
+        SUBENTRY_TYPE_SENTINEL,
+        "Sentinel",
+        {CONF_SENTINEL_ENABLED: True},
+    )
+    entry = DummyEntry()
+    entry.subentries[existing.subentry_id] = existing
+    flow = _make_sentinel_flow_for_mode(hass, entry)
+
+    result = await flow.async_step_user()
+
+    placeholders = result.get("description_placeholders") or {}
+    assert placeholders.get("overwrite_warning") == "\n\n" + localized
+    assert calls == [(hass, hass.config.language, "common", {DOMAIN})]
+
+
+@pytest.mark.asyncio
+async def test_sentinel_setup_mode_translation_hidden_without_existing(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No existing Sentinel subentry: warning stays empty, loader never called."""
+    key = f"component.{DOMAIN}.common.sentinel_overwrite_warning"
+    calls = _patch_common_translations(monkeypatch, {key: "\n\nLokalizovane varovani."})
+    entry = DummyEntry()
+    flow = _make_sentinel_flow_for_mode(hass, entry)
+
+    result = await flow.async_step_user()
+
+    placeholders = result.get("description_placeholders") or {}
+    assert placeholders.get("overwrite_warning") == ""
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_sentinel_setup_mode_selector_uses_translation_key(
+    hass: HomeAssistant,
+) -> None:
+    """The setup_mode selector uses plain values with a translation key."""
+    entry = DummyEntry()
+    flow = _make_sentinel_flow_for_mode(hass, entry)
+
+    result = await flow.async_step_user()
+
+    config = _setup_mode_selector_config(result)
+    assert config["options"] == ["basic", "advanced"]
+    assert config["translation_key"] == "setup_mode"
+    assert config["mode"] == "list"
+    assert config["sort"] is False
+    assert config["custom_value"] is False

--- a/tests/custom_components/home_generative_agent/test_translations.py
+++ b/tests/custom_components/home_generative_agent/test_translations.py
@@ -1,0 +1,114 @@
+# ruff: noqa: S101
+"""
+Parity checks for strings.json and the translation files (Issue #494).
+
+Guards against drift between strings.json, en.json, and the localized
+translation files. Non-English files may lag behind en.json (Home Assistant
+falls back to English for missing keys), but they must never contain keys
+that do not exist in en.json, and placeholders must match on shared keys.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+COMPONENT_DIR = (
+    Path(__file__).parents[3] / "custom_components" / "home_generative_agent"
+)
+TRANSLATIONS_DIR = COMPONENT_DIR / "translations"
+
+_PLACEHOLDER_RE = re.compile(r"{\w+}")
+
+
+def _flatten(data: dict[str, Any], prefix: str = "") -> dict[str, str]:
+    """Flatten a nested translation dict into dotted-key/string pairs."""
+    out: dict[str, str] = {}
+    for key, value in data.items():
+        dotted = f"{prefix}.{key}" if prefix else key
+        if isinstance(value, dict):
+            out.update(_flatten(value, dotted))
+        else:
+            out[dotted] = value
+    return out
+
+
+def _load(path: Path) -> dict[str, str]:
+    with path.open(encoding="utf-8") as fp:
+        return _flatten(json.load(fp))
+
+
+def _translation_files() -> list[Path]:
+    files = sorted(TRANSLATIONS_DIR.glob("*.json"))
+    assert files, "no translation files found"
+    return files
+
+
+def test_en_json_matches_strings_json() -> None:
+    """translations/en.json must be an exact copy of strings.json."""
+    strings = _load(COMPONENT_DIR / "strings.json")
+    en = _load(TRANSLATIONS_DIR / "en.json")
+    assert en == strings
+
+
+def test_cs_json_has_full_key_parity_with_en() -> None:
+    """cs.json is a complete translation: exact key parity with en.json."""
+    en = _load(TRANSLATIONS_DIR / "en.json")
+    cs = _load(TRANSLATIONS_DIR / "cs.json")
+    missing = set(en) - set(cs)
+    extra = set(cs) - set(en)
+    assert not missing, f"cs.json missing keys: {sorted(missing)}"
+    assert not extra, f"cs.json has unknown keys: {sorted(extra)}"
+
+
+@pytest.mark.parametrize("path", _translation_files(), ids=lambda p: p.name)
+def test_translation_files_have_no_unknown_keys(path: Path) -> None:
+    """No translation file may contain keys absent from en.json."""
+    en = _load(TRANSLATIONS_DIR / "en.json")
+    translated = _load(path)
+    extra = set(translated) - set(en)
+    assert not extra, f"{path.name} has keys not in en.json: {sorted(extra)}"
+
+
+@pytest.mark.parametrize("path", _translation_files(), ids=lambda p: p.name)
+def test_translation_values_have_no_surrounding_whitespace(path: Path) -> None:
+    """Hassfest rejects values with leading/trailing whitespace — enforce locally."""
+    translated = _load(path)
+    bad = sorted(
+        key
+        for key, value in translated.items()
+        if isinstance(value, str) and value != value.strip()
+    )
+    assert not bad, f"{path.name} values with surrounding whitespace: {bad}"
+
+
+@pytest.mark.parametrize("path", _translation_files(), ids=lambda p: p.name)
+def test_translation_placeholders_match_en(path: Path) -> None:
+    """Shared keys must use the same {placeholder} set as en.json."""
+    en = _load(TRANSLATIONS_DIR / "en.json")
+    translated = _load(path)
+    mismatches = {
+        key: (
+            sorted(set(_PLACEHOLDER_RE.findall(en[key]))),
+            sorted(set(_PLACEHOLDER_RE.findall(translated[key]))),
+        )
+        for key in set(en) & set(translated)
+        if set(_PLACEHOLDER_RE.findall(en[key]))
+        != set(_PLACEHOLDER_RE.findall(translated[key]))
+    }
+    assert not mismatches, f"{path.name} placeholder mismatches: {mismatches}"
+
+
+def test_setup_mode_localization_keys_present() -> None:
+    """The Issue #494 keys exist in strings.json."""
+    strings = _load(COMPONENT_DIR / "strings.json")
+    for subentry in ("sentinel", "feature"):
+        key = f"common.{subentry}_overwrite_warning"
+        assert key in strings, f"missing {key}"
+        assert strings[key], f"{key} is empty"
+    assert strings["selector.setup_mode.options.basic"] == "Basic setup"
+    assert strings["selector.setup_mode.options.advanced"] == "Advanced setup"


### PR DESCRIPTION
Closes #494

## Summary

**Localization fix** (`541e737`) — the "Basic setup"/"Advanced setup" selector labels and the "already configured — Basic setup will overwrite…" warning in the Feature and Sentinel `setup_mode` steps were hardcoded English strings in Python, so they could never be translated even though the title/description on the same form localized correctly. The selector now uses plain values with `translation_key="setup_mode"` (labels resolved per-user by the frontend), and the warning is fetched through a new shared `flows/localization.py` helper from a top-level `common` translations section, following the server language with an English fallback.

Two constraints discovered during review shaped the design (both verified against `script/hassfest/translations.py`, and both would have failed this repo's hassfest CI as originally patched):
- hassfest's per-step schema is closed — an `overwrite_warning` key inside a step object is rejected, so the strings live in the schema-legal `common` section instead;
- hassfest forbids leading/trailing whitespace in translation values, so the `\n\n` separator is prepended in Python rather than stored in the string.

Using `async_get_translations` (the loading variant) instead of `async_get_cached_translations` also removes a silent failure mode where a cold cache would always render English. A corrupt translation file on disk degrades to the English fallback instead of crashing the flow step.

**Czech translation** (`8c29817`) — complete `cs` localization with exact key parity to `en.json`, contributed by @hruba202. One correction to the contributed file: the STT "translate" option label read "Přeložit do čěštiny" ("Translate to Czech", with a typo); Whisper-style translation only ever targets English, so it now reads "Přeložit do angličtiny".

**Translation invariants** (`8c29817`) — new `test_translations.py` enforces: `strings.json` ≡ `en.json`, full `cs` key parity, no file may contain keys absent from `en.json` (ru/tr may lag; HA falls back to English), `{placeholder}` parity on shared keys, and no value with surrounding whitespace (the hassfest rule, enforced locally).

## Test Coverage

Tests: 1561 → 1585 (+24 new). All changed code paths covered:

```
async_step_setup_mode (feature flow + sentinel flow, each)
├── has_existing=True  → warning in placeholders      [★★★] exact en.json text
├── has_existing=False → warning "" & loader not called [★★★]
├── translation HIT    → localized string used         [★★★] + exact key/call args
├── translation MISS   → English fallback == en.json   [★★★] (pins literal against drift)
├── loader RAISES (corrupt file) → English fallback    [★★★]
└── selector schema: options ["basic","advanced"],
    translation_key="setup_mode", LIST/no-sort         [★★★]
submission routing basic/advanced (unchanged logic)    [★★ ] pre-existing

translation JSON invariants (test_translations.py)
├── en.json ≡ strings.json                             [★★★]
├── cs.json full key parity with en.json               [★★★]
├── no unknown keys in any translation file            [★★★]
├── {placeholder} parity on shared keys                [★★★]
└── no surrounding whitespace in values (hassfest)     [★★★]

COVERAGE: 100% of changed paths
```

Test efficacy was mutation-verified: typo'ing the lookup key or drifting the fallback literal fails the suite.

## Pre-Landing Review

9 findings (2 critical, 7 informational) from checklist + testing/maintainability specialists — **all fixed before commit**:
- [CRITICAL×2, testing] translation-lookup branch untested in both flows → hit/miss/failure tests added
- [CRITICAL, maintainability→verified P1] `overwrite_warning` illegal inside hassfest's closed step schema → moved to `common`
- [INFO] duplicated lookup block in both flows → extracted shared `flows/localization.py`
- [INFO] fallback literal can drift from en.json → pinned by test
- [INFO] server-vs-frontend language limitation → documented in helper docstring
- [INFO] selector config + JSON parity untested → tests added

## Adversarial Review (cross-model synthesis)

- **High confidence (found by both Claude & Codex independently):** the hassfest step-schema violation (fixed via `common`); the server-language limitation (inherent to `description_placeholders`, documented).
- **Unique to Codex:** hassfest's leading-whitespace rule (fixed — separator moved to Python); pyright errors in new tests (fixed).
- **Unique to Claude adversarial:** cs.json semantically inverted the STT translate label (fixed); corrupt-translation-file crash path (fixed with `HomeAssistantError` catch + regression test). Verified clean: no cache-lock deadlock, `common` category flattening, `SelectSelectorConfig` accepts `list[str]`, selector defaults/sort/custom_value unchanged, no dead imports, cs.json scanned for markup/control-character/placeholder injection — clean.
- Models used: Claude structured ✓ Claude adversarial ✓ Codex ✓ (structured review skipped — diff < 200 lines)

Known follow-up (pre-existing, out of scope): other hardcoded `SelectOptionDict` labels remain in the Sentinel flow ("Disabled", hour labels, severity names) — Czech users see those in English; same class as this fix if anyone wants to extend it.

## Design Review

No frontend files changed — design review skipped.

## Eval Results

No prompt-related files changed — evals skipped.

## Scope Drift

Scope Check: CLEAN — intent (fix #494 localization + add Czech) matches delivered diff exactly.

## Plan Completion

No plan file detected.

## TODOS

No TODO items completed in this PR.

## Documentation

- **docs/configuration.md**: intro now states the configuration UI is available in English, Czech, and Turkish with a partial Russian translation, follows the Home Assistant language settings with English fallback for untranslated strings, and links to the new Translations contribution guide.
- **docs/contributing.md**: new "Translations" section — `strings.json`/`en.json` parity rule, how to add a language, the invariants enforced by `test_translations.py`, and the pytest command to run the checks.
- **README.md**: Documentation table — Configuration row now lists UI languages (en/cs/ru/tr); Contributing row mentions the translations workflow.
- Documentation debt noted: `translations/ru.json` is a partial stub (~85% English) and lacks the new keys — falls back to English; needs a native-speaker refresh.

## Test plan

- [x] Full pytest suite passes: 1585 passed (was 1561 on main)
- [x] `make lint` (ruff format + check, manifest-requirements sync) clean
- [x] `make typecheck` (pyright): 0 errors, 0 warnings
- [x] All four new `common`/`selector` translation values validated against hassfest's actual validators (`cv.string_with_no_html`, strip, URL, combined-reference, slug keys) in this venv

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRb4SgC7Fo3x1NfWWqafBa
