### PR TITLE
v3.21.3 fix: normalize Sentinel power readings to watts across all HA power units (#461)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.21.3] - 2026-07-29
+
+### Fixed
+
+- **Power sensors reporting in any Home Assistant power unit are now measured correctly** — the `appliance_power_duration` rule and the power-history enrichment converted only kW readings to watts; a sensor denominated in MW, mW, GW, TW, or BTU/h was compared raw against the watts threshold, so a 0.25 MW (250,000 W) reading looked like 0.25 W and could never trigger — silently. All HA power units are now normalized to watts before any comparison, and a `device_class: power` sensor reporting a unit that *isn't* power (e.g. VA apparent power) is skipped rather than compared wrongly — skipped ends any in-progress episode, so a sensor that changes units mid-run restarts its clock. Surfaced by [@andymcmanus](https://github.com/andymcmanus)'s unit-mixing question in [#461](https://github.com/goruck/home-generative-agent/issues/461).
+- **Cycle-completion detection now works for kW-denominated appliances** — the baseline anomaly detector compared a sensor's native baseline value against its 100 W activity floor without unit conversion, so a washer reporting 1.2 (kW) never passed `1.2 >= 100` and its cycle-end power drops were never downgraded to low severity. The floor now compares in watts (1.2 kW = 1200 W). The baseline standby-noise guard gets the same treatment: deviations are normalized to watts from any power unit before the 50 W minimum, instead of only kW.
+
+- **Hand-typed unit spellings keep their sensors monitored** — ESPHome/MQTT/template sensors carry free-text units, and a `device_class: power` sensor labeled `"w"` or `"KW"` would have been skipped by the new normalization (it was previously compared raw). Unit strings are now matched case-insensitively where unambiguous; `mW` vs `MW` must match exact-case since lowercase "mw" could mean either. Sensors whose unit still can't be recognized are logged (debug, once per unit string) instead of disappearing silently.
+- **A malformed sensor attribute can no longer stop Sentinel** — an entity whose `unit_of_measurement` is a list or dict (settable via the REST API or misbehaving custom integrations) crashed the power-sensor filter, and in the enrichment step that exception killed the entire Sentinel detection loop until the integration was reloaded. The filter now coerces attribute values safely, and snapshot enrichment as a whole is guarded so a failure degrades to un-enriched snapshots instead of ending detection. Found by adversarial review with an empirical reproduction.
+- **Recorder history is read in each row's own unit** — when a sensor's unit was reconfigured mid-window (say W → kW in a template), the "on since" search interpreted old readings in the new unit, missing the off boundary and pushing the on-since time arbitrarily far back. Historical rows now honor their recorded `unit_of_measurement`, falling back to the current unit when absent. `nan`/`inf` readings are also rejected in this walk (they compared as "on") — mirroring the guard the rule already had — and a finite reading that overflows to infinity in watts (a garbage 1e300 TW value) is rejected after conversion everywhere, since an infinite value in a finding would crash notification dispatch.
+
+### Changed
+
+- The appliance power rule's episode tracker now also resets eagerly when a sensor stops identifying as a power sensor (attributes change), closing a narrow path where a stale episode start could survive an evaluation error.
+- The power enrichment's 10 W "off" level and 30-day recorder lookback are now documented in `docs/constants.md`.
+
 ## [3.21.2] - 2026-07-28
 
 ### Fixed

--- a/TODOS.md
+++ b/TODOS.md
@@ -141,7 +141,7 @@
 
 ### Dynamic `sensor_threshold_condition` rules don't normalize units
 
-**What:** Discovery's `sensor_threshold_condition` template (`sentinel/proposal_templates.py`) compares an LLM-extracted numeric threshold against the sensor's native state with no unit normalization — the #461 bug class: a rule meaning "over 100 watts" against a kW sensor never fires (or a "below 1 kW" against a W sensor always fires). Arguably the user's threshold is native-unit by intent, but nothing disambiguates. Surfaced by adversarial review during the v3.21.3 ship.
+**What:** Discovery's `sensor_threshold_condition` template (`sentinel/proposal_templates.py`) compares an LLM-extracted numeric threshold against the sensor's native state with no unit normalization — the #461 bug class: a rule meaning "over 100 watts" against a kW sensor never fires (the template only extracts above-thresholds today; a below-variant would invert the failure — always firing). Arguably the user's threshold is native-unit by intent, but nothing disambiguates. Surfaced by adversarial review during the v3.21.3 ship.
 
 **How to apply:** When the target sensor has `device_class: power` (or a power unit), normalize both the threshold and the reading via `sentinel/power_units.watts_per_unit` — requires deciding/recording the threshold's intended unit at proposal-approval time (candidate text usually names it: "100 W", "1.5 kW").
 
@@ -254,7 +254,7 @@
 
 ### Store baselines unit-normalized (or reset on unit change)
 
-**What:** `sentinel_baselines` rows store native-unit values with no unit column; evaluation interprets the stored value in the entity's *current* unit. After a W→kW sensor reconfiguration, a stored `1200` (W) baseline against a current `1.2` (kW) reading produces a false ~99.9% deviation (misclassified as cycle completion), and new `1.2` samples blend into the old `1200` rolling average, corrupting rolling/hourly/DOW metrics until the EMA converges. Pre-existing design property; surfaced by Codex adversarial review during the v3.21.3 ship.
+**What:** `sentinel_baselines` rows store native-unit values with no unit column; evaluation interprets the stored value in the entity's *current* unit. After a W→kW sensor reconfiguration, a stored `1200` (W) baseline against a current `1.2` (kW) reading produces a false ~99.9% deviation (misclassified as cycle completion), and new `1.2` samples blend into the old `1200` rolling average, corrupting rolling/hourly/DOW metrics until the averages re-converge (rolling/hourly are EMA-based; DOW slots use Welford accumulators). Pre-existing design property; surfaced by Codex adversarial review during the v3.21.3 ship.
 
 **How to apply:** Either normalize power-class samples to watts at write time in `SentinelBaselineUpdater` (with a one-time migration or metric-version bump), or store `unit_of_measurement` alongside the value and reset the row when the recorded unit differs from the current one.
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -139,6 +139,16 @@
 
 ## Sentinel Rules
 
+### Dynamic `sensor_threshold_condition` rules don't normalize units
+
+**What:** Discovery's `sensor_threshold_condition` template (`sentinel/proposal_templates.py`) compares an LLM-extracted numeric threshold against the sensor's native state with no unit normalization — the #461 bug class: a rule meaning "over 100 watts" against a kW sensor never fires (or a "below 1 kW" against a W sensor always fires). Arguably the user's threshold is native-unit by intent, but nothing disambiguates. Surfaced by adversarial review during the v3.21.3 ship.
+
+**How to apply:** When the target sensor has `device_class: power` (or a power unit), normalize both the threshold and the reading via `sentinel/power_units.watts_per_unit` — requires deciding/recording the threshold's intended unit at proposal-approval time (candidate text usually names it: "100 W", "1.5 kW").
+
+**Effort:** M
+**Priority:** P3
+**Depends on:** v3.21.3
+
 ### Add `sentinel_camera_entry_links` config for explicit camera-to-entry mapping
 
 **What:** Add a `sentinel_camera_entry_links` config key (Sentinel subentry options flow) that allows users to explicitly associate cameras with entry sensors regardless of HA area assignment. Format: `{camera_entity_id: [entry_entity_id, ...]}`.
@@ -241,6 +251,30 @@
 ---
 
 ## Baseline
+
+### Store baselines unit-normalized (or reset on unit change)
+
+**What:** `sentinel_baselines` rows store native-unit values with no unit column; evaluation interprets the stored value in the entity's *current* unit. After a W→kW sensor reconfiguration, a stored `1200` (W) baseline against a current `1.2` (kW) reading produces a false ~99.9% deviation (misclassified as cycle completion), and new `1.2` samples blend into the old `1200` rolling average, corrupting rolling/hourly/DOW metrics until the EMA converges. Pre-existing design property; surfaced by Codex adversarial review during the v3.21.3 ship.
+
+**How to apply:** Either normalize power-class samples to watts at write time in `SentinelBaselineUpdater` (with a one-time migration or metric-version bump), or store `unit_of_measurement` alongside the value and reset the row when the recorded unit differs from the current one.
+
+**Effort:** M
+**Priority:** P3
+**Depends on:** v3.21.3
+
+---
+
+### Bound the power-enrichment recorder walk
+
+**What:** `async_enrich_power_last_changed` fetches up to 30 days of `state_changes_during_period` rows with `limit=None` and `no_attributes=False` for every on-state power sensor, every Sentinel cycle. A high-frequency (~1 Hz) power sensor materializes millions of rows per cycle; several such sensors can exhaust memory or monopolize recorder executor workers. Pre-existing for `device_class: power` sensors; v3.21.3 marginally broadened admission (unit-only sensors). Surfaced by Codex adversarial review.
+
+**How to apply:** Walk history in capped descending pages (e.g. `limit=` batches, newest first) and stop at the first off-boundary; or cache the resolved on-since per entity and only re-query when the sensor drops below the off level.
+
+**Effort:** M
+**Priority:** P2
+**Depends on:** None
+
+---
 
 ### Config flow UI for CONF_SENTINEL_BASELINE_MIN_SAMPLES
 
@@ -541,6 +575,18 @@ WARNING per event that a window-scoped check could suppress.
 ---
 
 ## Notifier / Observability
+
+### Baseline-deviation notifications guess the display unit from the entity_id
+
+**What:** `_baseline_deviation_mobile_message` (`sentinel/notifier.py:904`) picks the display unit with `"W" if "power" in entity_id else "kWh" if "energy" in entity_id else ""`. A kW-denominated sensor renders as e.g. "0.4W vs usual 0.3W", and a power sensor without "power" in its entity_id gets no unit at all. Surfaced during the #461 unit-normalization review (v3.21.3).
+
+**How to apply:** Plumb the sensor's `unit_of_measurement` into the baseline finding evidence in `sentinel/baseline.py` (alongside `current_value`/`baseline_value`, which stay native) and render it verbatim in the notifier, falling back to the current heuristic for old persisted findings.
+
+**Effort:** S
+**Priority:** P3
+**Depends on:** None
+
+---
 
 ### Deduplicate the _friendly_type label maps
 

--- a/custom_components/home_generative_agent/manifest.json
+++ b/custom_components/home_generative_agent/manifest.json
@@ -34,5 +34,5 @@
     "langchain-google-genai==3.1.0",
     "langchain-anthropic==1.4.3"
   ],
-  "version": "3.21.2"
+  "version": "3.21.3"
 }

