### PR TITLE
fix: sanitize invalid 'required' in anyOf branches for Gemini tool schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.26.1] - 2026-08-09
+
+### Fixed
+
+- **Gemini no longer rejects the tool schemas Home Assistant's own intents produce**, reported with a root-cause analysis, patch and repro tests by [@hruba202](https://github.com/hruba202) in [#527](https://github.com/goruck/home-generative-agent/pull/527). Gemini validates function declarations through protobuf and refuses an `anyOf` branch that carries `required` without being `type: object`, or one whose `required` names a property that branch does not define (`any_of[N].required: only allowed for OBJECT type`). `voluptuous_openapi` emits exactly that shape for the "at least one target" pattern behind `HassTurnOn` and its siblings — `vol.Required(vol.Any("name", "area", "floor"))` becomes parent-level properties plus bare-`required` variants — so a Gemini install could fail on any turn where those tools were offered. Those branches are now stripped before the declaration is sent, variants emptied by the strip are dropped (and a fully emptied `anyOf` removed) so no `TYPE_UNSPECIFIED` entry reaches the proto, and what the strip drops is restated in the schema description — "At least one of: name, area, floor is required." — so the model still reads the constraint it can no longer be made to validate. `_ensure_array_items()` ([#430](https://github.com/goruck/home-generative-agent/pull/430)) already normalized the neighbouring `items`/`anyOf` problem but never touched `required`.
+- **The strip is gated on Gemini and applied to no other provider.** Those branches are valid JSON Schema, and OpenAI, Anthropic and Ollama all honour them; running the pass unconditionally would advertise a schema permitting a targetless `HassTurnOn`, which the model would duly emit and Home Assistant's own voluptuous validation would then reject at run time — trading a provider-specific error for a silent capability loss everywhere else. A variant carrying `properties` but no explicit type is treated as an object rather than stripped wholesale, and a malformed `anyOf` or `required` from a custom tool serializer is skipped rather than raised, so one bad schema cannot take down tool selection for the whole turn.
+
 ## [3.26.0] - 2026-08-05
 
 ### Security

--- a/custom_components/home_generative_agent/agent/graph.py
+++ b/custom_components/home_generative_agent/agent/graph.py
@@ -1231,8 +1231,112 @@ def _ensure_array_items(schema: dict[str, Any]) -> dict[str, Any]:
     return schema
 
 
