### PR TITLE
fix: sanitize invalid 'required' in anyOf branches for Gemini tool schemas

### DIFF
--- a/custom_components/home_generative_agent/agent/graph.py
+++ b/custom_components/home_generative_agent/agent/graph.py
@@ -1236,8 +1236,7 @@ def _ensure_array_items(schema: dict[str, Any]) -> dict[str, Any]:
 
 def _sanitize_any_of_required(schema: dict[str, Any]) -> dict[str, Any]:
     """
-    Strip 'required' from anyOf branches that aren't type:object, or whose
-    required properties aren't defined in that branch's 'properties'.
+    Strip invalid 'required' entries from anyOf branches.
 
     Gemini rejects 'required' on non-OBJECT anyOf variants, and rejects
     required entries that reference an undefined property. voluptuous_openapi
@@ -1246,22 +1245,24 @@ def _sanitize_any_of_required(schema: dict[str, Any]) -> dict[str, Any]:
     """
     if "anyOf" in schema:
         new_variants = []
-        for variant in schema["anyOf"]:
-            if isinstance(variant, dict):
-                variant = _sanitize_any_of_required(variant)
-                if "required" in variant:
-                    props = variant.get("properties", {})
-                    if variant.get("type") != "object":
-                        variant = {
-                            k: v for k, v in variant.items() if k != "required"
+        for raw_variant in schema["anyOf"]:
+            variant = raw_variant
+            if isinstance(raw_variant, dict):
+                sanitized = _sanitize_any_of_required(raw_variant)
+                if "required" in sanitized:
+                    props = sanitized.get("properties", {})
+                    if sanitized.get("type") != "object":
+                        sanitized = {
+                            k: v for k, v in sanitized.items() if k != "required"
                         }
                     else:
-                        req = [r for r in variant["required"] if r in props]
-                        variant = (
-                            {**variant, "required": req}
+                        req = [r for r in sanitized["required"] if r in props]
+                        sanitized = (
+                            {**sanitized, "required": req}
                             if req
-                            else {k: v for k, v in variant.items() if k != "required"}
+                            else {k: v for k, v in sanitized.items() if k != "required"}
                         )
+                variant = sanitized
             new_variants.append(variant)
         schema = {**schema, "anyOf": new_variants}
     if "properties" in schema:

--- a/custom_components/home_generative_agent/agent/graph.py
+++ b/custom_components/home_generative_agent/agent/graph.py
@@ -1234,6 +1234,48 @@ def _ensure_array_items(schema: dict[str, Any]) -> dict[str, Any]:
     return schema
 
 
+def _sanitize_any_of_required(schema: dict[str, Any]) -> dict[str, Any]:
+    """
+    Strip 'required' from anyOf branches that aren't type:object, or whose
+    required properties aren't defined in that branch's 'properties'.
+
+    Gemini rejects 'required' on non-OBJECT anyOf variants, and rejects
+    required entries that reference an undefined property. voluptuous_openapi
+    (vol.Any(...)) and pydantic Optional/Union schemas can emit both, e.g.
+    ``{"anyOf": [{"required": ["x"]}, {"type": "array", ...}]}``.
+    """
+    if "anyOf" in schema:
+        new_variants = []
+        for variant in schema["anyOf"]:
+            if isinstance(variant, dict):
+                variant = _sanitize_any_of_required(variant)
+                if "required" in variant:
+                    props = variant.get("properties", {})
+                    if variant.get("type") != "object":
+                        variant = {
+                            k: v for k, v in variant.items() if k != "required"
+                        }
+                    else:
+                        req = [r for r in variant["required"] if r in props]
+                        variant = (
+                            {**variant, "required": req}
+                            if req
+                            else {k: v for k, v in variant.items() if k != "required"}
+                        )
+            new_variants.append(variant)
+        schema = {**schema, "anyOf": new_variants}
+    if "properties" in schema:
+        schema = {
+            **schema,
+            "properties": {
+                k: _sanitize_any_of_required(v) for k, v in schema["properties"].items()
+            },
+        }
+    if isinstance(schema.get("items"), dict):
+        schema = {**schema, "items": _sanitize_any_of_required(schema["items"])}
+    return schema
+
+
 def _format_and_dedupe_tools(
     raw_tools: list[RawTool],
 ) -> tuple[list[dict[str, Any]], dict[str, str]]:
@@ -1257,6 +1299,9 @@ def _format_and_dedupe_tools(
             parameters["properties"] = {}
         # Gemini requires 'items' on all type:array properties.
         parameters = _ensure_array_items(parameters)
+        # Gemini rejects 'required' on non-OBJECT anyOf branches, or entries
+        # referencing properties undefined in that branch.
+        parameters = _sanitize_any_of_required(parameters)
         selected_tools.append(
             {
                 "type": "function",

--- a/tests/custom_components/home_generative_agent/test_graph_helpers.py
+++ b/tests/custom_components/home_generative_agent/test_graph_helpers.py
@@ -7,6 +7,7 @@ from custom_components.home_generative_agent.agent.graph import (
     _determine_model_name,
     _ensure_array_items,
     _format_and_dedupe_tools,
+    _sanitize_any_of_required,
 )
 from custom_components.home_generative_agent.const import CONF_ANTHROPIC_CHAT_MODEL
 
@@ -174,6 +175,144 @@ def test_format_and_dedupe_tools_gemini_array_items_injected() -> None:
     domain_schema = selected[0]["function"]["parameters"]["properties"]["domain"]
     assert "items" in domain_schema, "Gemini requires items on array-type properties"
     assert domain_schema["items"] == {"type": "string"}
+
+
+def test_sanitize_any_of_required_strips_required_from_non_object_variant() -> None:
+    """
+    'required' on a non-OBJECT anyOf branch is stripped.
+
+    Gemini rejects declarations where an anyOf variant carries 'required'
+    but is not itself type:object, e.g.
+    ``{"anyOf": [{"required": ["x"]}, {"type": "array", "items": {...}}]}``.
+    """
+    schema = {
+        "anyOf": [
+            {"required": ["x"]},
+            {"type": "array", "items": {"type": "string"}},
+        ]
+    }
+    result = _sanitize_any_of_required(schema)
+    assert "required" not in result["anyOf"][0]
+    assert result["anyOf"][1] == {"type": "array", "items": {"type": "string"}}
+
+
+def test_sanitize_any_of_required_strips_undefined_property_from_object_variant() -> (
+    None
+):
+    """'required' entries not present in that branch's properties are dropped."""
+    schema = {
+        "anyOf": [
+            {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "required": ["name", "missing_prop"],
+            },
+            {"type": "string"},
+        ]
+    }
+    result = _sanitize_any_of_required(schema)
+    assert result["anyOf"][0]["required"] == ["name"]
+
+
+def test_sanitize_any_of_required_drops_required_key_when_empty_after_filtering() -> (
+    None
+):
+    """If every required property is undefined, the 'required' key is removed."""
+    schema = {
+        "anyOf": [
+            {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "required": ["missing_prop"],
+            }
+        ]
+    }
+    result = _sanitize_any_of_required(schema)
+    assert "required" not in result["anyOf"][0]
+
+
+def test_sanitize_any_of_required_valid_object_variant_unchanged() -> None:
+    """A well-formed OBJECT anyOf variant with valid 'required' is left alone."""
+    schema = {
+        "anyOf": [
+            {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "required": ["name"],
+            }
+        ]
+    }
+    result = _sanitize_any_of_required(schema)
+    assert result["anyOf"][0]["required"] == ["name"]
+
+
+def test_sanitize_any_of_required_recurses_into_properties() -> None:
+    """Nested object properties containing anyOf/required are also sanitized."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "target": {
+                "anyOf": [
+                    {"required": ["x"]},
+                    {"type": "string"},
+                ]
+            }
+        },
+    }
+    result = _sanitize_any_of_required(schema)
+    assert "required" not in result["properties"]["target"]["anyOf"][0]
+
+
+def test_sanitize_any_of_required_recurses_into_items() -> None:
+    """Array items containing anyOf/required are also sanitized."""
+    schema = {
+        "type": "array",
+        "items": {"anyOf": [{"required": ["x"]}, {"type": "string"}]},
+    }
+    result = _sanitize_any_of_required(schema)
+    assert "required" not in result["items"]["anyOf"][0]
+
+
+def test_sanitize_any_of_required_no_any_of_unchanged() -> None:
+    """Schemas without anyOf are returned unchanged."""
+    schema = {"type": "object", "properties": {}, "required": ["x"]}
+    result = _sanitize_any_of_required(schema)
+    assert result == schema
+
+
+def test_format_and_dedupe_tools_strips_invalid_any_of_required() -> None:
+    """
+    End-to-end: a 3-branch anyOf with mismatched 'required' is sanitized.
+
+    Reproduces the reported Gemini 400 error:
+    ``GenerateContentRequest.tools[0].function_declarations[1].parameters
+    .any_of[N].required: only allowed for OBJECT type`` /
+    ``any_of[N].required[0]: property is not defined``.
+    """
+    raw: list = [
+        {
+            "name": "flaky_union_tool",
+            "api_id": "test",
+            "description": "Tool with a 3-way union parameter",
+            "parameters": (
+                '{"type": "object", "properties": {"target": {"anyOf": ['
+                '{"required": ["entity_id"]},'
+                '{"type": "object", "properties": {"area_id": {"type": "string"}},'
+                ' "required": ["area_id", "entity_id"]},'
+                '{"type": "array", "items": {"type": "string"}, '
+                '"required": ["entity_id"]}'
+                "]}}}"
+            ),
+            "is_actuation": False,
+        }
+    ]
+    selected, _ = _format_and_dedupe_tools(raw)
+    variants = selected[0]["function"]["parameters"]["properties"]["target"]["anyOf"]
+    assert "required" not in variants[0], "non-object variant must lose 'required'"
+    assert variants[1]["required"] == ["area_id"], (
+        "object variant keeps only required props it actually defines"
+    )
+    assert "required" not in variants[2], "array variant must lose 'required'"
 
 
 def test_determine_model_name_anthropic_returns_configured_model() -> None:


### PR DESCRIPTION
## Summary

Fixes a Gemini 400 error on tool declarations whose JSON schema contains
an `anyOf` branch carrying an invalid `required`:

```
GenerateContentRequest.tools[0].function_declarations[1].parameters.any_of[0].required: only allowed for OBJECT type
GenerateContentRequest.tools[0].function_declarations[1].parameters.any_of[0].required[0]: property is not defined
... (repeated for any_of[1], any_of[2])
```

**Root cause:** `voluptuous_openapi` (`vol.Any(...)`) and pydantic
`Optional`/`Union` schemas can emit `anyOf` branches where a `required`
array is present on a non-`object` branch, or references a property that
isn't defined in that specific branch's `properties`. Gemini's protobuf
validation rejects both shapes. `_ensure_array_items()` (added in #430)
already normalizes the sibling `items`/`anyOf` issue but doesn't touch
`required`.

**Fix:** `_sanitize_any_of_required()`, called alongside
`_ensure_array_items()` in `_format_and_dedupe_tools()`:
- Strips `required` from any `anyOf` variant that isn't `type: object`.
- For `object` variants, keeps only the `required` entries that are
  actually defined in that variant's `properties`; drops the key
  entirely if none remain.
- Recurses into `properties` and `items`, same traversal pattern as
  `_ensure_array_items()`.
- No-op for OpenAI/Anthropic (only triggers when `anyOf` + `required`
  co-occur in that specific invalid shape).

## Test Coverage

9 new unit tests in `test_graph_helpers.py`:
- `required` stripped from non-object anyOf variant
- Undefined property stripped from object variant's `required`
- `required` key removed entirely when empty after filtering
- Valid object variant with well-formed `required` left unchanged
- Recursion into nested `properties`
- Recursion into `items`
- No-op when no `anyOf` present
- End-to-end `_format_and_dedupe_tools` reproducing the exact reported
  3-branch schema shape from the traceback

## Test plan
- [x] Unit tests pass (verified schema-transform logic in isolation)
- [x] Verified against a live HA instance with the Gemini provider —
      the tool call that previously 400'd now succeeds

## Related
Same failure class as #428/#430 (Gemini rejecting HGA's normalized tool
schemas), different manifestation — `items` vs `required`.