--- a/custom_components/home_generative_agent/sentinel/baseline.py
+++ b/custom_components/home_generative_agent/sentinel/baseline.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import math
 from datetime import UTC, timedelta
 from typing import TYPE_CHECKING, Any
 
@@ -1100,6 +1101,10 @@ def evaluate_baseline_deviation(  # noqa: PLR0911, PLR0912, PLR0915
         current_value = float(str(entity.get("state", "")))
     except (TypeError, ValueError):
         return []
+    if not math.isfinite(current_value):
+        # nan/inf poison every downstream comparison and evidence field
+        # (round(inf) raises in the notifier during dispatch).
+        return []
 
     baseline_value = (baselines.get(entity_id) or {}).get(metric)
     if baseline_value is None:
@@ -1342,6 +1347,10 @@ def _evaluate_dow_anomaly(  # noqa: PLR0913
     try:
         current_value = float(str(entity.get("state", "")))
     except (TypeError, ValueError):
+        return []
+    if not math.isfinite(current_value):
+        # Same guard as evaluate_baseline_deviation: non-finite readings must
+        # not reach evidence fields the notifier rounds during dispatch.
         return []
 
     # Global hourly mean for this hour (the fallback anchor).

--- a/custom_components/home_generative_agent/sentinel/baseline.py
+++ b/custom_components/home_generative_agent/sentinel/baseline.py
@@ -51,6 +51,7 @@ from custom_components.home_generative_agent.const import (
 )
 
 from .models import AnomalyFinding, Severity, build_anomaly_id
+from .power_units import is_power_unit, watts_per_unit
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -1120,10 +1121,9 @@ def evaluate_baseline_deviation(  # noqa: PLR0911, PLR0912, PLR0915
     # standby guard and for completion detection below.
     _attrs: dict[str, Any] = (entity.get("attributes") or {}) if entity else {}
     _unit = str(_attrs.get("unit_of_measurement") or "")
-    is_power_entity = str(_attrs.get("device_class") or "") == "power" or _unit in {
-        "W",
-        "kW",
-    }
+    is_power_entity = str(_attrs.get("device_class") or "") == "power" or is_power_unit(
+        _unit
+    )
     friendly_name = str(entity.get("friendly_name") or "").lower()
     is_appliance = is_power_entity and any(
         hint in entity_id.lower() or hint in friendly_name for hint in _APPLIANCE_HINTS
@@ -1133,11 +1133,15 @@ def evaluate_baseline_deviation(  # noqa: PLR0911, PLR0912, PLR0915
     # A 2.9 W → 0 W swing on a washer sensor is pure noise; a 40 W UPS or
     # 30 W switch going dark is a real event worth notifying on.
     # Normalize to watts first: kW entities report values like 30.0 (kW).
-    _deviation_w = abs(current_value - baseline_value) * (
-        1000.0 if _unit == "kW" else 1.0
-    )
-    if is_appliance and _deviation_w < MINIMUM_POWER_DEVIATION_WATTS:
-        return []
+    # A power sensor in a non-power unit (e.g. VA) cannot be normalized — the
+    # guard is skipped (fails open) while completion detection below fails
+    # closed: both directions deliberately prefer visibility (notify, keep
+    # severity) over suppression when the unit is unintelligible.
+    _unit_factor = watts_per_unit(_unit) if is_appliance else None
+    if is_appliance and _unit_factor is not None:
+        _deviation_w = abs(current_value - baseline_value) * _unit_factor
+        if _deviation_w < MINIMUM_POWER_DEVIATION_WATTS:
+            return []
 
     rule_id = str(rule.get("rule_id") or "baseline_deviation")
     evidence = {
@@ -1158,10 +1162,13 @@ def evaluate_baseline_deviation(  # noqa: PLR0911, PLR0912, PLR0915
     # a dedicated appliance circuit (washer, dryer, dishwasher, etc.).
     # Generic power sensors (UPS, fridge, whole-home, server rack) are
     # intentionally excluded to avoid silencing real faults.
-    # (is_appliance already computed above for the standby guard)
+    # (is_appliance and _unit_factor already computed above for the standby
+    # guard; the active-wattage floor compares in watts, so the native
+    # baseline is normalized first — 1.2 kW is 1200 W, not 1.2 W.)
     if (
         is_appliance
-        and baseline_value >= COMPLETION_MIN_ACTIVE_WATTS
+        and _unit_factor is not None
+        and baseline_value * _unit_factor >= COMPLETION_MIN_ACTIVE_WATTS
         and current_value < COMPLETION_THRESHOLD_PCT * baseline_value
     ):
         # Only treat as completion if the state changed recently.  If the

--- a/custom_components/home_generative_agent/sentinel/engine.py
+++ b/custom_components/home_generative_agent/sentinel/engine.py
@@ -534,9 +534,23 @@ class SentinelEngine:
             "snapshot_build",
             "Sentinel snapshot build recovered after %d failed cycle(s).",
         )
-        await async_enrich_alarm_last_changed(self._hass, snapshot)
-        await async_enrich_lock_last_changed(self._hass, snapshot)
-        await async_enrich_power_last_changed(self._hass, snapshot)
+        try:
+            await async_enrich_alarm_last_changed(self._hass, snapshot)
+            await async_enrich_lock_last_changed(self._hass, snapshot)
+            await async_enrich_power_last_changed(self._hass, snapshot)
+        except (ValueError, TypeError, KeyError):
+            # Enrichment only corrects last_changed context; a bug here must
+            # degrade to un-enriched snapshots, not kill the run loop (an
+            # unguarded exception would end Sentinel until reload).
+            self._log_limiter.warning(
+                "snapshot_enrichment",
+                "Snapshot enrichment failed; continuing with raw last_changed.",
+            )
+        else:
+            self._log_limiter.recovered(
+                "snapshot_enrichment",
+                "Sentinel snapshot enrichment recovered after %d failed cycle(s).",
+            )
 
         # Force Level 0 when suppression state is in read-only mode (version
         # mismatch after a downgrade).

--- a/custom_components/home_generative_agent/sentinel/power_enrichment.py
+++ b/custom_components/home_generative_agent/sentinel/power_enrichment.py
@@ -121,10 +121,12 @@ async def async_enrich_power_last_changed(
     Correct last_changed for power sensors reset by HA startup.
 
     When HA restarts, a power sensor re-reports its current wattage, creating a
-    new last_changed at startup time.  The appliance duration rule then computes
-    a falsely short duration and fires too late (or not at all).  This function
-    queries the recorder to find when the sensor last crossed from off to on and
-    corrects last_changed before rules evaluate.
+    new last_changed at startup time.  This function queries the recorder to
+    find when the sensor last crossed from off to on and corrects last_changed
+    before rules evaluate.  The appliance duration rule does NOT consume this
+    (it measures duration by direct observation); the enriched value informs
+    advisory context only — dynamic rules, triage, and the baseline
+    cycle-completion recency check.
     """
     if DATA_INSTANCE not in getattr(hass, "data", {}):
         return

--- a/custom_components/home_generative_agent/sentinel/power_enrichment.py
+++ b/custom_components/home_generative_agent/sentinel/power_enrichment.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import functools
 import logging
+import math
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
@@ -11,6 +12,8 @@ from homeassistant.components.recorder import history as recorder_history
 from homeassistant.helpers.recorder import DATA_INSTANCE
 from homeassistant.helpers.recorder import get_instance as get_recorder_instance
 from homeassistant.util import dt as dt_util
+
+from .power_units import is_power_unit, watts_per_unit
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -31,22 +34,52 @@ _TRANSIENT_STATES = frozenset({"unavailable", "unknown"})
 
 def _parse_float(raw: str) -> float | None:
     try:
-        return float(raw)
+        parsed = float(raw)
     except (ValueError, TypeError):
         return None
+    # nan compares False against the off threshold and would masquerade as an
+    # 'on' reading (rewriting last_changed from garbage); inf likewise.
+    return parsed if math.isfinite(parsed) else None
+
+
+def _row_watts(state: Any, current_factor: float) -> float | None:
+    """
+    Return a recorder row's reading in watts, or None if unusable.
+
+    The row's own unit_of_measurement is honored when present — a sensor whose
+    unit was reconfigured mid-window (W → kW template edit) must not have its
+    old readings interpreted in the new unit.  Rows without a unit attribute
+    fall back to the sensor's current factor; rows in a non-power unit are
+    skipped like transients.
+    """
+    val = _parse_float(state.state)
+    if val is None:
+        return None
+    attrs = getattr(state, "attributes", None) or {}
+    if "unit_of_measurement" in attrs:
+        factor = watts_per_unit(attrs.get("unit_of_measurement"))
+        if factor is None:
+            return None
+    else:
+        factor = current_factor
+    val_w = val * factor
+    # Finite native value can overflow to inf in watts (1e300 TW); inf
+    # compares False against the off level and would masquerade as 'on'.
+    return val_w if math.isfinite(val_w) else None
 
 
 def _find_true_on_since(
     state_list: list[Any],
-    off_threshold_native: float,
+    current_factor: float,
     start_time: datetime,
 ) -> Any | None:
     """
     Return the state when the sensor last transitioned from off to on.
 
     Walk newest-to-oldest, skip transients.  The first reading at or below
-    off_threshold_native marks the boundary of the current 'on' episode; the
-    state immediately after it (newer) is the true start.
+    the off level (compared in watts, honoring each row's own unit) marks the
+    boundary of the current 'on' episode; the state immediately after it
+    (newer) is the true start.
 
     If no 'off' reading exists in the window, the oldest within-window record
     is returned as the best available approximation (the sensor has been on
@@ -57,10 +90,10 @@ def _find_true_on_since(
     for state in reversed(state_list):
         if state.state in _TRANSIENT_STATES:
             continue
-        val = _parse_float(state.state)
-        if val is None:
+        val_w = _row_watts(state, current_factor)
+        if val_w is None:
             continue
-        if val <= off_threshold_native:
+        if val_w <= _POWER_OFF_W:
             # 'Off' reading found — prev is the true on-start (may be None if
             # the first non-transient record is already below threshold).
             return prev
@@ -71,7 +104,8 @@ def _find_true_on_since(
         (
             s
             for s in state_list
-            if s.state not in _TRANSIENT_STATES and _parse_float(s.state) is not None
+            if s.state not in _TRANSIENT_STATES
+            and _row_watts(s, current_factor) is not None
         ),
         None,
     )
@@ -101,7 +135,7 @@ async def async_enrich_power_last_changed(
         if e["domain"] == "sensor"
         and (
             e["attributes"].get("device_class") == "power"
-            or e["attributes"].get("unit_of_measurement") in {"W", "kW"}
+            or is_power_unit(e["attributes"].get("unit_of_measurement"))
         )
     ]
     if not power_entities:
@@ -113,16 +147,19 @@ async def async_enrich_power_last_changed(
 
     for power_entity in power_entities:
         entity_id = power_entity["entity_id"]
-        unit = str(power_entity["attributes"].get("unit_of_measurement") or "W")
+        unit_factor = watts_per_unit(
+            power_entity["attributes"].get("unit_of_measurement")
+        )
 
         current_val = _parse_float(power_entity["state"])
-        if current_val is None:
+        if current_val is None or unit_factor is None:
+            # Non-numeric reading, or a device_class:power sensor in a
+            # non-power unit (e.g. VA) whose history cannot be compared
+            # against the watts off level.
             continue
-        current_w = current_val * 1000.0 if unit == "kW" else current_val
-        if current_w <= _POWER_OFF_W:
-            continue  # appliance is off — nothing to correct
-
-        off_threshold_native = _POWER_OFF_W / (1000.0 if unit == "kW" else 1.0)
+        current_w = current_val * unit_factor
+        if not math.isfinite(current_w) or current_w <= _POWER_OFF_W:
+            continue  # off, or garbage that overflowed to inf in watts
 
         try:
             states = await instance.async_add_executor_job(
@@ -149,9 +186,7 @@ async def async_enrich_power_last_changed(
         if len(state_list) < 2:  # noqa: PLR2004
             continue
 
-        true_on_state = _find_true_on_since(
-            state_list, off_threshold_native, start_time
-        )
+        true_on_state = _find_true_on_since(state_list, unit_factor, start_time)
         if true_on_state is None:
             continue
 

--- a/custom_components/home_generative_agent/sentinel/power_units.py
+++ b/custom_components/home_generative_agent/sentinel/power_units.py
@@ -1,0 +1,91 @@
+"""Normalization of power-sensor readings to watts."""
+
+from __future__ import annotations
+
+import logging
+from functools import lru_cache
+
+from homeassistant.const import UnitOfPower
+from homeassistant.util.unit_conversion import PowerConverter
+
+_LOGGER = logging.getLogger(__name__)
+
+# Unit strings a power sensor may legitimately report in (W, kW, MW, GW, TW,
+# mW, BTU/h).  Sensors carrying any of these are treated as power sensors even
+# without a power device_class.
+POWER_UNITS: frozenset[str] = frozenset(str(u) for u in PowerConverter.VALID_UNITS)
+
+
+def _build_folded_units() -> dict[str, str]:
+    """
+    Map case-folded unit spellings to their canonical unit string.
+
+    Fallback for hand-typed unit strings ("w", "KW", " W" from ESPHome/MQTT/
+    template configs).  Only unambiguous folds are included: "mw" could mean
+    either mW (0.001 W) or MW (1e6 W), so milli/mega must match exact-case.
+    """
+    folded: dict[str, str] = {}
+    ambiguous: set[str] = set()
+    for u in PowerConverter.VALID_UNITS:
+        key = str(u).strip().lower()
+        if key in folded:
+            ambiguous.add(key)
+        folded[key] = str(u)
+    for key in ambiguous:
+        del folded[key]
+    return folded
+
+
+_FOLDED_UNITS: dict[str, str] = _build_folded_units()
+
+
+def watts_per_unit(unit: object | None) -> float | None:
+    """
+    Return the factor converting one native unit of ``unit`` to watts.
+
+    Accepts the raw ``unit_of_measurement`` attribute value: a missing/empty
+    unit is treated as watts (bare power sensors report W by convention),
+    non-string values are coerced, and unit strings are matched
+    case-insensitively where unambiguous ("w", "KW"; but mW/MW must match
+    exact-case).  Returns None for units that are not power units — callers
+    must skip such readings rather than compare them against a watts
+    threshold, which would be silently wrong for e.g. VA (apparent power).
+    """
+    if unit is None or unit == "":
+        return 1.0
+    return _watts_per_unit_cached(str(unit))
+
+
+def is_power_unit(unit: object | None) -> bool:
+    """
+    Return True when ``unit`` identifies a power sensor on its own.
+
+    Unlike ``watts_per_unit``, a missing/empty unit is False here — a bare
+    unit does not make a sensor a power sensor.  Never raises, even for
+    non-hashable attribute values (lists/dicts from misbehaving integrations),
+    so it is safe as a snapshot admission test.
+    """
+    if unit is None or unit == "":
+        return False
+    return _watts_per_unit_cached(str(unit)) is not None
+
+
+@lru_cache
+def _watts_per_unit_cached(unit: str) -> float | None:
+    # Strip before the exact-case match too: " MW" must not fall through to
+    # the folded lookup, where milli/mega is deliberately absent as ambiguous.
+    stripped = unit.strip()
+    canonical = (
+        stripped if stripped in POWER_UNITS else _FOLDED_UNITS.get(stripped.lower())
+    )
+    if canonical is None:
+        # Cached, so this logs once per distinct unit string: the skip is
+        # otherwise invisible (rule, enrichment, and baseline all silently
+        # ignore sensors whose unit cannot be normalized to watts).
+        _LOGGER.debug(
+            "Unit %r is not a recognized power unit; power sensors reporting "
+            "it are skipped by watts-denominated Sentinel checks",
+            unit,
+        )
+        return None
+    return PowerConverter.convert(1.0, canonical, UnitOfPower.WATT)

--- a/custom_components/home_generative_agent/sentinel/rules/appliance_power_duration.py
+++ b/custom_components/home_generative_agent/sentinel/rules/appliance_power_duration.py
@@ -18,6 +18,10 @@ from custom_components.home_generative_agent.sentinel.models import (
     AnomalyFinding,
     build_anomaly_id,
 )
+from custom_components.home_generative_agent.sentinel.power_units import (
+    is_power_unit,
+    watts_per_unit,
+)
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -51,6 +55,11 @@ class AppliancePowerDurationRule:
     appliance is re-detected after a full ``duration_min`` of observation
     (same accepted tradeoff as the engine's cyclical sustained-deviation
     gate).
+
+    Readings are normalized to watts from any HA power unit (W, kW, MW, GW,
+    TW, mW, BTU/h) before comparison against ``power_threshold_w``; power
+    sensors in a non-power unit (e.g. VA) are skipped rather than compared
+    raw.
     """
 
     rule_id = "appliance_power_duration"
@@ -82,18 +91,32 @@ class AppliancePowerDurationRule:
             attrs = entity["attributes"]
             device_class = attrs.get("device_class")
             unit = attrs.get("unit_of_measurement")
-            if device_class != "power" and unit not in {"W", "kW"}:
-                continue
             entity_id = entity["entity_id"]
-            power_val = _coerce_float(entity["state"])
-            if power_val is None:
-                # Falling edge is applied eagerly (not only in the post-loop
-                # sweep) so an exception later in the loop — swallowed by the
-                # engine — cannot preserve a stale episode start.
+            if device_class != "power" and not is_power_unit(unit):
+                # Same eager falling edge as below: an entity whose attributes
+                # stop identifying it as a power sensor must not retain a
+                # stale episode if a later exception skips the post-loop
+                # sweep.
                 self._above_since.pop(entity_id, None)
                 continue
-            if unit == "kW":
-                power_val *= 1000.0
+            power_val = _coerce_float(entity["state"])
+            unit_factor = watts_per_unit(unit)
+            if power_val is None or unit_factor is None:
+                # Non-numeric reading, or a device_class:power sensor in a
+                # non-power unit (e.g. VA) that cannot be compared against a
+                # watts threshold.  Falling edge is applied eagerly (not only
+                # in the post-loop sweep) so an exception later in the loop —
+                # swallowed by the engine — cannot preserve a stale episode
+                # start.
+                self._above_since.pop(entity_id, None)
+                continue
+            power_val *= unit_factor
+            if not math.isfinite(power_val):
+                # Finite native value, infinite in watts (1e300 TW): garbage.
+                # An inf power_w in evidence would crash the notifier's
+                # round() during dispatch, killing the run loop.
+                self._above_since.pop(entity_id, None)
+                continue
             if power_val < self._power_threshold_w:
                 self._above_since.pop(entity_id, None)
                 continue

--- a/docs/constants.md
+++ b/docs/constants.md
@@ -278,7 +278,7 @@ This document covers the named constants that affect integration behaviour, orga
 | `RECOMMENDED_AUDIT_HOT_MAX_RECORDS` | `audit_hot_max_records` | `500` | Maximum records kept in the in-memory audit hot store. User-visible findings are preserved in preference to suppressed records when at capacity. |
 | `RECOMMENDED_SENTINEL_CAMERA_ENTRY_LINKS` | `sentinel_camera_entry_links` | `{}` | Maps camera `entity_id` → list of entry/lock `entity_id`s in other HA areas. Used by the `camera_entry_unsecured` rule for cameras that physically overlook entries not in the same HA area (e.g. `{"camera.driveway": ["lock.front_door"]}`). |
 | `RECOMMENDED_SENTINEL_RULE_ENTITY_EXCLUSIONS` | `sentinel_rule_entity_exclusions` | `{}` | Maps an anomaly type (or `"*"` for all types) → list of `entity_id`s or glob patterns (`*` and `?` wildcards only) to exclude from that rule. Type keys are exact; entries may use only lowercase entity-ID characters plus the wildcards, must contain a dot and at least one literal character, and be at most 256 characters (match-all entries like `"*"`, `"*.*"`, or character-class tricks like `"[!.]*.*"` are rejected). Applied to all finding sources (static rules, dynamic rules, baseline) before correlation and dispatch; exclusions under the entity's domain-mapped anomaly type or `"*"` also suppress event-driven triggering — those entities' state changes do not enqueue triggers (e.g. `{"appliance_power_duration": ["sensor.living_room_ac_power"], "camera_entry_unsecured": ["camera.map_*"]}`). |
-| `RECOMMENDED_SENTINEL_APPLIANCE_POWER_THRESHOLD_W` | `sentinel_appliance_power_threshold_w` | `100.0` (W) | Power level the `appliance_power_duration` rule treats as "appliance running" |
+| `RECOMMENDED_SENTINEL_APPLIANCE_POWER_THRESHOLD_W` | `sentinel_appliance_power_threshold_w` | `100.0` (W) | Power level the `appliance_power_duration` rule treats as "appliance running". Sensor readings are normalized to watts from any HA power unit (W, kW, MW, GW, TW, mW, BTU/h) before comparison; power sensors reporting a non-power unit (e.g. VA) are skipped. |
 | `RECOMMENDED_SENTINEL_APPLIANCE_DURATION_MIN` | `sentinel_appliance_duration_min` | `60` (min) | Continuous minutes above the power threshold before `appliance_power_duration` fires |
 
 **Code-only:**
@@ -287,6 +287,8 @@ This document covers the named constants that affect integration behaviour, orga
 |---|---|---|---|
 | `SENTINEL_CAMERA_ACTIVITY_STALENESS_MINUTES` | `const.py` | `10` | Staleness gate for `alarm_disarmed_during_external_threat`. Camera activity must be within this window of the snapshot to fire the rule. |
 | `SENTINEL_OCCUPANCY_ARMED_STATES` | `const.py` | `{"armed_home", "armed_night"}` | Alarm states treated as occupancy-compatible. These states never trigger an `alarm_state_mismatch` finding when `expected_presence=home`. |
+| `_POWER_OFF_W` | `sentinel/power_enrichment.py` | `10.0` (W) | Below this wattage a power sensor is treated as "appliance off" when walking recorder history for the last off→on transition. Only affects the enriched `last_changed` used as advisory context (dynamic rules, triage); the `appliance_power_duration` rule measures duration by direct observation and does not use it. |
+| `_LOOKBACK_DAYS` | `sentinel/power_enrichment.py` | `30` (days) | Recorder history window searched for a power sensor's last off→on transition. |
 | `SENTINEL_ADMISSION_TIMEOUT_S` | `core/utils.py` | `2.0` (s) | How long a Sentinel LLM call waits for the chat/video foreground to become idle before deferring. Keeps interactive latency unaffected by Sentinel background work. |
 | `_SENTINEL_STARVATION_WARN_S` | `core/utils.py` | `300.0` (s) | Consecutive deferral duration that triggers a `degraded` sentinel health state and a WARNING log. |
 | `_SENTINEL_CANCEL_WAIT_S` | `core/utils.py` | `2.0` (s) | Grace period given to a Sentinel task to cancel cleanly when a chat turn begins. |
@@ -358,9 +360,9 @@ This document covers the named constants that affect integration behaviour, orga
 | Constant | File | Value | Purpose |
 |---|---|---|---|
 | `COMPLETION_THRESHOLD_PCT` | `sentinel/baseline.py` | `0.10` | Appliance cycle-completion threshold: power must drop below 10% of baseline to be considered complete |
-| `COMPLETION_MIN_ACTIVE_WATTS` | `sentinel/baseline.py` | `100.0` (W) | Minimum baseline wattage to consider cycle-completion detection meaningful |
+| `COMPLETION_MIN_ACTIVE_WATTS` | `sentinel/baseline.py` | `100.0` (W) | Minimum baseline wattage to consider cycle-completion detection meaningful. The native baseline is normalized to watts first (1.2 kW = 1200 W). |
 | `COMPLETION_RECENCY_SECS` | `sentinel/baseline.py` | `900` (s) | Recency window for completion detection |
-| `MINIMUM_POWER_DEVIATION_WATTS` | `sentinel/baseline.py` | `50.0` (W) | Absolute minimum power deviation required to fire a baseline anomaly, even if percent threshold is met |
+| `MINIMUM_POWER_DEVIATION_WATTS` | `sentinel/baseline.py` | `50.0` (W) | Absolute minimum power deviation required to fire a baseline anomaly, even if percent threshold is met. The deviation is normalized to watts from any HA power unit; power sensors in a non-power unit (e.g. VA) skip this guard rather than compare raw. |
 
 ---
 

--- a/docs/constants.md
+++ b/docs/constants.md
@@ -287,7 +287,7 @@ This document covers the named constants that affect integration behaviour, orga
 |---|---|---|---|
 | `SENTINEL_CAMERA_ACTIVITY_STALENESS_MINUTES` | `const.py` | `10` | Staleness gate for `alarm_disarmed_during_external_threat`. Camera activity must be within this window of the snapshot to fire the rule. |
 | `SENTINEL_OCCUPANCY_ARMED_STATES` | `const.py` | `{"armed_home", "armed_night"}` | Alarm states treated as occupancy-compatible. These states never trigger an `alarm_state_mismatch` finding when `expected_presence=home`. |
-| `_POWER_OFF_W` | `sentinel/power_enrichment.py` | `10.0` (W) | Below this wattage a power sensor is treated as "appliance off" when walking recorder history for the last off→on transition. Only affects the enriched `last_changed` used as advisory context (dynamic rules, triage); the `appliance_power_duration` rule measures duration by direct observation and does not use it. |
+| `_POWER_OFF_W` | `sentinel/power_enrichment.py` | `10.0` (W) | At or below this wattage a power sensor is treated as "appliance off" when walking recorder history for the last off→on transition. Only affects the enriched `last_changed` consumed downstream (dynamic rules, triage context, and the baseline cycle-completion recency window); the `appliance_power_duration` rule measures duration by direct observation and does not use it. |
 | `_LOOKBACK_DAYS` | `sentinel/power_enrichment.py` | `30` (days) | Recorder history window searched for a power sensor's last off→on transition. |
 | `SENTINEL_ADMISSION_TIMEOUT_S` | `core/utils.py` | `2.0` (s) | How long a Sentinel LLM call waits for the chat/video foreground to become idle before deferring. Keeps interactive latency unaffected by Sentinel background work. |
 | `_SENTINEL_STARVATION_WARN_S` | `core/utils.py` | `300.0` (s) | Consecutive deferral duration that triggers a `degraded` sentinel health state and a WARNING log. |
@@ -353,7 +353,7 @@ This document covers the named constants that affect integration behaviour, orga
 | `RECOMMENDED_SENTINEL_BASELINE_DRIFT_THRESHOLD_PCT` | `sentinel_baseline_drift_threshold_pct` | `30.0` | Percent deviation from rolling average that triggers a `baseline_deviation` or `time_of_day_anomaly` finding |
 | `RECOMMENDED_SENTINEL_BASELINE_WEEKLY_PATTERNS` | `sentinel_baseline_weekly_patterns` | `False` | Enable per-(day-of-week, hour) baselines for `time_of_day_anomaly`. Requires more data to warm up. |
 | `RECOMMENDED_SENTINEL_BASELINE_DOW_MIN_SAMPLES` | `sentinel_baseline_dow_min_samples` | `4` | Observations per DOW-hour slot before the DOW blend weight reaches 1.0. Lower than global min because DOW slots update at most once per week. |
-| `RECOMMENDED_SENTINEL_BASELINE_SUSTAINED_MINUTES` | `sentinel_baseline_sustained_minutes` | `20` | For cyclic loads (fridge, compressor), the deviation must persist this long before firing. Set `0` to disable the sustained gate. |
+| `RECOMMENDED_SENTINEL_BASELINE_SUSTAINED_MINUTES` | `sentinel_baseline_sustained_minutes` | `45` | For cyclic loads (fridge, compressor), the deviation must persist this long before firing. Set `0` to disable the sustained gate. |
 
 **Code-only:**
 

--- a/docs/sentinel.md
+++ b/docs/sentinel.md
@@ -88,7 +88,7 @@ These rules run on every detection cycle without any configuration or approval.
 
 | Rule | Description |
 |---|---|
-| `appliance_power_duration` | Appliance observed drawing more than `sentinel_appliance_power_threshold_w` (default 100 W) continuously for longer than `sentinel_appliance_duration_min` (default 60 min), measured from when the sensor was first seen above the threshold (e.g. *"Washer drew about 296 W for 633 min, above the 60 min threshold. Check it."*). Both thresholds are configurable in the Sentinel subentry (Advanced setup). Readings are normalized to watts from any HA power unit (W, kW, MW, GW, TW, mW, BTU/h), matching unit strings case-insensitively where unambiguous (`mW` vs `MW` must match exact-case); power sensors reporting a non-power unit (e.g. VA) are skipped rather than compared raw, with a once-per-unit debug log. |
+| `appliance_power_duration` | Appliance observed drawing at or above `sentinel_appliance_power_threshold_w` (default 100 W) continuously for at least `sentinel_appliance_duration_min` (default 60 min), measured from when the sensor was first seen above the threshold (e.g. *"Washer drew about 296 W for 633 min, above the 60 min threshold. Check it."*). Both thresholds are configurable in the Sentinel subentry (Advanced setup). Readings are normalized to watts from any HA power unit (W, kW, MW, GW, TW, mW, BTU/h), matching unit strings case-insensitively where unambiguous (`mW` vs `MW` must match exact-case); power sensors reporting a non-power unit (e.g. VA) are skipped rather than compared raw, with a once-per-unit debug log. |
 
 **Cameras**
 
@@ -193,7 +193,7 @@ When `sentinel_baseline_enabled` is `true` and `sentinel_enabled` is `true`, a b
 
 On each detection cycle the engine reads current baseline values and passes them to dynamic-rule evaluators. Two temporal templates are always registered:
 
-- **`baseline_deviation`** — fires when a numeric entity state deviates from its rolling average by more than `threshold_pct` percent (default `50.0`).
+- **`baseline_deviation`** — fires when a numeric entity state deviates from its rolling average by at least `threshold_pct` percent (default `50.0`).
 - **`time_of_day_anomaly`** — fires when a numeric entity state differs from the expected hour-of-day rolling average by more than `threshold_pct` percent (default `50.0`). When day-of-week baselines are enabled, this template uses a weighted blend of the DOW-hour mean and the global hourly mean, transitioning smoothly from global to DOW baselines as data accumulates.
 
 Both templates produce no findings while the table is empty — baselines accumulate over time.

--- a/docs/sentinel.md
+++ b/docs/sentinel.md
@@ -88,7 +88,7 @@ These rules run on every detection cycle without any configuration or approval.
 
 | Rule | Description |
 |---|---|
-| `appliance_power_duration` | Appliance observed drawing more than `sentinel_appliance_power_threshold_w` (default 100 W) continuously for longer than `sentinel_appliance_duration_min` (default 60 min), measured from when the sensor was first seen above the threshold (e.g. *"Washer drew about 296 W for 633 min, above the 60 min threshold. Check it."*). Both thresholds are configurable in the Sentinel subentry (Advanced setup). |
+| `appliance_power_duration` | Appliance observed drawing more than `sentinel_appliance_power_threshold_w` (default 100 W) continuously for longer than `sentinel_appliance_duration_min` (default 60 min), measured from when the sensor was first seen above the threshold (e.g. *"Washer drew about 296 W for 633 min, above the 60 min threshold. Check it."*). Both thresholds are configurable in the Sentinel subentry (Advanced setup). Readings are normalized to watts from any HA power unit (W, kW, MW, GW, TW, mW, BTU/h), matching unit strings case-insensitively where unambiguous (`mW` vs `MW` must match exact-case); power sensors reporting a non-power unit (e.g. VA) are skipped rather than compared raw, with a once-per-unit debug log. |
 
 **Cameras**
 
@@ -491,7 +491,7 @@ In the Sentinel subentry:
 | `sentinel_area_notify_map` | Area name → notify service (e.g. `{"Garage": "notify.mobile_app_garage_tablet"}`) |
 | `sentinel_camera_entry_links` | Camera entity ID → list of entry/lock entity IDs in other areas (e.g. `{"camera.driveway": ["lock.front_door"]}`) |
 | `sentinel_rule_entity_exclusions` | Anomaly type (or `"*"` for all) → list of entity IDs or glob patterns excluded from that rule; exclusions under the entity's domain-mapped type or `"*"` also suppress event-driven triggering (e.g. `{"appliance_power_duration": ["sensor.ac_power"], "camera_entry_unsecured": ["camera.map_*"]}`) |
-| `sentinel_appliance_power_threshold_w` | `appliance_power_duration`: power level treated as "running" (default 100 W) |
+| `sentinel_appliance_power_threshold_w` | `appliance_power_duration`: power level treated as "running" (default 100 W); readings in any HA power unit are normalized to watts before comparison |
 | `sentinel_appliance_duration_min` | `appliance_power_duration`: continuous minutes above the threshold before alerting (default 60) |
 | `audit_hot_max_records` | Max records in local hot store (default 500) |
 

--- a/tests/custom_components/home_generative_agent/test_power_enrichment.py
+++ b/tests/custom_components/home_generative_agent/test_power_enrichment.py
@@ -55,10 +55,15 @@ def _power_entity(
     }
 
 
-def _mock_state(state: str, last_changed: datetime) -> MagicMock:
+def _mock_state(
+    state: str, last_changed: datetime, unit: str | None = None
+) -> MagicMock:
     s = MagicMock()
     s.state = state
     s.last_changed = last_changed
+    # No unit → empty attributes dict: the walk falls back to the sensor's
+    # current unit factor, matching rows recorded without attribute payloads.
+    s.attributes = {"unit_of_measurement": unit} if unit is not None else {}
     return s
 
 
@@ -197,6 +202,187 @@ async def test_kw_unit_sensor_corrected() -> None:
     await async_enrich_power_last_changed(hass, snapshot)
 
     assert snapshot["entities"][0]["last_changed"] == true_on_time.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_mw_unit_sensor_corrected() -> None:
+    """MW-unit sensor: off threshold applied in native MW units."""
+    true_on_time = _NOW - timedelta(hours=2, minutes=16)
+
+    recorder_states = [
+        _mock_state("0.000001", _NOW - timedelta(hours=2, minutes=17)),  # 1W — off
+        _mock_state("0.0015", true_on_time),  # 1500W — on
+        _mock_state("unavailable", _NOW),
+        _mock_state("0.0015", _NOW),
+    ]
+    hass = _make_hass(recorder_states)
+
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [
+        _power_entity(
+            state="0.0015", unit="MW", last_changed="2026-06-22T05:16:00+00:00"
+        )
+    ]
+
+    await async_enrich_power_last_changed(hass, snapshot)
+
+    assert snapshot["entities"][0]["last_changed"] == true_on_time.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_non_power_unit_sensor_skipped() -> None:
+    """A device_class:power sensor in VA cannot be compared to the watts off level."""
+    hass = MagicMock()
+    instance = MagicMock()
+    instance.async_add_executor_job = AsyncMock()
+    hass.data = {DATA_INSTANCE: instance}
+
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [
+        _power_entity(state="1500", unit="VA", last_changed="2026-06-22T05:16:00+00:00")
+    ]
+
+    await async_enrich_power_last_changed(hass, snapshot)
+
+    instance.async_add_executor_job.assert_not_called()
+    assert snapshot["entities"][0]["last_changed"] == "2026-06-22T05:16:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_unit_only_sensor_enriched() -> None:
+    """A sensor with a power unit but no device_class is still enriched."""
+    true_on_time = _NOW - timedelta(hours=2, minutes=16)
+
+    recorder_states = [
+        _mock_state("2", _NOW - timedelta(hours=2, minutes=17)),  # off
+        _mock_state("1500", true_on_time),  # on
+        _mock_state("1500", _NOW),
+    ]
+    hass = _make_hass(recorder_states)
+
+    snapshot = _base_snapshot()
+    entity = _power_entity(state="1500", last_changed="2026-06-22T05:16:00+00:00")
+    entity["attributes"] = {"unit_of_measurement": "W"}
+    snapshot["entities"] = [entity]
+
+    await async_enrich_power_last_changed(hass, snapshot)
+
+    assert snapshot["entities"][0]["last_changed"] == true_on_time.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_missing_unit_sensor_treated_as_watts() -> None:
+    """A device_class:power sensor with no unit is compared in watts."""
+    true_on_time = _NOW - timedelta(hours=2, minutes=16)
+
+    recorder_states = [
+        _mock_state("2", _NOW - timedelta(hours=2, minutes=17)),  # off
+        _mock_state("1500", true_on_time),  # on
+        _mock_state("1500", _NOW),
+    ]
+    hass = _make_hass(recorder_states)
+
+    snapshot = _base_snapshot()
+    entity = _power_entity(state="1500", last_changed="2026-06-22T05:16:00+00:00")
+    entity["attributes"] = {"device_class": "power"}
+    snapshot["entities"] = [entity]
+
+    await async_enrich_power_last_changed(hass, snapshot)
+
+    assert snapshot["entities"][0]["last_changed"] == true_on_time.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_historical_rows_honor_their_own_unit() -> None:
+    """
+    A sensor reconfigured from W to kW mid-window walks history correctly.
+
+    The historical 5 (W, off) row must read as 5 W, not 5 kW: interpreting old
+    rows in the sensor's *current* unit would miss the off boundary and push
+    the on-since arbitrarily far back.
+    """
+    true_on_time = _NOW - timedelta(hours=2, minutes=16)
+
+    recorder_states = [
+        _mock_state("5", _NOW - timedelta(hours=2, minutes=17), unit="W"),  # off
+        _mock_state("1498", true_on_time, unit="W"),  # on, recorded as W
+        _mock_state("1.500", _NOW, unit="kW"),  # after unit reconfiguration
+    ]
+    hass = _make_hass(recorder_states)
+
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [
+        _power_entity(
+            state="1.500", unit="kW", last_changed="2026-06-22T05:16:00+00:00"
+        )
+    ]
+
+    await async_enrich_power_last_changed(hass, snapshot)
+
+    assert snapshot["entities"][0]["last_changed"] == true_on_time.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_non_finite_states_never_treated_as_on() -> None:
+    """
+    nan/inf states are rejected at both the current-state gate and the walk.
+
+    nan compares False against the off threshold, so without the isfinite
+    guard a nan reading would look 'on' and could be captured as the on-since
+    boundary — rewriting last_changed from garbage.
+    """
+    # Current state nan: enrichment skips the sensor without querying.
+    hass = MagicMock()
+    instance = MagicMock()
+    instance.async_add_executor_job = AsyncMock()
+    hass.data = {DATA_INSTANCE: instance}
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [
+        _power_entity(state="nan", last_changed="2026-06-22T05:16:00+00:00")
+    ]
+    await async_enrich_power_last_changed(hass, snapshot)
+    instance.async_add_executor_job.assert_not_called()
+
+    # Historical nan/inf rows are skipped like transients, not read as 'on'.
+    true_on_time = _NOW - timedelta(hours=2, minutes=16)
+    recorder_states = [
+        _mock_state("0.5", _NOW - timedelta(hours=2, minutes=17)),  # off
+        _mock_state("nan", _NOW - timedelta(hours=2, minutes=17)),
+        _mock_state("1498.5", true_on_time),  # true on-start
+        _mock_state("1e309", _NOW - timedelta(hours=1)),  # inf
+        _mock_state("1500.1", _NOW),
+    ]
+    hass = _make_hass(recorder_states)
+    snapshot = _base_snapshot()
+    snapshot["entities"] = [_power_entity(last_changed="2026-06-22T05:16:00+00:00")]
+    await async_enrich_power_last_changed(hass, snapshot)
+    assert snapshot["entities"][0]["last_changed"] == true_on_time.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_unhashable_unit_attribute_does_not_crash() -> None:
+    """
+    A poisoned unit_of_measurement (list) must not raise from the filter.
+
+    Raw frozenset membership hashes its operand; an unhashable unit on a
+    sensor without device_class:power previously raised TypeError, which
+    propagated out of the engine's unguarded enrichment call and killed the
+    Sentinel run loop until reload.
+    """
+    hass = MagicMock()
+    instance = MagicMock()
+    instance.async_add_executor_job = AsyncMock()
+    hass.data = {DATA_INSTANCE: instance}
+
+    snapshot = _base_snapshot()
+    entity = _power_entity(state="1500", last_changed="2026-06-22T05:16:00+00:00")
+    entity["attributes"] = {"unit_of_measurement": ["W"]}  # no device_class
+    snapshot["entities"] = [entity]
+
+    await async_enrich_power_last_changed(hass, snapshot)
+
+    instance.async_add_executor_job.assert_not_called()
+    assert snapshot["entities"][0]["last_changed"] == "2026-06-22T05:16:00+00:00"
 
 
 @pytest.mark.asyncio

--- a/tests/custom_components/home_generative_agent/test_power_units.py
+++ b/tests/custom_components/home_generative_agent/test_power_units.py
@@ -1,0 +1,87 @@
+# ruff: noqa: S101
+"""Tests for sentinel power unit normalization helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.home_generative_agent.sentinel.power_units import (
+    POWER_UNITS,
+    is_power_unit,
+    watts_per_unit,
+)
+
+
+def test_watts_per_unit_missing_unit_is_watts() -> None:
+    """Bare power sensors report watts by convention."""
+    assert watts_per_unit(None) == 1.0
+    assert watts_per_unit("") == 1.0
+
+
+def test_watts_per_unit_canonical_units() -> None:
+    """Every canonical HA power unit converts."""
+    assert watts_per_unit("W") == 1.0
+    assert watts_per_unit("kW") == 1000.0
+    assert watts_per_unit("MW") == pytest.approx(1e6)
+    assert watts_per_unit("GW") == pytest.approx(1e9)
+    assert watts_per_unit("TW") == pytest.approx(1e12)
+    assert watts_per_unit("mW") == pytest.approx(0.001)
+    assert watts_per_unit("BTU/h") == pytest.approx(0.29307107)
+
+
+def test_watts_per_unit_case_and_whitespace_variants() -> None:
+    """
+    Hand-typed unit spellings normalize when unambiguous.
+
+    ESPHome/MQTT/template configs carry free-text units; pre-normalization
+    these sensors were compared raw, so skipping them would be a silent
+    monitoring regression (issue #461 follow-up).
+    """
+    assert watts_per_unit("w") == 1.0
+    assert watts_per_unit(" W ") == 1.0
+    assert watts_per_unit("KW") == 1000.0
+    assert watts_per_unit("kw") == 1000.0
+    assert watts_per_unit("btu/h") == pytest.approx(0.29307107)
+
+
+def test_watts_per_unit_milli_mega_must_match_exact_case() -> None:
+    """Lowercase "mw" is ambiguous between mW (0.001) and MW (1e6) — never folded."""
+    assert watts_per_unit("mw") is None
+    assert watts_per_unit("Mw") is None
+    assert watts_per_unit("mW") == pytest.approx(0.001)
+    assert watts_per_unit("MW") == pytest.approx(1e6)
+    # Exact-case with surrounding whitespace must still match — stripping
+    # happens before the exact lookup, not only in the ambiguous fold.
+    assert watts_per_unit(" MW") == pytest.approx(1e6)
+    assert watts_per_unit("mW ") == pytest.approx(0.001)
+
+
+def test_watts_per_unit_non_power_units_rejected() -> None:
+    """Apparent power and other units cannot be compared to watts."""
+    assert watts_per_unit("VA") is None
+    assert watts_per_unit("kWh") is None
+    assert watts_per_unit("°C") is None
+
+
+def test_watts_per_unit_non_string_values() -> None:
+    """Malformed attribute values are coerced, never raise."""
+    assert watts_per_unit(0) is None  # falsy but not missing — not watts
+    assert watts_per_unit(["W"]) is None  # unhashable — coerced then rejected
+    assert watts_per_unit({"u": "W"}) is None
+
+
+def test_is_power_unit_admission_semantics() -> None:
+    """A missing unit alone must not make a sensor a power sensor."""
+    assert is_power_unit(None) is False
+    assert is_power_unit("") is False
+    assert is_power_unit("W") is True
+    assert is_power_unit("w") is True
+    assert is_power_unit("VA") is False
+    # Never raises on non-hashable attribute values (snapshot admission test).
+    assert is_power_unit(["W"]) is False
+    assert is_power_unit({"unit": "kW"}) is False
+
+
+def test_power_units_set_matches_ha() -> None:
+    """POWER_UNITS mirrors HA's PowerConverter units."""
+    assert {"W", "kW", "MW", "GW", "TW", "mW", "BTU/h"} == POWER_UNITS

--- a/tests/custom_components/home_generative_agent/test_rules_sentinel.py
+++ b/tests/custom_components/home_generative_agent/test_rules_sentinel.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+import pytest
+
 from custom_components.home_generative_agent.explain.prompts import SYSTEM_PROMPT
 from custom_components.home_generative_agent.sentinel.dynamic_rules import (
     evaluate_dynamic_rule,
@@ -343,11 +345,196 @@ def test_appliance_power_duration_kw_unit() -> None:
     assert findings[0].evidence["power_w"] == 250.0
 
 
+def test_appliance_power_duration_all_power_units_normalized() -> None:
+    """Every HA power unit is converted to W before the threshold comparison."""
+    for unit, state, expected_w in [
+        ("MW", "0.00025", 250.0),
+        ("GW", "0.00000025", pytest.approx(250.0)),
+        ("TW", "0.00000000025", pytest.approx(250.0)),
+        ("mW", "250000", 250.0),
+        ("BTU/h", "1000", pytest.approx(293.07107)),
+    ]:
+        rule = AppliancePowerDurationRule(duration_min=30)
+        entity = _power_entity(state=state, last_changed="2025-01-01T00:00:00+00:00")
+        entity["attributes"] = {"device_class": "power", "unit_of_measurement": unit}
+        snapshot = _base_snapshot()
+
+        snapshot["derived"]["now"] = "2025-01-01T00:00:00+00:00"
+        snapshot["entities"] = [entity]
+        assert rule.evaluate(snapshot) == [], unit
+
+        snapshot["derived"]["now"] = "2025-01-01T00:35:00+00:00"
+        findings = rule.evaluate(snapshot)
+        assert len(findings) == 1, unit
+        assert findings[0].evidence["power_w"] == expected_w, unit
+
+
+def test_appliance_power_duration_skips_non_power_units() -> None:
+    """
+    A device_class:power sensor in a non-power unit (e.g. VA) is skipped.
+
+    Comparing apparent power (or any unconvertible unit) raw against the
+    watts threshold would be silently wrong, and a switch to such a unit
+    mid-episode must also end the episode.
+    """
+    rule = AppliancePowerDurationRule(duration_min=30)
+    entity = _power_entity(state="250", last_changed="2025-01-01T00:00:00+00:00")
+    entity["attributes"] = {"device_class": "power", "unit_of_measurement": "VA"}
+    snapshot = _base_snapshot()
+    snapshot["derived"]["now"] = "2025-01-01T00:00:00+00:00"
+    snapshot["entities"] = [entity]
+    assert rule.evaluate(snapshot) == []
+    snapshot["derived"]["now"] = "2025-01-01T01:00:00+00:00"
+    assert rule.evaluate(snapshot) == []
+
+    # Episode started under "W" must reset when the unit becomes unconvertible.
+    rule = AppliancePowerDurationRule(duration_min=30)
+    assert _evaluate_power_at(rule, "2025-01-01T00:00:00+00:00", "250") == []
+    snapshot["derived"]["now"] = "2025-01-01T00:20:00+00:00"
+    snapshot["entities"] = [entity]
+    assert rule.evaluate(snapshot) == []
+    # Back to W: the clock restarted, so 25 min later there is still no finding.
+    assert _evaluate_power_at(rule, "2025-01-01T00:25:00+00:00", "250") == []
+    assert _evaluate_power_at(rule, "2025-01-01T00:45:00+00:00", "250") == []
+    findings = _evaluate_power_at(rule, "2025-01-01T00:56:00+00:00", "250")
+    assert len(findings) == 1
+
+
+def test_appliance_power_duration_unit_only_sensor_admitted() -> None:
+    """A sensor with a power unit but no device_class is still tracked."""
+    rule = AppliancePowerDurationRule(duration_min=30)
+    entity = _power_entity(state="0.25", last_changed="2025-01-01T00:00:00+00:00")
+    entity["attributes"] = {"unit_of_measurement": "kW"}
+    snapshot = _base_snapshot()
+
+    snapshot["derived"]["now"] = "2025-01-01T00:00:00+00:00"
+    snapshot["entities"] = [entity]
+    assert rule.evaluate(snapshot) == []
+
+    snapshot["derived"]["now"] = "2025-01-01T00:35:00+00:00"
+    findings = rule.evaluate(snapshot)
+    assert len(findings) == 1
+    assert findings[0].evidence["power_w"] == 250.0
+
+    # Without device_class, a non-power unit means the sensor is not a power
+    # sensor at all — it must never be admitted, no matter how long it reads
+    # above threshold.
+    rule = AppliancePowerDurationRule(duration_min=30)
+    entity = _power_entity(state="250", last_changed="2025-01-01T00:00:00+00:00")
+    entity["attributes"] = {"unit_of_measurement": "VA"}
+    snapshot["derived"]["now"] = "2025-01-01T00:00:00+00:00"
+    snapshot["entities"] = [entity]
+    assert rule.evaluate(snapshot) == []
+    snapshot["derived"]["now"] = "2025-01-01T01:00:00+00:00"
+    assert rule.evaluate(snapshot) == []
+
+
+def test_appliance_power_duration_missing_unit_treated_as_watts() -> None:
+    """A device_class:power sensor with no unit is compared as watts."""
+    rule = AppliancePowerDurationRule(duration_min=30)
+    entity = _power_entity(state="250", last_changed="2025-01-01T00:00:00+00:00")
+    entity["attributes"] = {"device_class": "power"}
+    snapshot = _base_snapshot()
+
+    snapshot["derived"]["now"] = "2025-01-01T00:00:00+00:00"
+    snapshot["entities"] = [entity]
+    assert rule.evaluate(snapshot) == []
+
+    snapshot["derived"]["now"] = "2025-01-01T00:35:00+00:00"
+    findings = rule.evaluate(snapshot)
+    assert len(findings) == 1
+    assert findings[0].evidence["power_w"] == 250.0
+
+
+def test_appliance_power_duration_unhashable_unit_does_not_crash() -> None:
+    """
+    A poisoned unit_of_measurement (list) must not raise from the filter.
+
+    Raw frozenset membership hashes its operand; TypeError here fails the
+    whole rule for every entity on every cycle (engine catches per-rule),
+    silently disabling appliance monitoring while the poisoned entity exists.
+    """
+    rule = AppliancePowerDurationRule(duration_min=30)
+    entity = _power_entity(state="250", last_changed="2025-01-01T00:00:00+00:00")
+    entity["attributes"] = {"unit_of_measurement": ["W"]}  # no device_class
+    snapshot = _base_snapshot()
+    snapshot["derived"]["now"] = "2025-01-01T00:00:00+00:00"
+    snapshot["entities"] = [entity]
+    assert rule.evaluate(snapshot) == []
+    snapshot["derived"]["now"] = "2025-01-01T01:00:00+00:00"
+    assert rule.evaluate(snapshot) == []
+
+
+def test_appliance_power_duration_case_variant_unit_still_monitored() -> None:
+    """
+    A hand-typed unit like "w" (ESPHome/MQTT free text) keeps monitoring.
+
+    Pre-normalization these sensors were compared raw as watts; skipping them
+    for case alone would silently disable the rule for that appliance.
+    """
+    rule = AppliancePowerDurationRule(duration_min=30)
+    entity = _power_entity(state="250", last_changed="2025-01-01T00:00:00+00:00")
+    entity["attributes"] = {"device_class": "power", "unit_of_measurement": "w"}
+    snapshot = _base_snapshot()
+    snapshot["derived"]["now"] = "2025-01-01T00:00:00+00:00"
+    snapshot["entities"] = [entity]
+    assert rule.evaluate(snapshot) == []
+
+    snapshot["derived"]["now"] = "2025-01-01T00:35:00+00:00"
+    findings = rule.evaluate(snapshot)
+    assert len(findings) == 1
+    assert findings[0].evidence["power_w"] == 250.0
+
+
+def test_appliance_power_duration_reclassified_entity_resets_episode() -> None:
+    """
+    An entity that stops being a power sensor ends its episode eagerly.
+
+    Attributes changing mid-episode (device_class cleared, unit no longer a
+    power unit) must reset the rising-edge tracker on the classification skip
+    path itself, not only in the post-loop sweep.
+    """
+    rule = AppliancePowerDurationRule(duration_min=30)
+    assert _evaluate_power_at(rule, "2025-01-01T00:00:00+00:00", "250") == []
+
+    entity = _power_entity(state="250", last_changed="2025-01-01T00:20:00+00:00")
+    entity["attributes"] = {"device_class": "temperature", "unit_of_measurement": "°C"}
+    snapshot = _base_snapshot()
+    snapshot["derived"]["now"] = "2025-01-01T00:20:00+00:00"
+    snapshot["entities"] = [entity]
+    assert rule.evaluate(snapshot) == []
+    assert not rule._above_since  # eager reset is the invariant under test
+
+    # Back to a power sensor: the clock restarted at 00:25.
+    assert _evaluate_power_at(rule, "2025-01-01T00:25:00+00:00", "250") == []
+    assert _evaluate_power_at(rule, "2025-01-01T00:45:00+00:00", "250") == []
+    findings = _evaluate_power_at(rule, "2025-01-01T00:56:00+00:00", "250")
+    assert len(findings) == 1
+
+
 def test_appliance_power_duration_ignores_non_finite_readings() -> None:
     """A 'nan' state must not count as above threshold (nan < x is False)."""
     rule = AppliancePowerDurationRule(duration_min=30)
     assert _evaluate_power_at(rule, "2025-01-01T00:00:00+00:00", "nan") == []
     assert _evaluate_power_at(rule, "2025-01-01T01:00:00+00:00", "nan") == []
+
+
+def test_appliance_power_duration_rejects_overflow_after_conversion() -> None:
+    """
+    A finite native reading that overflows to inf in watts is rejected.
+
+    1e300 TW converts to inf; an inf power_w in evidence would crash the
+    notifier's round() during dispatch and end the Sentinel run loop.
+    """
+    rule = AppliancePowerDurationRule(duration_min=30)
+    entity = _power_entity(state="1e300", last_changed="2025-01-01T00:00:00+00:00")
+    entity["attributes"] = {"device_class": "power", "unit_of_measurement": "TW"}
+    snapshot = _base_snapshot()
+    snapshot["derived"]["now"] = "2025-01-01T00:00:00+00:00"
+    snapshot["entities"] = [entity]
+    assert rule.evaluate(snapshot) == []
+    snapshot["derived"]["now"] = "2025-01-01T01:00:00+00:00"
+    assert rule.evaluate(snapshot) == []
 
 
 def test_appliance_power_duration_friendly_name_excluded_from_anomaly_id() -> None:

--- a/tests/custom_components/home_generative_agent/test_sentinel_baseline.py
+++ b/tests/custom_components/home_generative_agent/test_sentinel_baseline.py
@@ -1203,6 +1203,26 @@ def test_baseline_deviation_standby_baseline_not_completion() -> None:
     assert len(findings) == 0
 
 
+def test_baseline_deviation_rejects_non_finite_readings() -> None:
+    """
+    nan/inf states must not produce findings.
+
+    A nan current_value defeats every comparison, and an inf deviation_pct in
+    evidence would crash the notifier's round() during dispatch.
+    """
+    for bad_state in ("nan", "inf", "1e309"):
+        snapshot = _snapshot(
+            [
+                _power_entity(
+                    "sensor.washer_power", bad_state, device_class="power", unit="W"
+                )
+            ]
+        )
+        baselines = {"sensor.washer_power": {METRIC_ROLLING_AVG: 800.0}}
+        rule = _rule(entity_id="sensor.washer_power", threshold_pct=50.0)
+        assert evaluate_baseline_deviation(snapshot, rule, baselines) == [], bad_state
+
+
 def test_baseline_deviation_standby_guard_normalizes_all_power_units() -> None:
     """
     A kW-beyond unit (MW) is normalized to watts before the standby guard.

--- a/tests/custom_components/home_generative_agent/test_sentinel_baseline.py
+++ b/tests/custom_components/home_generative_agent/test_sentinel_baseline.py
@@ -1203,6 +1203,65 @@ def test_baseline_deviation_standby_baseline_not_completion() -> None:
     assert len(findings) == 0
 
 
+def test_baseline_deviation_standby_guard_normalizes_all_power_units() -> None:
+    """
+    A kW-beyond unit (MW) is normalized to watts before the standby guard.
+
+    A washer sensor in MW dropping 0.0002 MW (200 W) is a real deviation: the
+    raw native value (0.0002) is far below MINIMUM_POWER_DEVIATION_WATTS, so
+    comparing it un-normalized would silently suppress the finding.
+    """
+    snapshot = _snapshot(
+        [_power_entity("sensor.washer_power", "0.0", device_class="power", unit="MW")]
+    )
+    baselines = {"sensor.washer_power": {METRIC_ROLLING_AVG: 0.0002}}
+    rule = _rule(entity_id="sensor.washer_power", threshold_pct=50.0)
+
+    findings = evaluate_baseline_deviation(snapshot, rule, baselines)
+
+    assert len(findings) == 1
+
+
+def test_baseline_deviation_non_power_unit_skips_standby_guard() -> None:
+    """
+    A device_class:power sensor in VA cannot be normalized to watts.
+
+    The standby guard is skipped rather than fed a raw apparent-power value,
+    so the deviation still notifies.
+    """
+    snapshot = _snapshot(
+        [_power_entity("sensor.washer_power", "0.0", device_class="power", unit="VA")]
+    )
+    baselines = {"sensor.washer_power": {METRIC_ROLLING_AVG: 30.0}}
+    rule = _rule(entity_id="sensor.washer_power", threshold_pct=50.0)
+
+    findings = evaluate_baseline_deviation(snapshot, rule, baselines)
+
+    assert len(findings) == 1
+
+
+def test_baseline_deviation_kw_appliance_completion_detected() -> None:
+    """
+    Completion detection normalizes the active-wattage floor for kW sensors.
+
+    A washer with a 1.2 kW baseline (1200 W) dropping to 0.05 kW is a cycle
+    end; comparing the native 1.2 against COMPLETION_MIN_ACTIVE_WATTS=100
+    un-normalized would silently disable completion downgrading for every
+    kW-denominated appliance.
+    """
+    snapshot = _snapshot(
+        [_power_entity("sensor.washer_power", "0.05", device_class="power", unit="kW")]
+    )
+    baselines = {"sensor.washer_power": {METRIC_ROLLING_AVG: 1.2}}
+    rule = _rule(entity_id="sensor.washer_power", threshold_pct=50.0, severity="medium")
+
+    findings = evaluate_baseline_deviation(snapshot, rule, baselines)
+
+    assert len(findings) == 1
+    assert findings[0].evidence.get("is_completion") is True
+    assert findings[0].severity == "low"
+
+
 def test_baseline_deviation_stale_idle_appliance_not_completion() -> None:
     """
     Appliance idle for longer than COMPLETION_RECENCY_SECS → no is_completion.


### PR DESCRIPTION
## Summary

Follow-up to @andymcmanus's comments on #461: his "does the engine normalise units before comparing to the threshold?" question was a yes for W/kW — and a silent no for everything else. This PR closes that class everywhere Sentinel compares power to watts, then fixes what four review passes found around it.

**Unit normalization (#461)**
- New `sentinel/power_units.py` (`watts_per_unit` / `is_power_unit`) built on HA's `PowerConverter`. All seven HA power units (W, kW, MW, GW, TW, mW, BTU/h) normalize to watts in the `appliance_power_duration` rule and power enrichment; previously only kW converted, so a 0.25 MW reading compared as 0.25 W — silently.
- `device_class: power` sensors in a non-power unit (VA) are skipped rather than compared raw; skipping ends any in-progress episode.
- Hand-typed unit spellings ("w", "KW", " MW") match case-insensitively/whitespace-stripped where unambiguous; lowercase "mw" (mW vs MW) requires exact-case. Unrecognized units log once per distinct string.

**Baseline consumers of the same bug class**
- Standby-noise guard normalizes deviations from any power unit (a 200 W drop on an MW washer sensor read as 0.0002 raw and was suppressed).
- Cycle-completion floor compares in watts — kW appliances (`1.2 >= 100` never true) never got completion downgrades before.
- Unconvertible units skip the guard (fail open) while completion fails closed: both directions prefer visibility over suppression.

**Robustness (found by adversarial review, empirically reproduced)**
- An unhashable `unit_of_measurement` (list/dict via REST API or misbehaving integrations) crashed the raw frozenset membership test; in enrichment that exception killed the Sentinel run loop until reload. Admission now goes through the str-safe helper, and the engine wraps all snapshot enrichment so any failure degrades to un-enriched snapshots instead of ending detection.
- Finite readings that overflow to inf in watts (1e300 TW) are rejected post-conversion — an inf `power_w` in evidence would crash the notifier's `round()` during dispatch. The baseline evaluators get the same isfinite guard on parsed states (nan/inf → no finding).
- The enrichment recorder walk honors each historical row's own unit (a W→kW reconfiguration mid-window no longer corrupts the on-since search) and rejects nan/inf rows, mirroring the rule's existing guard.

## Test Coverage

Coverage audit (subagent): **100% of diff branches**, 0 gaps. Tests: 1753 → 1776 (+23 new).

```
Event flow: sensor state -> snapshot -> [enrichment (pre-rules)] -> [rule evaluate] -> AnomalyFinding

power_units.watts_per_unit(unit)                       [100% line+branch]
|- unit None/"" -> 1.0            *** missing-unit tests, rule + enrichment
|- unit not in POWER_UNITS -> None *** VA skip tests, both call sites
|- case/whitespace variants        *** "w"/"KW"/" MW"; "mw" ambiguity pinned
|- unhashable values -> False/None *** list/dict units never raise
`- known unit -> factor            *** all seven units, exact evidence values

AppliancePowerDurationRule.evaluate
|- filter: device_class=="power" OR is_power_unit(unit)
|  |- admit via device_class / via unit only / reject VA   *** all tested
|  `- reclassified entity resets episode eagerly           *** tested
|- non-finite native OR inf-after-conversion -> reset      *** nan + 1e300 TW
|- power_val *= factor; threshold; duration                *** existing + per-unit

async_enrich_power_last_changed
|- filter broadened, crash-safe                            *** incl. poisoned-unit test
|- per-row units honored (W->kW mid-window)                *** tested
|- nan/inf rows and off-threshold in watts                 *** tested
`- recorder walk / fallbacks                               *** existing suite

evaluate_baseline_deviation
|- MW deviation normalized (was false-negative)            *** tested
|- VA skips standby guard, still notifies                  *** tested
`- kW completion floor normalized                          *** tested
```

## Pre-Landing Review

17 findings across 5 passes — 15 fixed in-branch, 2 deferred with TODOS entries, 0 open.

- Checklist (inline): baseline W/kW-only enum gap → **fixed**; notifier display-unit guess → **deferred (P3 TODO)**.
- Testing specialist: 2 coverage gaps → **fixed** (tests added).
- Maintainability specialist: coercion split across call sites, missing eager episode-pop → **fixed**.
- Red team: **[CRITICAL]** unhashable-unit TypeError kills Sentinel loop (empirical repro) → **fixed + engine guard**; case-variant regression, nan/inf in `_parse_float` → **fixed**.

## Adversarial Review (cross-model)

Models: Claude structured ✓ Claude adversarial ✓ Codex adversarial ✓ Codex structured ✓ (gate: **PASS**, no P1 in structured review)

- High confidence (multiple sources): case-variant unit skip (**fixed**), non-finite handling (**fixed**), unbounded recorder walk (**deferred, P2 TODO** — pre-existing).
- Unique to Claude adversarial: historical-row unit mismatch (**fixed**); VA guard fail-direction (**kept by design, documented** — both failure directions prefer visibility).
- Unique to Codex: post-conversion inf overflow (**fixed**); native-unit baseline storage corrupts on unit reconfiguration (**deferred, P3 TODO** — pre-existing design property); ` MW`/`mW ` whitespace P2 (**fixed**).

## Eval Results

No prompt-related files changed — evals skipped.

## Scope Drift

Scope Check: CLEAN. Intent: normalize power units per #461 follow-up; delivered exactly that plus review-driven hardening of the same code paths.

## Plan Completion

No plan file detected (issue-response work).

## TODOS

- Added 4 entries: notifier display-unit plumbing (P3), dynamic `sensor_threshold_condition` normalization (P3), baseline unit-normalized storage (P3), bounded enrichment recorder walk (P2).
- No existing TODO items completed by this PR.

## Documentation

Docs shipped in-branch with the code; a cross-model doc review (Codex, read-only) then verified them against the shipped diff. 5 verified precision fixes landed in `9b7248a`:

- **docs/constants.md** — `_POWER_OFF_W` boundary is inclusive (exactly 10 W is "off", code uses `<=`); its enriched `last_changed` is also consumed by baseline cycle-completion recency, not just dynamic rules/triage; `sentinel_baseline_sustained_minutes` default corrected 20 → 45 to match `const.py`.
- **docs/sentinel.md** — `appliance_power_duration` fires at-or-above the power threshold for at least the duration (both boundaries inclusive per code); `baseline_deviation` fires at at-least `threshold_pct` (`time_of_day_anomaly` is strictly-greater and keeps "more than").
- **TODOS.md** — `sensor_threshold_condition` only extracts above-thresholds today (impossible "below 1 kW" example removed); DOW baseline slots use Welford accumulators, not EMA.

CHANGELOG v3.21.3 entry preserved verbatim. README verified: no appliance-power content to update. The doc review's remaining debt notes (baseline isfinite gap, stale enrichment docstring) were closed in `ae90f23` rather than left as debt.

## Test plan

- [x] Full pytest suite: 1776 passed, 0 failures (`make test`)
- [x] `make lint` clean (ruff format + check, manifest sync)
- [x] pyright: 0 errors, 0 warnings (full `make typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gfi8TfJvQinAJq1WXB3ApT
