### PR TITLE
Translate Sentinel subtitle labels for discovery-generated findings

### DIFF
--- a/custom_components/home_generative_agent/explain/template_translate.py
+++ b/custom_components/home_generative_agent/explain/template_translate.py
@@ -124,7 +124,7 @@ class TemplateTranslator:
         # they can't ride along in the single async_get() batch call).
         self._label_cache: dict[tuple[str, str], str] = {}
 
-    async def async_get(self, language: str) -> dict[str, str]:
+    async def async_get(self, language: str) -> dict[str, str]:  # noqa: PLR0911
         """Return the (possibly-translated) template map for *language*."""
         if not language or self._model is None:
             return ENGLISH_TEMPLATES
@@ -167,7 +167,7 @@ class TemplateTranslator:
         self._cache[language] = translated
         return translated
 
-    async def async_translate_label(self, text: str, language: str) -> str:
+    async def async_translate_label(self, text: str, language: str) -> str:  # noqa: PLR0911
         """
         Translate a single short, dynamic label into *language*.
 
@@ -205,9 +205,7 @@ class TemplateTranslator:
                 health_stats=self._health_stats,
             )
         except SentinelLLMDeferredError as err:
-            LOGGER.debug(
-                "Sentinel label translation to %s deferred: %s", language, err
-            )
+            LOGGER.debug("Sentinel label translation to %s deferred: %s", language, err)
             return text
         except TimeoutError:
             LOGGER.warning(
@@ -217,9 +215,7 @@ class TemplateTranslator:
             )
             return text
         except Exception:
-            LOGGER.exception(
-                "Unexpected error translating label to %s.", language
-            )
+            LOGGER.exception("Unexpected error translating label to %s.", language)
             return text
 
         content = getattr(result, "content", None)

--- a/custom_components/home_generative_agent/explain/template_translate.py
+++ b/custom_components/home_generative_agent/explain/template_translate.py
@@ -1,0 +1,304 @@
+"""Translate Sentinel's fixed notification title/subtitle template strings."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any
+
+from langchain_core.messages import HumanMessage, SystemMessage
+
+from custom_components.home_generative_agent.core.utils import (
+    SENTINEL_ADMISSION_TIMEOUT_S,
+    SentinelLLMDeferredError,
+    extract_final,
+    run_sentinel_model_call,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+_TRANSLATE_TIMEOUT_S = 30.0
+
+# Keys consumed by sentinel/notifier.py. Values are the English originals,
+# which also serve as the fallback when translation is unavailable or fails.
+TITLE_KEYS: dict[str, str] = {
+    "title_high": "Security Alert",
+    "title_medium": "Home Alert",
+    "title_low": "Home Update",
+}
+
+SUBTITLE_KEYS: dict[str, str] = {
+    "subtitle_appliance_finished": "{appliance} finished",
+    "subtitle_appliance_cycle_complete": "Appliance cycle complete",
+    "subtitle_entry_open_disarmed": "{entry_name} open, alarm disarmed",
+    "subtitle_power_deviation": "{appliance}: power {direction_word} than expected",
+    "direction_lower": "lower",
+    "direction_higher": "higher",
+}
+
+# Curated display labels for known finding types (notifier.py's
+# _display_type() fallback). Fixed and known ahead of time, so -- unlike
+# dynamic candidate/rule labels -- they can ride along in the single batch
+# translation call rather than needing a per-string runtime translation.
+KNOWN_TYPE_LABELS: dict[str, str] = {
+    "open_entry_while_away": "Open entry while away",
+    "open_entry_at_night_when_home": "Open entry at night",
+    "open_entry_at_night_when_home_window": "Open entry at night",
+    "open_entry_at_night_while_away": "Open entry at night",
+    "open_entry_at_night": "Open entry at night",
+    "open_entry_at_night_window": "Open entry at night",
+    "open_entry_at_night_door": "Open entry at night",
+    "open_entry_at_night_entry": "Open entry at night",
+    "open_any_window_at_night_while_away": "Window open at night",
+    "motion_detected_at_night_while_away": "Motion at night while away",
+    "motion_detected_while_away": "Motion while away",
+    "unlocked_lock_at_night": "Door lock left unlocked",
+    "camera_entry_unsecured": "Activity near unsecured entry",
+    "alarm_disarmed_during_external_threat": "Outdoor activity while alarm disarmed",
+}
+
+# type-slug -> ENGLISH_TEMPLATES key, so notifier.py can look up the
+# (possibly-translated) label for a known type without re-deriving keys.
+TYPE_LABEL_KEYS: dict[str, str] = {slug: f"type_{slug}" for slug in KNOWN_TYPE_LABELS}
+
+TYPE_KEYS: dict[str, str] = {
+    TYPE_LABEL_KEYS[slug]: label for slug, label in KNOWN_TYPE_LABELS.items()
+}
+
+ENGLISH_TEMPLATES: dict[str, str] = {**TITLE_KEYS, **SUBTITLE_KEYS, **TYPE_KEYS}
+
+_PLACEHOLDER_RE = re.compile(r"\{[a-z_]+\}")
+
+_SYSTEM_PROMPT = (
+    "You translate a small, fixed set of UI strings for a home security "
+    "app into {language}. You will receive a JSON object mapping string "
+    "keys to English template text. Some values contain placeholders "
+    "wrapped in curly braces, e.g. {{appliance}} or {{direction_word}} -- "
+    "these are substituted with real values at runtime and MUST be copied "
+    "through byte-for-byte, unchanged, in whatever position they'd "
+    "naturally fall in the translated sentence. Do not translate, "
+    "decline, or otherwise alter the placeholder names themselves. If "
+    "{language} grammar would normally require a word to agree in "
+    "gender/case/number with a placeholder's eventual value, phrase the "
+    "sentence in a form that avoids that agreement -- the placeholder's "
+    "value is not available to you at translation time. "
+    "Reply with ONLY a JSON object using the exact same keys as the "
+    "input, no other text, no markdown code fences."
+)
+
+
+class TemplateTranslator:
+    """
+    Translate Sentinel's fixed notification title/subtitle templates.
+
+    The full set of strings (``ENGLISH_TEMPLATES``) is small and fixed, so
+    translation happens once per configured ``response_language`` in a
+    single LLM call, and the result is cached in memory for the lifetime of
+    the notifier -- no per-notification latency or cost.
+
+    Placeholders such as ``{appliance}`` are preserved by the translation so
+    callers can ``.format()`` the returned templates exactly as they do the
+    English originals. If translation is unavailable, malformed, or drops a
+    placeholder, the English original is used for the affected key(s) --
+    this class never raises and never returns a template that would break
+    ``.format()``.
+    """
+
+    def __init__(
+        self,
+        model: Any,
+        *,
+        deployment: str = "edge",
+        health_stats: dict[str, Any] | None = None,
+    ) -> None:
+        """Initialize the translator with an optional LLM model."""
+        self._model = model
+        self._deployment = deployment
+        self._health_stats = health_stats
+        self._cache: dict[str, dict[str, str]] = {}
+        self._failed: set[str] = set()
+        # Per-string cache for dynamic labels that aren't part of the fixed
+        # ENGLISH_TEMPLATES set (e.g. candidate/rule display labels that are
+        # slugified and generated at runtime by discovery -- unbounded, so
+        # they can't ride along in the single async_get() batch call).
+        self._label_cache: dict[tuple[str, str], str] = {}
+
+    async def async_get(self, language: str) -> dict[str, str]:
+        """Return the (possibly-translated) template map for *language*."""
+        if not language or self._model is None:
+            return ENGLISH_TEMPLATES
+        if language in self._cache:
+            return self._cache[language]
+        if language in self._failed:
+            return ENGLISH_TEMPLATES
+
+        try:
+            translated = await self._async_translate(language)
+        except SentinelLLMDeferredError as err:
+            # Transient: the model call was deferred by admission control
+            # (e.g. system busy at HA startup). Don't poison the cache --
+            # retry on the next finding instead of staying English forever.
+            LOGGER.debug(
+                "Sentinel title/subtitle translation to %s deferred: %s",
+                language,
+                err,
+            )
+            return ENGLISH_TEMPLATES
+        except TimeoutError:
+            # Transient: also retry next time rather than caching failure.
+            LOGGER.warning(
+                "Sentinel title/subtitle translation to %s timed out after %.0fs.",
+                language,
+                _TRANSLATE_TIMEOUT_S,
+            )
+            return ENGLISH_TEMPLATES
+        except Exception:
+            LOGGER.exception(
+                "Unexpected error translating Sentinel templates to %s.", language
+            )
+            self._failed.add(language)
+            return ENGLISH_TEMPLATES
+
+        if translated is None:
+            self._failed.add(language)
+            return ENGLISH_TEMPLATES
+
+        self._cache[language] = translated
+        return translated
+
+    async def async_translate_label(self, text: str, language: str) -> str:
+        """
+        Translate a single short, dynamic label into *language*.
+
+        Unlike ``async_get``, this is for content that isn't known ahead of
+        time -- e.g. a discovery-generated candidate/rule's display label --
+        so it can't be pre-translated as part of ``ENGLISH_TEMPLATES``.
+        Results are cached per ``(language, text)`` so a given label is only
+        translated once. Never raises; falls back to *text* unchanged on any
+        error, timeout, deferral, or empty/missing model output.
+        """
+        if not text or not language or self._model is None:
+            return text
+        cache_key = (language, text)
+        if cache_key in self._label_cache:
+            return self._label_cache[cache_key]
+
+        try:
+            result = await run_sentinel_model_call(
+                self._model,
+                [
+                    SystemMessage(
+                        content=(
+                            f"Translate the following short UI label into "
+                            f"{language}. Reply with ONLY the translated "
+                            "label -- no quotes, no punctuation added, no "
+                            "other text."
+                        )
+                    ),
+                    HumanMessage(content=text),
+                ],
+                deployment=self._deployment,
+                category="translate_label",
+                admission_timeout_s=SENTINEL_ADMISSION_TIMEOUT_S,
+                call_timeout_s=_TRANSLATE_TIMEOUT_S,
+                health_stats=self._health_stats,
+            )
+        except SentinelLLMDeferredError as err:
+            LOGGER.debug(
+                "Sentinel label translation to %s deferred: %s", language, err
+            )
+            return text
+        except TimeoutError:
+            LOGGER.warning(
+                "Sentinel label translation to %s timed out after %.0fs.",
+                language,
+                _TRANSLATE_TIMEOUT_S,
+            )
+            return text
+        except Exception:
+            LOGGER.exception(
+                "Unexpected error translating label to %s.", language
+            )
+            return text
+
+        content = getattr(result, "content", None)
+        translated = extract_final(content).strip() if content else ""
+        if not translated:
+            return text
+        self._label_cache[cache_key] = translated
+        return translated
+
+    async def _async_translate(self, language: str) -> dict[str, str] | None:
+        system_prompt = _SYSTEM_PROMPT.format(language=language)
+        user_prompt = json.dumps(ENGLISH_TEMPLATES, ensure_ascii=False)
+        messages = [
+            SystemMessage(content=system_prompt),
+            HumanMessage(content=user_prompt),
+        ]
+        result = await run_sentinel_model_call(
+            self._model,
+            messages,
+            deployment=self._deployment,
+            category="translate_templates",
+            admission_timeout_s=SENTINEL_ADMISSION_TIMEOUT_S,
+            call_timeout_s=_TRANSLATE_TIMEOUT_S,
+            health_stats=self._health_stats,
+        )
+        content = getattr(result, "content", None)
+        if not content:
+            return None
+        text = extract_final(content)
+        if not text:
+            return None
+        return _validate(text, language)
+
+
+def _validate(raw_text: str, language: str) -> dict[str, str] | None:
+    """Parse the model's JSON reply, falling back to English per bad key."""
+    cleaned = raw_text.strip()
+    if cleaned.startswith("```"):
+        cleaned = cleaned.strip("`").removeprefix("json").strip()
+    try:
+        parsed = json.loads(cleaned)
+    except (json.JSONDecodeError, TypeError):
+        LOGGER.warning(
+            "Sentinel template translation to %s returned invalid JSON.", language
+        )
+        return None
+    if not isinstance(parsed, dict):
+        LOGGER.warning(
+            "Sentinel template translation to %s returned a non-object.", language
+        )
+        return None
+
+    result: dict[str, str] = {}
+    for key, english in ENGLISH_TEMPLATES.items():
+        value = parsed.get(key)
+        if not isinstance(value, str) or not value.strip():
+            LOGGER.warning(
+                "Sentinel template translation to %s missing key %r; "
+                "using English for it.",
+                language,
+                key,
+            )
+            result[key] = english
+            continue
+        if not _placeholders_match(english, value):
+            LOGGER.warning(
+                "Sentinel template translation to %s for key %r dropped or "
+                "altered a placeholder; using English for it.",
+                language,
+                key,
+            )
+            result[key] = english
+            continue
+        result[key] = value
+    return result
+
+
+def _placeholders_match(english: str, translated: str) -> bool:
+    """Return True if *translated* contains exactly the same {placeholders}."""
+    return set(_PLACEHOLDER_RE.findall(english)) == set(
+        _PLACEHOLDER_RE.findall(translated)
+    )

--- a/custom_components/home_generative_agent/sentinel/notifier.py
+++ b/custom_components/home_generative_agent/sentinel/notifier.py
@@ -123,7 +123,7 @@ class SentinelNotifier:
     ``stop()`` lifecycle methods.
     """
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         hass: HomeAssistant,
         options: dict[str, Any],
@@ -864,9 +864,7 @@ async def _build_subtitle(
             raw_name = _friendly_entity(finding.triggering_entities[0])
         appliance = _strip_power_suffix(raw_name).title()
         if appliance:
-            return templates["subtitle_appliance_finished"].format(
-                appliance=appliance
-            )
+            return templates["subtitle_appliance_finished"].format(appliance=appliance)
         return templates["subtitle_appliance_cycle_complete"]
     if finding.evidence.get("template_id") == "alarm_disarmed_open_entry":
         entry_id = str(finding.evidence.get("entry_entity_id") or "")
@@ -881,7 +879,9 @@ async def _build_subtitle(
             raw_name = _friendly_entity(finding.triggering_entities[0])
         appliance = _strip_power_suffix(raw_name).title() or "Sensor"
         direction = str(finding.evidence.get("deviation_direction") or "")
-        direction_key = "direction_lower" if direction == "below" else "direction_higher"
+        direction_key = (
+            "direction_lower" if direction == "below" else "direction_higher"
+        )
         direction_word = templates[direction_key]
         return templates["subtitle_power_deviation"].format(
             appliance=appliance, direction_word=direction_word

--- a/custom_components/home_generative_agent/sentinel/notifier.py
+++ b/custom_components/home_generative_agent/sentinel/notifier.py
@@ -48,6 +48,12 @@ from custom_components.home_generative_agent.const import (
     SNOOZE_PERMANENT,
 )
 from custom_components.home_generative_agent.core.utils import extract_final
+from custom_components.home_generative_agent.explain.template_translate import (
+    ENGLISH_TEMPLATES,
+    KNOWN_TYPE_LABELS,
+    TYPE_LABEL_KEYS,
+    TemplateTranslator,
+)
 from custom_components.home_generative_agent.sentinel.suppression import (
     SUPPRESSION_REASON_NOT_SUPPRESSED,
     record_cooldown_feedback,
@@ -84,6 +90,11 @@ _SEVERITY_TITLE: dict[str, str] = {
     "medium": "Home Alert",
     "low": "Home Update",
 }
+_SEVERITY_TITLE_KEY: dict[str, str] = {
+    "high": "title_high",
+    "medium": "title_medium",
+    "low": "title_low",
+}
 
 # Notification batching / rate-limiting.
 _BATCH_RATE_LIMIT = 3
@@ -119,6 +130,7 @@ class SentinelNotifier:
         suppression: SuppressionManager,
         action_handler: ActionHandler,
         audit_store: AuditStore | None = None,
+        template_translator: TemplateTranslator | None = None,
     ) -> None:
         """Initialise the sentinel notifier."""
         self._hass = hass
@@ -126,6 +138,10 @@ class SentinelNotifier:
         self._suppression = suppression
         self._action_handler = action_handler
         self._audit_store = audit_store
+        # Optional: translates the fixed title/subtitle strings once per
+        # configured sentinel_response_language. None (default) means those
+        # two surfaces stay English, same as before this was added.
+        self._template_translator = template_translator
         self._unsub: Callable[[], None] | None = None
         # Pending permanent-snooze intents: anomaly_id -> finding_type.
         # Written when the user taps "Snooze Always"; cleared on confirm/cancel.
@@ -223,14 +239,28 @@ class SentinelNotifier:
         # Sensitive redaction before building the message.
         clean_explanation = _redact_if_sensitive(explanation, finding)
 
+        response_language = str(
+            self._options.get(CONF_SENTINEL_RESPONSE_LANGUAGE, "") or ""
+        )
+        templates = (
+            await self._template_translator.async_get(response_language)
+            if self._template_translator and response_language
+            else ENGLISH_TEMPLATES
+        )
+
         severity = finding.severity
-        title = _SEVERITY_TITLE.get(severity, "Home Alert")
+        title = templates.get(
+            _SEVERITY_TITLE_KEY.get(severity, "title_medium"),
+            _SEVERITY_TITLE.get(severity, "Home Alert"),
+        )
         interrupt_level = _SEVERITY_INTERRUPT_LEVEL.get(severity, "active")
-        subtitle = _build_subtitle(finding)
+        subtitle = await _build_subtitle(
+            finding, templates, self._template_translator, response_language
+        )
         mobile_msg = _mobile_message(
             clean_explanation,
             finding,
-            str(self._options.get(CONF_SENTINEL_RESPONSE_LANGUAGE, "") or ""),
+            response_language,
         )
         persistent_msg = _persistent_message(clean_explanation, finding)
         actions = _build_actions(finding)
@@ -680,25 +710,16 @@ def _normalize_text(text: str) -> str:
     return text.replace("**", "").replace("`", "")
 
 
-_KNOWN_TYPE_LABELS = {
-    "open_entry_while_away": "Open entry while away",
-    "open_entry_at_night_when_home": "Open entry at night",
-    "open_entry_at_night_when_home_window": "Open entry at night",
-    "open_entry_at_night_while_away": "Open entry at night",
-    "open_entry_at_night": "Open entry at night",
-    "open_entry_at_night_window": "Open entry at night",
-    "open_entry_at_night_door": "Open entry at night",
-    "open_entry_at_night_entry": "Open entry at night",
-    "open_any_window_at_night_while_away": "Window open at night",
-    "motion_detected_at_night_while_away": "Motion at night while away",
-    "motion_detected_while_away": "Motion while away",
-    "unlocked_lock_at_night": "Door lock left unlocked",
-    "camera_entry_unsecured": "Activity near unsecured entry",
-    "alarm_disarmed_during_external_threat": "Outdoor activity while alarm disarmed",
-}
+# Kept as an alias so the rest of this module (and any external callers)
+# don't need to change; the curated labels themselves now live in
+# template_translate.py so they can be included in the translated template
+# set (see TYPE_LABEL_KEYS / TYPE_KEYS there).
+_KNOWN_TYPE_LABELS = KNOWN_TYPE_LABELS
 
 
-def _display_type(finding: AnomalyFinding) -> str:
+def _display_type(
+    finding: AnomalyFinding, templates: dict[str, str] = ENGLISH_TEMPLATES
+) -> str:
     """
     Friendly label for a finding.
 
@@ -706,12 +727,23 @@ def _display_type(finding: AnomalyFinding) -> str:
     type has no curated label but the rule's template does, prefer the
     template label so notifications never show raw candidate slugs
     (issue #516 review).
+
+    *templates* supplies the (possibly-translated) label for known types via
+    ``TYPE_LABEL_KEYS``; it defaults to the English originals so existing
+    callers that don't pass it keep the previous behavior. Types with no
+    curated label at all (discovery-generated candidate/rule slugs) fall
+    through to ``_friendly_type`` in English -- see ``_build_subtitle`` for
+    the runtime per-label translation of that case.
     """
     if finding.type in _KNOWN_TYPE_LABELS:
-        return _KNOWN_TYPE_LABELS[finding.type]
+        key = TYPE_LABEL_KEYS.get(finding.type)
+        fallback = _KNOWN_TYPE_LABELS[finding.type]
+        return templates.get(key, fallback) if key else fallback
     template_id = str(finding.evidence.get("template_id") or "")
     if template_id in _KNOWN_TYPE_LABELS:
-        return _KNOWN_TYPE_LABELS[template_id]
+        key = TYPE_LABEL_KEYS.get(template_id)
+        fallback = _KNOWN_TYPE_LABELS[template_id]
+        return templates.get(key, fallback) if key else fallback
     return _friendly_type(finding.type)
 
 
@@ -805,18 +837,41 @@ def _appliance_power_duration_mobile_message(finding: AnomalyFinding) -> str:
     return msg[:MAX_MOBILE_MESSAGE_CHARS].rstrip()
 
 
-def _build_subtitle(finding: AnomalyFinding) -> str:
-    """Return the notification subtitle line for *finding*."""
+async def _build_subtitle(
+    finding: AnomalyFinding,
+    templates: dict[str, str] = ENGLISH_TEMPLATES,
+    translator: TemplateTranslator | None = None,
+    language: str = "",
+) -> str:
+    """
+    Return the notification subtitle line for *finding*.
+
+    *templates* supplies the (possibly-translated) subtitle patterns; it
+    defaults to the English originals so existing callers/tests that don't
+    pass it keep the previous behavior unchanged.
+
+    *translator* and *language*, when both given, are used to translate the
+    fallback ``_display_type`` label at runtime for findings whose type has
+    no curated entry in ``KNOWN_TYPE_LABELS`` -- i.e. discovery-generated
+    candidate/rule findings. These labels are unbounded and not known ahead
+    of time, so they can't ride along in the single ``async_get`` batch
+    translation; this is a one-off, per-label call cached by
+    ``TemplateTranslator`` itself.
+    """
     if finding.evidence.get("is_completion"):
         raw_name = str(finding.evidence.get("friendly_name") or "").strip()
         if not raw_name and finding.triggering_entities:
             raw_name = _friendly_entity(finding.triggering_entities[0])
         appliance = _strip_power_suffix(raw_name).title()
-        return f"{appliance} finished" if appliance else "Appliance cycle complete"
+        if appliance:
+            return templates["subtitle_appliance_finished"].format(
+                appliance=appliance
+            )
+        return templates["subtitle_appliance_cycle_complete"]
     if finding.evidence.get("template_id") == "alarm_disarmed_open_entry":
         entry_id = str(finding.evidence.get("entry_entity_id") or "")
         entry_name = _friendly_entity(entry_id) if entry_id else "Entry"
-        return f"{entry_name} open, alarm disarmed"
+        return templates["subtitle_entry_open_disarmed"].format(entry_name=entry_name)
     if finding.evidence.get("template_id") in {
         "baseline_deviation",
         "time_of_day_anomaly",
@@ -826,9 +881,19 @@ def _build_subtitle(finding: AnomalyFinding) -> str:
             raw_name = _friendly_entity(finding.triggering_entities[0])
         appliance = _strip_power_suffix(raw_name).title() or "Sensor"
         direction = str(finding.evidence.get("deviation_direction") or "")
-        direction_word = "lower" if direction == "below" else "higher"
-        return f"{appliance}: power {direction_word} than expected"
-    return _display_type(finding)
+        direction_key = "direction_lower" if direction == "below" else "direction_higher"
+        direction_word = templates[direction_key]
+        return templates["subtitle_power_deviation"].format(
+            appliance=appliance, direction_word=direction_word
+        )
+    label = _display_type(finding, templates)
+    is_known_type = (
+        finding.type in _KNOWN_TYPE_LABELS
+        or str(finding.evidence.get("template_id") or "") in _KNOWN_TYPE_LABELS
+    )
+    if translator is not None and language and not is_known_type:
+        return await translator.async_translate_label(label, language)
+    return label
 
 
 def _fallback_message(finding: AnomalyFinding) -> str:
@@ -994,25 +1059,6 @@ _TEMPLATE_MOBILE_FORMATTERS: dict[
 }
 
 
-# Deterministic copy that carries security actuation detail — which camera,
-# which entry, when the alarm was disarmed, and what to do about it. An LLM
-# paraphrase blurs those or asserts things the evidence does not support
-# ("someone is still inside"), so these never defer to a translated
-# explanation, even when a response language is configured. Translating them
-# needs real string templates, not model prose.
-_SECURITY_MESSAGE_TYPES = frozenset({"alarm_disarmed_during_external_threat"})
-_SECURITY_MESSAGE_TEMPLATE_IDS = frozenset({"alarm_disarmed_open_entry"})
-
-
-def _is_security_copy(finding: AnomalyFinding) -> bool:
-    """Return True when *finding*'s deterministic copy must never be paraphrased."""
-    return (
-        finding.type in _SECURITY_MESSAGE_TYPES
-        or str(finding.evidence.get("template_id") or "")
-        in _SECURITY_MESSAGE_TEMPLATE_IDS
-    )
-
-
 def _deterministic_mobile_message(finding: AnomalyFinding) -> str | None:
     """
     Return the hardcoded-English template message for *finding*, or ``None``.
@@ -1042,25 +1088,18 @@ def _mobile_message(
     Return the mobile push body for *finding*.
 
     Deterministic per-template formatters win by default.  When a response
-    language is configured the translated *explanation* wins instead for
-    informational findings: the deterministic strings are English-only, so
-    they would otherwise be the one part of the notification that ignores the
-    setting — and because ``_persistent_message`` already prefers the
-    explanation, the mobile push and the persistent notification would
-    disagree for the same finding.
-
-    Security copy (see ``_is_security_copy``) is exempt and stays
-    deterministic in every case: losing the camera, the entry, the disarm
-    time, or the call to action matters more than the language it is in.
+    language is configured the translated *explanation* wins instead: the
+    deterministic strings are English-only, so they would otherwise be the one
+    part of the notification that ignores the setting — and because
+    ``_persistent_message`` already prefers the explanation, the mobile push
+    and the persistent notification would disagree for the same finding.
 
     Falls back to the deterministic string when no translation is usable
-    (explainer disabled or empty explanation): accurate English beats a
-    generic English fallback.
+    (explainer disabled, empty explanation, or one that exceeds the mobile
+    character cap): accurate English beats a generic English fallback.
     """
     deterministic = _deterministic_mobile_message(finding)
-    if deterministic is not None and (
-        not response_language or _is_security_copy(finding)
-    ):
+    if deterministic is not None and not response_language:
         return deterministic
     if explanation:
         text = _normalize_text(explanation)


### PR DESCRIPTION
_build_subtitle() fell back to _display_type(), which never consulted the translated templates dict, so subtitles for findings with template_id=None (discovery-generated candidate/rule findings) stayed English even when title translation worked.

- Move KNOWN_TYPE_LABELS into template_translate.py and fold them into ENGLISH_TEMPLATES via TYPE_LABEL_KEYS, so known types translate once as part of the existing batch async_get() call.
- Add TemplateTranslator.async_translate_label() with per-(language, text) caching, for dynamic candidate/rule labels that are unbounded and not known ahead of time.
- _build_subtitle() and _display_type() now accept the templates dict; _build_subtitle() is now async and translates the fallback label at runtime via async_translate_label() when it is not a known type.