### PR TITLE
Fix OpenAI 400 on tools with a top-level anyOf/oneOf/allOf schema

### DIFF
--- a/custom_components/home_generative_agent/agent/graph.py
+++ b/custom_components/home_generative_agent/agent/graph.py
@@ -1335,6 +1335,41 @@ def _sanitize_any_of_required(schema: dict[str, Any]) -> dict[str, Any]:
     return schema
 
 
+_TOP_LEVEL_UNION_KEYS = ("oneOf", "anyOf", "allOf")
+
+
+def _flatten_top_level_union(schema: dict[str, Any]) -> dict[str, Any]:
+    """
+    Flatten a top-level oneOf/anyOf/allOf into a single object schema.
+
+    OpenAI's function-calling validator rejects oneOf/anyOf/allOf/enum/
+    const/not at the top level of ``parameters`` ("schema must have type
+    'object' and not have 'oneOf'/'anyOf'/'allOf'/'enum'/'const'/'not' at
+    the top level"). HA's voluptuous->JSON-schema conversion emits exactly
+    this shape for services with multiple parameter forms, e.g.
+    HassStartTimer's ``duration``, which accepts either a plain string or
+    a structured hours/minutes/seconds object.
+
+    Union the ``properties`` from every variant into one permissive object
+    schema so OpenAI accepts it. Required fields are dropped since they
+    differ per variant and the union is inherently optional-only.
+    """
+    union_key = next((k for k in _TOP_LEVEL_UNION_KEYS if k in schema), None)
+    if union_key is None:
+        return schema
+    variants = schema[union_key]
+    if not isinstance(variants, list):
+        return schema
+    merged_properties: dict[str, Any] = {}
+    for variant in variants:
+        if isinstance(variant, dict):
+            merged_properties.update(variant.get("properties", {}))
+    schema = {k: v for k, v in schema.items() if k not in _TOP_LEVEL_UNION_KEYS}
+    schema["type"] = "object"
+    schema["properties"] = {**merged_properties, **schema.get("properties", {})}
+    return schema
+
+
 def _format_and_dedupe_tools(
     raw_tools: list[RawTool],
     provider: str | None = None,
@@ -1352,8 +1387,12 @@ def _format_and_dedupe_tools(
         parameters = json.loads(tool["parameters"])
         if not isinstance(parameters, dict):
             parameters = {"type": "object", "properties": {}}
-        elif not parameters.get("type"):
-            parameters["type"] = "object"
+        else:
+            # OpenAI rejects oneOf/anyOf/allOf at the top level of
+            # `parameters` (e.g. HassStartTimer's duration union).
+            parameters = _flatten_top_level_union(parameters)
+            if not parameters.get("type"):
+                parameters["type"] = "object"
         # OpenAI requires 'properties' on all type:object schemas.
         if parameters.get("type") == "object" and "properties" not in parameters:
             parameters["properties"] = {}

--- a/tests/custom_components/home_generative_agent/test_graph_helpers.py
+++ b/tests/custom_components/home_generative_agent/test_graph_helpers.py
@@ -546,7 +546,7 @@ def test_flatten_top_level_union_merges_any_of_properties() -> None:
 
 
 def test_flatten_top_level_union_handles_one_of_and_all_of() -> None:
-    """oneOf and allOf are flattened the same way as anyOf."""
+    """OneOf and allOf are flattened the same way as anyOf."""
     for key in ("oneOf", "allOf"):
         schema = {
             key: [

--- a/tests/custom_components/home_generative_agent/test_graph_helpers.py
+++ b/tests/custom_components/home_generative_agent/test_graph_helpers.py
@@ -3,9 +3,12 @@
 
 from __future__ import annotations
 
+import json
+
 from custom_components.home_generative_agent.agent.graph import (
     _determine_model_name,
     _ensure_array_items,
+    _flatten_top_level_union,
     _format_and_dedupe_tools,
     _sanitize_any_of_required,
 )
@@ -513,3 +516,104 @@ def test_determine_model_name_anthropic_returns_configured_model() -> None:
 def test_determine_model_name_anthropic_missing_key_returns_empty() -> None:
     """Anthropic provider with no key in opts returns empty string."""
     assert _determine_model_name("anthropic", {}) == ""
+
+
+def test_flatten_top_level_union_merges_any_of_properties() -> None:
+    """
+    A top-level anyOf is flattened to a single object schema.
+
+    Mirrors HassStartTimer's ``duration`` parameter shape, which
+    voluptuous_openapi emits as a top-level anyOf between a plain string
+    and a structured hours/minutes/seconds object. OpenAI rejects any of
+    oneOf/anyOf/allOf/enum/const/not at the top level of ``parameters``.
+    """
+    schema = {
+        "anyOf": [
+            {"type": "object", "properties": {"duration": {"type": "string"}}},
+            {
+                "type": "object",
+                "properties": {
+                    "hours": {"type": "integer"},
+                    "minutes": {"type": "integer"},
+                },
+            },
+        ]
+    }
+    result = _flatten_top_level_union(schema)
+    assert result["type"] == "object"
+    assert "anyOf" not in result
+    assert set(result["properties"]) == {"duration", "hours", "minutes"}
+
+
+def test_flatten_top_level_union_handles_one_of_and_all_of() -> None:
+    """oneOf and allOf are flattened the same way as anyOf."""
+    for key in ("oneOf", "allOf"):
+        schema = {
+            key: [
+                {"properties": {"a": {"type": "string"}}},
+                {"properties": {"b": {"type": "string"}}},
+            ]
+        }
+        result = _flatten_top_level_union(schema)
+        assert result["type"] == "object"
+        assert key not in result
+        assert set(result["properties"]) == {"a", "b"}
+
+
+def test_flatten_top_level_union_no_union_key_unchanged() -> None:
+    """Schemas without a top-level union key pass through untouched."""
+    schema = {"type": "object", "properties": {"x": {"type": "string"}}}
+    assert _flatten_top_level_union(schema) == schema
+
+
+def test_flatten_top_level_union_preserves_existing_properties() -> None:
+    """Pre-existing top-level properties win over merged variant properties."""
+    schema = {
+        "anyOf": [{"properties": {"a": {"type": "string"}}}],
+        "properties": {"a": {"type": "integer"}},
+    }
+    result = _flatten_top_level_union(schema)
+    assert result["properties"]["a"] == {"type": "integer"}
+
+
+def test_format_and_dedupe_tools_flattens_hass_start_timer_any_of() -> None:
+    """
+    End-to-end: a HassStartTimer-shaped schema no longer has a top-level anyOf.
+
+    Regression test for openai.BadRequestError: "Invalid schema for function
+    'HassStartTimer': schema must have type 'object' and not have
+    'oneOf'/'anyOf'/'allOf'/'enum'/'const'/'not' at the top level."
+    """
+    raw: list = [
+        {
+            "name": "HassStartTimer",
+            "api_id": "assist",
+            "description": "Start a timer",
+            "parameters": json.dumps(
+                {
+                    "anyOf": [
+                        {
+                            "type": "object",
+                            "properties": {"duration": {"type": "string"}},
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "hours": {"type": "integer"},
+                                "minutes": {"type": "integer"},
+                                "seconds": {"type": "integer"},
+                            },
+                        },
+                    ]
+                }
+            ),
+            "is_actuation": True,
+        }
+    ]
+    selected, _ = _format_and_dedupe_tools(raw)
+    params = selected[0]["function"]["parameters"]
+    assert params["type"] == "object"
+    assert "anyOf" not in params
+    assert "oneOf" not in params
+    assert "allOf" not in params
+    assert set(params["properties"]) == {"duration", "hours", "minutes", "seconds"}


### PR DESCRIPTION
```
openai.BadRequestError: Invalid schema for function 'HassStartTimer':
schema must have type 'object' and not have 'oneOf'/'anyOf'/'allOf'/
'enum'/'const'/'not' at the top level.
```

HA's built-in `HassStartTimer` intent accepts its `duration` parameter as either a plain string or a structured hours/minutes/seconds object. voluptuous_openapi's conversion of that `vol.Any(...)` emits a top-level `{"anyOf": [...]}` for the tool's `parameters` schema (no `type` key at all). `_format_and_dedupe_tools` then hit its `elif not parameters.get("type")` branch and injected `"type": "object"` -- but left the `anyOf` key sitting right next to it, which is exactly the shape OpenAI's function-calling validator rejects.

Adds `_flatten_top_level_union`, which unions the `properties` of every oneOf/anyOf/allOf variant into a single permissive object schema before the type/properties normalization runs. Required fields are dropped since they differ per variant.

Rebased onto v3.28.0 (main); resolved a placement conflict with the new Gemini `anyOf`-required sanitization helpers added alongside in that release -- both sets of helper functions now live side by side ahead of `_format_and_dedupe_tools`, no logic overlap.