+def _filter_variant_required(
+    variant: dict[str, Any],
+) -> tuple[dict[str, Any], list[str]]:
+    """
+    Drop the ``required`` entries Gemini rejects, returning what was lost.
+
+    A variant carrying ``properties`` but no explicit ``type`` is treated as an
+    object: both current producers emit the type, but the filter leg is the
+    correct one for an implicit object.
+    """
+    required = [r for r in variant["required"] if isinstance(r, str)]
+    is_object = variant.get("type") == "object" or "properties" in variant
+    kept = (
+        [r for r in required if r in variant.get("properties", {})] if is_object else []
+    )
+    cleaned = {k: v for k, v in variant.items() if k != "required"}
+    if kept:
+        cleaned["required"] = kept
+    return cleaned, [r for r in required if r not in kept]
+
+
+def _append_requirement_hint(
+    schema: dict[str, Any], dropped: list[list[str]]
+) -> dict[str, Any]:
+    """
+    Restate a dropped ``anyOf`` constraint in the schema description.
+
+    Gemini cannot validate the constraint, but it does read descriptions, so
+    surfacing it here keeps the model from emitting a call that the stripped
+    schema permits and Home Assistant's own validation then rejects.
+    """
+    if all(len(group) == 1 for group in dropped):
+        names = list(dict.fromkeys(group[0] for group in dropped))
+        hint = f"At least one of: {', '.join(names)} is required."
+    else:
+        groups = "; ".join(f"({', '.join(group)})" for group in dropped)
+        hint = f"At least one of these property groups is required: {groups}."
+    existing = schema.get("description")
+    return {
+        **schema,
+        "description": f"{existing} {hint}" if existing else hint,
+    }
+
+
+def _sanitize_any_of_required(schema: dict[str, Any]) -> dict[str, Any]:
+    """
+    Recursively strip ``required`` entries that Gemini's validation rejects.
+
+    Gemini rejects ``required`` on a non-OBJECT ``anyOf`` variant, and rejects
+    entries naming a property that variant does not itself define::
+
+        parameters.any_of[0].required: only allowed for OBJECT type
+        parameters.any_of[0].required[0]: property is not defined
+
+    voluptuous_openapi emits exactly that shape for Home Assistant's
+    "at least one target" pattern — ``vol.Required(vol.Any("name", "area",
+    "floor"))`` becomes parent-level ``properties`` plus bare-``required``
+    variants::
+
+        {"anyOf": [{"required": ["name"]}, {"required": ["area"]}]}
+
+    Those variants are valid JSON Schema, and every other provider honours
+    them, so unlike the purely additive ``_ensure_array_items()`` this
+    subtractive pass is scoped to Gemini by ``_format_and_dedupe_tools()``.
+    Whatever it has to drop is restated in the description so the constraint
+    survives as guidance even though it cannot survive in the proto schema.
+    """
+    if isinstance(schema.get("anyOf"), list):
+        variants: list[Any] = []
+        dropped: list[list[str]] = []
+        for raw_variant in schema["anyOf"]:
+            if not isinstance(raw_variant, dict):
+                variants.append(raw_variant)
+                continue
+            variant = _sanitize_any_of_required(raw_variant)
+            if isinstance(variant.get("required"), list):
+                variant, lost = _filter_variant_required(variant)
+                if lost:
+                    dropped.append(lost)
+            # A variant emptied by the strip carries no constraint at all;
+            # langchain_google_genai passes anyOf straight to the gapic proto,
+            # so leaving {} behind would reach Gemini as TYPE_UNSPECIFIED.
+            if variant:
+                variants.append(variant)
+        schema = (
+            {**schema, "anyOf": variants}
+            if variants
+            else {k: v for k, v in schema.items() if k != "anyOf"}
+        )
+        if dropped:
+            schema = _append_requirement_hint(schema, dropped)
+    if "properties" in schema:
+        schema = {
+            **schema,
+            "properties": {
+                k: _sanitize_any_of_required(v) for k, v in schema["properties"].items()
+            },
+        }
+    if isinstance(schema.get("items"), dict):
+        schema = {**schema, "items": _sanitize_any_of_required(schema["items"])}
+    return schema
+
+
 def _format_and_dedupe_tools(
     raw_tools: list[RawTool],
+    provider: str | None = None,
 ) -> tuple[list[dict[str, Any]], dict[str, str]]:
     """Convert raw tools to output format and deduplicate (first-seen wins)."""
     selected_tools: list[dict[str, Any]] = []
