### PR TITLE
docs: add compact Sentinel health entity-attributes-card recipe (#538)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ actions:
 
 Dashboard recipes shared by users. Have one of your own? Post it in [Discussions](https://github.com/goruck/home-generative-agent/discussions) and it may get featured here.
 
-The recipes below were shared by [@hruba202](https://github.com/hruba202) in [discussion #513](https://github.com/goruck/home-generative-agent/discussions/513). The first two use the excellent [flex-table-card](https://github.com/custom-cards/flex-table-card); the third combines [vertical-stack-in-card](https://github.com/ofekashery/vertical-stack-in-card), [entity-attributes-card](https://github.com/custom-cards/entity-attributes-card), and [card-mod](https://github.com/thomasloven/lovelace-card-mod) (all installable from HACS). Replace the example entity IDs with your own; the column names and labels are in Czech from the original install — rename them to taste. The `grid_options` sizing in the flex-table recipes assumes the newer sections dashboard layout with wide sections — trim the `columns:` values to fit your grid (standard sections are 12 columns wide; the older masonry layout ignores `grid_options` entirely).
+The recipes below were shared by [@hruba202](https://github.com/hruba202) in [discussion #513](https://github.com/goruck/home-generative-agent/discussions/513) and [issue #538](https://github.com/goruck/home-generative-agent/issues/538). The first two use the excellent [flex-table-card](https://github.com/custom-cards/flex-table-card) (the second also has a compact [entity-attributes-card](https://github.com/custom-cards/entity-attributes-card) variant); the third combines [vertical-stack-in-card](https://github.com/ofekashery/vertical-stack-in-card), entity-attributes-card, and [card-mod](https://github.com/thomasloven/lovelace-card-mod) (all installable from HACS). Replace the example entity IDs with your own; the column names and labels are in Czech from the original install — rename them to taste. The `grid_options` sizing in the flex-table recipes assumes the newer sections dashboard layout with wide sections — trim the `columns:` values to fit your grid (standard sections are 12 columns wide; the older masonry layout ignores `grid_options` entirely).
 
 ### Recognized people across cameras
 
@@ -264,6 +264,36 @@ columns: 1
 ```
 
 > **Tip:** `findings_count_by_severity` is a dictionary attribute (keys `low`/`medium`/`high`), so it renders as `[object Object]` by default. Use the column's `modify` option (same two gotchas as above) to pull out one severity per column, `modify: "Array.isArray(x) || x == null ? '—' : (x.high ?? 0)"`, or render the whole dictionary compactly with `modify: "Array.isArray(x) || x == null ? '—' : JSON.stringify(x)"`.
+
+#### Compact variant
+
+A tighter single-card alternative (shared in [issue #538](https://github.com/goruck/home-generative-agent/issues/538)) that lists a hand-picked subset of the health sensor's attributes — plus `triggers_excluded`, which the flex-table grid above doesn't show — as label/value rows via `entity-attributes-card`:
+
+```yaml
+type: custom:entity-attributes-card
+heading_name: Sentinel
+heading_state: ok
+filter:
+  include:
+    - key: sensor.sentinel_health.triggers_excluded
+      name: vyloučená spuštění
+    - key: sensor.sentinel_health.baseline_rules_waiting
+      name: čekajici pr.
+    - key: sensor.sentinel_health.last_run_start
+      name: poslední běh
+    - key: sensor.sentinel_health.run_duration_ms
+      name: doba běhu
+    - key: sensor.sentinel_health.active_rule_count
+      name: aktivní pravidla
+    - key: sensor.sentinel_health.triggers_dropped_incoming
+      name: zahozené příchozí t.
+    - key: sensor.sentinel_health.triggers_ttl_expired
+      name: triggers_ttl_expired
+    - key: sensor.sentinel_health.triggers_dropped_queued
+      name: zahazované/zařazené tr.
+```
+
+> **Tip:** `heading_name` and `heading_state` are static column-header text, not live entity state — the `ok` above stays "ok" even when the health sensor reports `degraded`. `entity-attributes-card` renders attributes only; to show the actual sensor state, keep the flex-table variant's `data: state` column or pair this card with an `entities` row for `sensor.sentinel_health`, as in the per-camera recipe below. Two more quirks: the three `triggers_*` scheduler rows only exist after the first Sentinel run completes, so a fresh install shows five rows until then — warm-up, not dead keys. And the card renders values raw: `last_run_start` appears as a full ISO-8601 timestamp and not-yet-populated attributes as the literal text `None` (the original post's `autoformat: true` is not an `entity-attributes-card` option and is omitted here).
 
 ### Per-camera event card
 

--- a/tests/custom_components/home_generative_agent/test_readme_dashboard_recipes.py
+++ b/tests/custom_components/home_generative_agent/test_readme_dashboard_recipes.py
@@ -1,0 +1,132 @@
+# ruff: noqa: S101
+"""
+README community-dashboard recipes must reference real sensor attributes.
+
+The ``entity-attributes-card`` recipes in README's Community Dashboards
+section address rows as ``key: sensor.<entity>.<attribute>``. The card
+silently omits any row whose key does not resolve — discussion #513's
+per-camera recipe originally shipped three dead keys that nobody noticed
+until PR #528 corrected them. Issue #538 added a second recipe of this
+card type (the compact Sentinel health variant), so the documented keys
+are pinned here: renaming or removing a sensor attribute must fail this
+test and prompt a README update instead of a silently thinner card.
+
+The checks run behavior-level, against the attribute dictionaries the
+real sensor classes actually build, not against source-text greps — a
+grep accepts docstring hits and producer-side literals that never reach
+the sensor. A separate losslessness check pins the regex extractor
+itself: every ``- key:`` row in README must parse, so reformatting a
+recipe (quoted keys, wildcards, renamed entities) cannot silently drop
+rows from coverage.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.home_generative_agent.core.recognized_sensor import (
+    RecognizedPeopleSensor,
+)
+from custom_components.home_generative_agent.sentinel.trigger_scheduler import (
+    SentinelTriggerScheduler,
+)
+
+from .test_sentinel_health_sensor import _make_sensor, _mock_async_write_ha_state
+
+_README = Path(__file__).resolve().parents[3] / "README.md"
+_KEY_LINE = re.compile(r"^\s*- key: sensor\.(\w+)\.(\w+)\s*$", re.MULTILINE)
+_ANY_KEY_LINE = re.compile(r"^\s*- key:", re.MULTILINE)
+
+_SENTINEL_RECIPE_KEYS = {
+    "triggers_excluded",
+    "baseline_rules_waiting",
+    "last_run_start",
+    "run_duration_ms",
+    "active_rule_count",
+    "triggers_dropped_incoming",
+    "triggers_ttl_expired",
+    "triggers_dropped_queued",
+}
+_RECOGNIZED_RECIPE_KEYS = {"recognized_people", "count", "summary", "last_event"}
+
+
+def _documented_keys() -> list[tuple[str, str]]:
+    """Extract (entity, attribute) pairs from README entity-attributes-card rows."""
+    return _KEY_LINE.findall(_README.read_text(encoding="utf-8"))
+
+
+def test_key_extraction_is_lossless() -> None:
+    """Every ``- key:`` row in README parses into the (entity, attribute) form."""
+    text = _README.read_text(encoding="utf-8")
+    assert len(_ANY_KEY_LINE.findall(text)) == len(_KEY_LINE.findall(text)), (
+        "A README '- key:' row no longer matches the extractor pattern "
+        "'- key: sensor.<entity>.<attribute>' — it has silently dropped out "
+        "of parity coverage. Update the recipe or the extractor."
+    )
+
+
+def test_every_documented_entity_is_covered() -> None:
+    """Each documented entity has a behavior-level check in this module."""
+    unknown = {
+        entity
+        for entity, _ in _documented_keys()
+        if entity != "sentinel_health" and not entity.endswith("_recognized_people")
+    }
+    assert not unknown, (
+        f"README documents entity-attributes-card keys for {sorted(unknown)} "
+        "but this module has no parity check for them — add one."
+    )
+
+
+@pytest.mark.asyncio
+async def test_sentinel_recipe_keys_are_real_sensor_attributes() -> None:
+    """
+    Every documented sentinel_health key exists on a refreshed health sensor.
+
+    The scheduler stats come from a real ``SentinelTriggerScheduler`` so the
+    three ``triggers_*`` counters are the genuine post-first-run attribute
+    names, not a hand-copied list that could drift alongside the README.
+    """
+    documented = {
+        attr for entity, attr in _documented_keys() if entity == "sentinel_health"
+    }
+    assert documented >= _SENTINEL_RECIPE_KEYS, (
+        "The issue #538 compact variant lost documented rows: "
+        f"{sorted(_SENTINEL_RECIPE_KEYS - documented)}"
+    )
+
+    sensor = _make_sensor(run_stats={"scheduler": SentinelTriggerScheduler().stats})
+    _mock_async_write_ha_state(sensor)
+    await sensor._async_refresh()
+
+    missing = documented - set(sensor._attrs)
+    assert not missing, (
+        f"README documents sensor.sentinel_health attributes {sorted(missing)} "
+        "that the sensor no longer exposes — entity-attributes-card would "
+        "silently drop those rows. Update the README recipe."
+    )
+
+
+def test_recognized_recipe_keys_are_real_sensor_attributes() -> None:
+    """Every documented recognized-people key exists on the per-camera sensor."""
+    documented = {
+        attr
+        for entity, attr in _documented_keys()
+        if entity.endswith("_recognized_people")
+    }
+    assert documented >= _RECOGNIZED_RECIPE_KEYS, (
+        "The per-camera recipe lost documented rows: "
+        f"{sorted(_RECOGNIZED_RECIPE_KEYS - documented)}"
+    )
+
+    sensor = RecognizedPeopleSensor(MagicMock(), "camera.test_cam")
+    missing = documented - set(sensor._attrs)
+    assert not missing, (
+        f"README documents recognized-people attributes {sorted(missing)} "
+        "that the sensor no longer exposes — entity-attributes-card would "
+        "silently drop those rows. Update the README recipe."
+    )


### PR DESCRIPTION
## Summary

Fixes #538

**Community Dashboards — compact Sentinel health variant** (`11d32e8`)
- Adds @hruba202's `custom:entity-attributes-card` recipe from #538 to the Community Dashboards section as a **compact variant alongside** the existing flex-table Sentinel health recipe, rather than replacing it: the flex-table grid still carries the KPI row (`false_positive_rate_14d`, baseline counts, `findings_count_by_severity`, `action_success_rate`) that the compact card omits, while the compact card adds `triggers_excluded`, which the grid doesn't show. Section intro now credits both #513 and #538.
- Three deviations from the issue as posted, each verified against the upstream `entity-attributes-card` source at master:
  - Dropped `autoformat: true` — not a card option (the card's entire config surface is `title`, `heading_name`, `heading_state`, `filter` with `key`/`name`/`unit`). Silently ignored, so keeping it would teach users a nonexistent setting.
  - Tip documents that `heading_name`/`heading_state` are **static header text** — the hardcoded `ok` will not track the sensor's actual `ok`/`degraded` state, and the card cannot render entity state at all (pair with an `entities` row or the flex-table `data: state` column).
  - Tip warns that the three `triggers_*` scheduler rows only exist **after the first Sentinel run completes** (fresh installs see five rows — warm-up, not dead keys), and that values render raw (ISO-8601 timestamps, literal `None`).

**Docs-parity test** (`tests/.../test_readme_dashboard_recipes.py`, 4 tests)
- All 8 documented `sensor.sentinel_health` keys and the per-camera recipe's 4 recognized-people keys are now pinned **behavior-level**: the test asserts each key exists in the attribute dict a real `SentinelHealthSensor` refresh (with genuine `SentinelTriggerScheduler().stats`) / `RecognizedPeopleSensor.__init__` actually builds. Source-text greps were rejected during adversarial review — they accept docstring and producer-side literals that never reach the sensor.
- A lossless-extraction check pins the parser itself (every `- key:` row in README must match the extractor), so reformatting a recipe cannot silently drop rows from coverage, and an unknown-entity guard forces a parity check for any future recipe entity.
- Rationale: `entity-attributes-card` silently omits unresolved rows — the exact failure mode that shipped three dead keys in the original #513 per-camera recipe until PR #528 corrected them. Mutation-verified: a misspelled README key, removal of an attribute from the sensor merge tuple, and a quoted README key each fail the suite.

Docs-only ship per repo precedent (#528, #530): no version bump, no release — `manifest.json` stays 3.27.0.

## Test Coverage

Docs-only diff — no new application code paths to audit. Tests: 2188 → 2192 (+4 new parity tests, mutation-checked with 3 kill-verified mutations).

## Pre-Landing Review

1 issue (0 critical, 1 informational): parity coverage deliberately scoped to `entity-attributes-card` recipes (silent-drop failure mode) and not flex-table `data:` columns (visible `undefined`/`n/a` failure mode — users notice and report, which is how #513's issues surfaced). Intentionally uncovered.

## Adversarial Review

Claude subagent + Codex (gpt-5.6-sol, high reasoning) both ran; structured P1 gate skipped (121-line diff < 200). Cross-model consensus findings, all fixed before commit:
- `autoformat: true` is not a card option → dropped from the recipe.
- Source-grep parity test accepted false greens (Codex mutation-demonstrated: removing `"triggers_excluded"` from the sensor merge tuple stayed green via producer-side literals) → rewritten behavior-level.
- Regex extractor silently lossy on YAML-legal reformatting → lossless-extraction pin added.
- Scheduler rows absent before first Sentinel run → documented in tip.
- Claude-unique: "same attributes" wording was wrong (`triggers_excluded` isn't in the flex-table grid) → reworded.
- Left verbatim by precedent (#528 corrects broken config, not cosmetics): the OP's raw `triggers_ttl_expired` label and `čekajici` spelling among the Czech labels; the section already says "rename them to taste".

## Eval Results

No prompt-related files changed — evals skipped.

## Scope Drift

Scope Check: CLEAN
Intent: feature #538 — publish the compact Sentinel card recipe in README.
Delivered: the recipe (vetted + corrected) plus its parity guard. No unrelated changes.

## Plan Completion

No plan file detected.

## TODOS

No TODO items completed in this PR. Reviewed the P3 "Trigger drop alert automation" TODO: the compact card surfaces the `triggers_*` counters, but that TODO's core deliverable is a threshold-alert automation blueprint, which this PR does not add — left open.

## Test plan

- [x] `make lint` clean (ruff format + check, manifest requirements current)
- [x] Full suite: 2192 passed (was 2188), fresh run after all changes
- [x] New parity tests mutation-checked: misspelled README key, sensor merge-tuple removal, and quoted-key reformat each fail the suite; restored state passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUE3XLGwmXZYBwwXiqHKhV