@@ -1254,6 +1358,11 @@ def _format_and_dedupe_tools(
             parameters["properties"] = {}
         # Gemini requires 'items' on all type:array properties.
         parameters = _ensure_array_items(parameters)
+        # Gemini alone rejects 'required' inside anyOf branches. This pass is
+        # subtractive — it would delete HA's "at least one target" constraint
+        # for providers that can honour it — so it is gated on the provider.
+        if provider == "gemini":
+            parameters = _sanitize_any_of_required(parameters)
         selected_tools.append(
             {
                 "type": "function",
@@ -1571,8 +1680,12 @@ async def _retrieve_tools(
                 "tool index or fallback; skipping force-injection"
             )
 
-    # 4. Format and deduplicate
-    selected_tools, routing_map = _format_and_dedupe_tools(all_candidates)
+    # 4. Format and deduplicate. The provider drives Gemini-only schema
+    # normalisation (see _sanitize_any_of_required).
+    provider_raw = opts.get(CONF_CHAT_MODEL_PROVIDER)
+    selected_tools, routing_map = _format_and_dedupe_tools(
+        all_candidates, str(provider_raw) if provider_raw else None
+    )
 
     LOGGER.debug(
         "Tool retrieval: limit=%d eff=%d rag=%d safety=%d/%d pin=%d merged=%d tools=%s",

--- a/custom_components/home_generative_agent/manifest.json
+++ b/custom_components/home_generative_agent/manifest.json
@@ -34,5 +34,5 @@
     "langchain-google-genai==3.1.0",
     "langchain-anthropic==1.4.3"
   ],
-  "version": "3.26.0"
+  "version": "3.26.1"
 }

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,7 +1,7 @@
 # Home Assistant integration testing requirements
 
-homeassistant==2026.7.4
-pytest-homeassistant-custom-component==0.13.352
+homeassistant==2026.8.1
+pytest-homeassistant-custom-component==0.13.355
 
 pytest==9.*
 pytest-asyncio==1.*

--- a/tests/custom_components/home_generative_agent/test_graph_helpers.py
+++ b/tests/custom_components/home_generative_agent/test_graph_helpers.py
@@ -7,6 +7,7 @@ from custom_components.home_generative_agent.agent.graph import (
     _determine_model_name,
     _ensure_array_items,
     _format_and_dedupe_tools,
+    _sanitize_any_of_required,
 )
 from custom_components.home_generative_agent.const import CONF_ANTHROPIC_CHAT_MODEL
 
@@ -174,6 +175,333 @@ def test_format_and_dedupe_tools_gemini_array_items_injected() -> None:
     domain_schema = selected[0]["function"]["parameters"]["properties"]["domain"]
     assert "items" in domain_schema, "Gemini requires items on array-type properties"
     assert domain_schema["items"] == {"type": "string"}
+
+
+# The shape voluptuous_openapi emits for Home Assistant's "at least one target"
+# pattern, vol.Required(vol.Any("name", "area", "floor")): parent-level
+# properties plus bare-'required' anyOf variants. Valid JSON Schema; only
+# Gemini's protobuf validation rejects it.
+_HA_TARGET_SCHEMA = (
+    '{"type": "object", "properties": {"name": {"type": "string"}, '
+    '"area": {"type": "string"}, "floor": {"type": "string"}}, '
+    '"required": [], "anyOf": [{"required": ["name"]}, '
+    '{"required": ["area"]}, {"required": ["floor"]}]}'
+)
+
+
+def _target_tool(name: str = "HassTurnOn") -> list:
+    """Build a raw tool carrying the HA at-least-one-target schema."""
+    return [
+        {
+            "name": name,
+            "api_id": "test",
+            "description": "Turns on a device",
+            "parameters": _HA_TARGET_SCHEMA,
+            "is_actuation": True,
+        }
+    ]
+
+
+def test_sanitize_any_of_required_strips_required_from_non_object_variant() -> None:
+    """
+    'required' on a non-OBJECT anyOf branch is stripped.
+
+    Gemini rejects declarations where an anyOf variant carries 'required'
+    but is not itself type:object.
+    """
+    schema = {
+        "anyOf": [
+            {"type": "array", "items": {"type": "string"}, "required": ["x"]},
+            {"type": "string"},
+        ]
+    }
+    result = _sanitize_any_of_required(schema)
+    assert "required" not in result["anyOf"][0]
+    assert result["anyOf"][0] == {"type": "array", "items": {"type": "string"}}
+
+
+def test_sanitize_any_of_required_strips_undefined_property_from_object_variant() -> (
+    None
+):
+    """'required' entries not present in that branch's properties are dropped."""
+    schema = {
+        "anyOf": [
+            {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "required": ["name", "missing_prop"],
+            },
+            {"type": "string"},
+        ]
+    }
+    result = _sanitize_any_of_required(schema)
+    assert result["anyOf"][0]["required"] == ["name"]
+
+
+def test_sanitize_any_of_required_drops_required_key_when_empty_after_filtering() -> (
+    None
+):
+    """If every required property is undefined, the 'required' key is removed."""
+    schema = {
+        "anyOf": [
+            {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "required": ["missing_prop"],
+            }
+        ]
+    }
+    result = _sanitize_any_of_required(schema)
+    assert "required" not in result["anyOf"][0]
+
+
+def test_sanitize_any_of_required_valid_object_variant_unchanged() -> None:
+    """A well-formed OBJECT anyOf variant with valid 'required' is left alone."""
+    schema = {
+        "anyOf": [
+            {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "required": ["name"],
+            }
+        ]
+    }
+    result = _sanitize_any_of_required(schema)
+    assert result["anyOf"][0]["required"] == ["name"]
+
+
+def test_sanitize_any_of_required_implicit_object_variant_is_filtered() -> None:
+    """A variant with properties but no explicit type keeps its valid required."""
+    schema = {
+        "anyOf": [
+            {
+                "properties": {"name": {"type": "string"}},
+                "required": ["name", "missing_prop"],
+            }
+        ]
+    }
+    result = _sanitize_any_of_required(schema)
+    assert result["anyOf"][0]["required"] == ["name"], (
+        "implicit object must be filtered, not stripped wholesale"
+    )
+
+
+def test_sanitize_any_of_required_drops_emptied_variants() -> None:
+    """Variants left empty by the strip are removed rather than sent as {}."""
+    schema = {
+        "properties": {"name": {"type": "string"}, "area": {"type": "string"}},
+        "anyOf": [{"required": ["name"]}, {"required": ["area"]}],
+    }
+    result = _sanitize_any_of_required(schema)
+    assert "anyOf" not in result, "a fully emptied anyOf must not reach the proto"
+
+
+def test_sanitize_any_of_required_keeps_surviving_variants() -> None:
+    """An emptied variant is dropped while a non-empty sibling survives."""
+    schema = {
+        "properties": {"name": {"type": "string"}},
+        "anyOf": [{"required": ["name"]}, {"type": "string"}],
+    }
+    result = _sanitize_any_of_required(schema)
+    assert result["anyOf"] == [{"type": "string"}]
+
+
+def test_sanitize_any_of_required_records_dropped_constraint_in_description() -> None:
+    """A stripped constraint is restated in the description for the model."""
+    schema = {
+        "properties": {
+            "name": {"type": "string"},
+            "area": {"type": "string"},
+            "floor": {"type": "string"},
+        },
+        "anyOf": [
+            {"required": ["name"]},
+            {"required": ["area"]},
+            {"required": ["floor"]},
+        ],
+    }
+    result = _sanitize_any_of_required(schema)
+    assert result["description"] == "At least one of: name, area, floor is required."
+
+
+def test_sanitize_any_of_required_appends_hint_to_existing_description() -> None:
+    """An existing description is preserved and the hint appended."""
+    schema = {
+        "description": "Turns on a device.",
+        "properties": {"name": {"type": "string"}},
+        "anyOf": [{"required": ["name"]}],
+    }
+    result = _sanitize_any_of_required(schema)
+    assert result["description"] == (
+        "Turns on a device. At least one of: name is required."
+    )
+
+
+def test_sanitize_any_of_required_multi_property_groups_in_hint() -> None:
+    """Multi-property branches are rendered as groups in the hint."""
+    schema = {
+        "properties": {"name": {"type": "string"}, "area": {"type": "string"}},
+        "anyOf": [{"required": ["name", "area"]}, {"required": ["name"]}],
+    }
+    result = _sanitize_any_of_required(schema)
+    assert result["description"] == (
+        "At least one of these property groups is required: (name, area); (name)."
+    )
+
+
+def test_sanitize_any_of_required_recurses_into_properties() -> None:
+    """Nested object properties containing anyOf/required are also sanitized."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "target": {
+                "anyOf": [
+                    {"type": "array", "items": {"type": "string"}, "required": ["x"]},
+                    {"type": "string"},
+                ]
+            }
+        },
+    }
+    result = _sanitize_any_of_required(schema)
+    assert "required" not in result["properties"]["target"]["anyOf"][0]
+
+
+def test_sanitize_any_of_required_recurses_into_items() -> None:
+    """Array items containing anyOf/required are also sanitized."""
+    schema = {
+        "type": "array",
+        "items": {
+            "anyOf": [
+                {"type": "array", "items": {"type": "string"}, "required": ["x"]},
+                {"type": "string"},
+            ]
+        },
+    }
+    result = _sanitize_any_of_required(schema)
+    assert "required" not in result["items"]["anyOf"][0]
+
+
+def test_sanitize_any_of_required_recurses_into_nested_any_of() -> None:
+    """An anyOf nested inside an anyOf variant is sanitized too."""
+    schema = {
+        "anyOf": [
+            {
+                "type": "object",
+                "properties": {"inner": {"type": "string"}},
+                "anyOf": [
+                    {"type": "array", "items": {"type": "string"}, "required": ["x"]}
+                ],
+            }
+        ]
+    }
+    result = _sanitize_any_of_required(schema)
+    assert "required" not in result["anyOf"][0]["anyOf"][0]
+
+
+def test_sanitize_any_of_required_non_dict_variant_passes_through() -> None:
+    """Non-dict anyOf entries are left untouched rather than crashing."""
+    schema = {"anyOf": ["not_a_dict", {"type": "string"}]}
+    result = _sanitize_any_of_required(schema)
+    assert result["anyOf"] == ["not_a_dict", {"type": "string"}]
+
+
+def test_sanitize_any_of_required_malformed_required_does_not_raise() -> None:
+    """A null or non-list 'required' is ignored instead of raising TypeError."""
+    schema = {
+        "anyOf": [
+            {"type": "object", "properties": {}, "required": None},
+            {"type": "object", "properties": {}, "required": "name"},
+            {"type": "object", "properties": {"a": {}}, "required": ["a", 3, None]},
+        ]
+    }
+    result = _sanitize_any_of_required(schema)
+    assert result["anyOf"][0]["required"] is None, "non-list required left as-is"
+    assert result["anyOf"][1]["required"] == "name"
+    assert result["anyOf"][2]["required"] == ["a"], "non-str entries filtered out"
+
+
+def test_sanitize_any_of_required_non_list_any_of_unchanged() -> None:
+    """A malformed non-list anyOf is left alone instead of being iterated."""
+    schema = {"anyOf": "bogus"}
+    assert _sanitize_any_of_required(schema) == schema
+
+
+def test_sanitize_any_of_required_no_any_of_unchanged() -> None:
+    """Schemas without anyOf are returned unchanged."""
+    schema = {"type": "object", "properties": {}, "required": ["x"]}
+    result = _sanitize_any_of_required(schema)
+    assert result == schema
+
+
+def test_format_and_dedupe_tools_gemini_strips_invalid_any_of_required() -> None:
+    """
+    End-to-end: a 3-branch anyOf with mismatched 'required' is sanitized.
+
+    Reproduces the reported Gemini 400 error:
+    ``GenerateContentRequest.tools[0].function_declarations[1].parameters
+    .any_of[N].required: only allowed for OBJECT type`` /
+    ``any_of[N].required[0]: property is not defined``.
+    """
+    raw: list = [
+        {
+            "name": "flaky_union_tool",
+            "api_id": "test",
+            "description": "Tool with a 3-way union parameter",
+            "parameters": (
+                '{"type": "object", "properties": {"target": {"anyOf": ['
+                '{"required": ["entity_id"]},'
+                '{"type": "object", "properties": {"area_id": {"type": "string"}},'
+                ' "required": ["area_id", "entity_id"]},'
+                '{"type": "array", "items": {"type": "string"}, '
+                '"required": ["entity_id"]}'
+                "]}}}"
+            ),
+            "is_actuation": False,
+        }
+    ]
+    selected, _ = _format_and_dedupe_tools(raw, "gemini")
+    target = selected[0]["function"]["parameters"]["properties"]["target"]
+    variants = target["anyOf"]
+    assert len(variants) == 2, "the bare-required variant is dropped once emptied"
+    assert variants[0]["required"] == ["area_id"], (
+        "object variant keeps only required props it actually defines"
+    )
+    assert "required" not in variants[1], "array variant must lose 'required'"
+    assert "entity_id" in target["description"], (
+        "the dropped constraint must survive as description guidance"
+    )
+
+
+def test_format_and_dedupe_tools_gemini_rewrites_ha_target_constraint() -> None:
+    """The real HA at-least-one-target schema is made Gemini-safe."""
+    selected, _ = _format_and_dedupe_tools(_target_tool(), "gemini")
+    params = selected[0]["function"]["parameters"]
+    assert "anyOf" not in params, "bare-required branches must not reach Gemini"
+    assert params["description"] == (
+        "At least one of: name, area, floor is required."
+    ), "constraint must be preserved as guidance"
+    assert set(params["properties"]) == {"name", "area", "floor"}
+
+
+def test_format_and_dedupe_tools_non_gemini_keeps_any_of_required() -> None:
+    """
+    Non-Gemini providers keep HA's at-least-one-target constraint intact.
+
+    The sanitizer is subtractive: running it unconditionally would hand
+    OpenAI/Anthropic/Ollama a vacuous schema, letting the model emit a
+    targetless call that HA's own voluptuous validation then rejects.
+    """
+    for provider in ("openai", "openai_compatible", "anthropic", "ollama", None):
+        selected, _ = _format_and_dedupe_tools(_target_tool(), provider)
+        params = selected[0]["function"]["parameters"]
+        assert params["anyOf"] == [
+            {"required": ["name"]},
+            {"required": ["area"]},
+            {"required": ["floor"]},
+        ], f"provider {provider!r} must keep the at-least-one-target constraint"
+        assert "description" not in params, (
+            f"provider {provider!r} needs no description workaround"
+        )
 
 
 def test_determine_model_name_anthropic_returns_configured_model() -> None:


### PR DESCRIPTION
Three commits: the Gemini tool-schema fix, a test-requirements fix that has to land for the suite to be installable at all, and the v3.26.1 bump.

## `anyOf` `required` sanitization for Gemini

Gemini's protobuf validation rejects function declarations where an `anyOf` branch carries `required` but isn't `type: object`, or where a required entry names a property that branch does not define:

```
GenerateContentRequest.tools[0].function_declarations[1].parameters
  .any_of[N].required: only allowed for OBJECT type
  any_of[N].required[0]: property is not defined
```

`voluptuous_openapi` emits exactly this shape for Home Assistant's "at least one target" pattern: `vol.Required(vol.Any("name", "area", "floor"))` becomes parent-level properties plus bare-`required` `anyOf` variants. `_ensure_array_items()` (#430) already normalizes the sibling `items`/`anyOf` issue but does not touch `required`.

Adds `_sanitize_any_of_required()`, called from `_format_and_dedupe_tools()`. Unlike the purely additive `_ensure_array_items()`, this pass is **subtractive**: those bare-`required` branches are valid JSON Schema, and OpenAI, Anthropic and Ollama all honour them. Running it unconditionally would hand those providers a vacuous schema and let the model emit a targetless `HassTurnOn` that the advertised schema permits but HA's own voluptuous validation then rejects at runtime. It is therefore gated on the Gemini provider, threaded in from `_retrieve_tools()`.

Beyond the gate:

- Variants emptied by the strip are dropped, and a fully emptied `anyOf` key removed, so no `TYPE_UNSPECIFIED` entries reach the gapic proto.
- What the strip drops is restated in the schema description ("At least one of: name, area, floor is required."), preserving the constraint as guidance Gemini can read even though it cannot validate it.
- Variants carrying `properties` but no explicit type are filtered as objects rather than stripped wholesale.
- `isinstance` guards on `anyOf` and `required`, so one malformed schema from a custom serializer cannot take down tool selection for the whole turn.

The root-cause analysis, original patch and repro tests are the work of @hruba202 in #527; this revision adds the provider gate and the follow-ups raised in that PR's review.

## Test requirements no longer resolve

Separately, #534 bumped `pytest-homeassistant-custom-component` to 0.13.352, but that harness release pins `homeassistant==2026.8.0b4` while `requirements/test.txt` still pinned `2026.7.4`. Installing the test requirements on current `main` fails outright:

```
Because pytest-homeassistant-custom-component==0.13.352 depends on
homeassistant==2026.8.0b4 and you require homeassistant==2026.7.4, we can
conclude that your requirements are unsatisfiable.
```

The harness pins an exact Home Assistant version per release, so the two have to move together — this is the same follow-up the maintainer has made by hand after previous harness bumps (`2af0a7e`, `f55184c`, `a639a6f`). Rather than pinning the beta 0.13.352 asks for, this moves to **0.13.355**, the first harness release pinning a stable 2026.8 line (`homeassistant==2026.8.1`), keeping the convention that this file never points at a Home Assistant beta.

Nothing in CI caught this: the Lint workflow installs `requirements/dev.txt` only, and the suite runs locally.

## Release

Bumps `manifest.json` to **3.26.1** with a matching CHANGELOG entry — a patch release for the Gemini fix, on top of v3.26.0 published earlier today. The test-pin realignment is dev-only and is not logged, matching this changelog's practice of never recording dependency bumps.

## Testing

- Adds 20 unit tests for the sanitizer, including the reported three-branch repro and a regression test asserting non-Gemini providers keep the constraint intact.
- Full suite on Python 3.14.2 with the new pins: **2176 passed**, 1 deselected.
- The deselected test is `test_seed_retention_unreadable_camera_dir_skipped`. It `chmod 0o000`s a directory and expects the scan to fail; this container runs as uid 0, which bypasses the mode bits, so the warning it asserts never fires. It is an artifact of running as root, unrelated to any change here, and passes for a normal user.
- `ruff format --check` and `ruff check` clean over `custom_components` and `tests`; `scripts/gen_manifest_requirements.py` produces no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116JwrGccqA37MTNCjZcTDV