### PR TITLE
fix: write translation JSON examples as prose (MALFORMED_ARGUMENT in Sentinel settings)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.29.1] - 2026-08-13
+
+### Fixed
+
+- **Sentinel settings no longer shows "Translation error: MALFORMED_ARGUMENT" under the advanced exclusions field.** Two different template engines read the integration's translation strings and disagree about braces: hassfest validates them with `str.format` semantics, where a literal brace is doubled (`{{`), while the Home Assistant frontend renders the same strings through ICU MessageFormat, where `{{` is not an escape at all but a malformed argument. The advanced-exclusions help text carried a literal JSON example, so it could satisfy one engine or the other but never both — v3.29.0 shipped the spelling that passes CI and fails to render. The JSON examples are now written as prose, which both engines accept. The same defect is fixed in the two "must be a JSON object..." validation errors for camera entry links and rule entity exclusions, which have carried it longer and would have replaced the message explaining a bad entry with the same render error. A test now rejects literal braces in any translation value, in either spelling, across `strings.json` and all four translation files.
+
 ## [3.29.0] - 2026-08-12
 
 ### Added

--- a/custom_components/home_generative_agent/manifest.json
+++ b/custom_components/home_generative_agent/manifest.json
@@ -34,5 +34,5 @@
     "langchain-google-genai==3.1.0",
     "langchain-anthropic==1.4.3"
   ],
-  "version": "3.29.0"
+  "version": "3.29.1"
 }

--- a/custom_components/home_generative_agent/strings.json
+++ b/custom_components/home_generative_agent/strings.json
@@ -146,11 +146,11 @@
         "reconfigure_successful": "Sentinel configuration updated."
       },
       "error": {
-        "invalid_camera_entry_links": "Must be a JSON object mapping camera entity IDs to lists of entry entity IDs, e.g. {{\"camera.driveway\": [\"lock.front_door\"]}}.",
+        "invalid_camera_entry_links": "Must be a JSON object mapping camera entity IDs to lists of entry entity IDs, e.g. a \"camera.driveway\" key with the value [\"lock.front_door\"].",
         "invalid_pin": "PIN must be 4-10 digits.",
         "quiet_hours_incomplete": "Set both quiet hours start and end (or set both to Disabled).",
         "invalid_quiet_hours": "Quiet hours must be local hours between 0 and 23.",
-        "invalid_rule_entity_exclusions": "Must be a JSON object mapping an anomaly type (or \"*\" for all types) to lists of entity IDs or glob patterns (* and ? wildcards only, lowercase entity-ID characters), each containing a dot and at least one literal character, e.g. {{\"appliance_power_duration\": [\"sensor.ac_power\"], \"camera_entry_unsecured\": [\"camera.map_*\"]}}. Match-all entries such as \"*\" or \"*.*\" are not allowed — use the \"*\" type key instead."
+        "invalid_rule_entity_exclusions": "Must be a JSON object mapping an anomaly type (or \"*\" for all types) to lists of entity IDs or glob patterns (* and ? wildcards only, lowercase entity-ID characters), each containing a dot and at least one literal character, e.g. an \"appliance_power_duration\" key with the value [\"sensor.ac_power\"], or a \"camera_entry_unsecured\" key with the value [\"camera.map_*\"]. Match-all entries such as \"*\" or \"*.*\" are not allowed — use the \"*\" type key instead."
       },
       "initiate_flow": {
         "reconfigure": "Reconfigure Sentinel",
@@ -213,7 +213,7 @@
           "data_description": {
             "sentinel_response_language": "Language for the LLM-authored finding explanation shown in notifications, e.g. 'Czech'. Leave empty for English. Discovery candidate title/summary and triage decision/reason_code/summary are unaffected -- those are parsed by code and always stay in English.",
             "sentinel_rule_entity_exclusions_all": "Pick entities Sentinel should ignore everywhere -- e.g. a touch panel's template lock that only mirrors another entity's state. Excluded entities are dropped from every rule's findings and no longer wake Sentinel, so a real anomaly involving them is only caught on the next poll (default 5 minutes). Don't exclude a camera, lock, or alarm panel you still want instant alerts from.",
-            "sentinel_rule_entity_exclusions": "For excluding an entity from one specific rule only (not all of them), and for glob patterns such as camera.map_*, which the picker above cannot hold. Format: {{\"rule_id\": [\"entity.id\", ...]}}; the \"*\" key means all rules. Most people won't need this -- use the picker above instead."
+            "sentinel_rule_entity_exclusions": "For excluding an entity from one specific rule only (not all of them), and for glob patterns such as camera.map_*, which the picker above cannot hold. Expects a JSON object whose keys are anomaly types and whose values are lists of entity IDs; the \"*\" key means all rules. See the Sentinel docs for examples. Most people won't need this -- use the picker above instead."
           }
         }
       }

--- a/custom_components/home_generative_agent/translations/cs.json
+++ b/custom_components/home_generative_agent/translations/cs.json
@@ -146,11 +146,11 @@
         "reconfigure_successful": "Konfigurace Sentinel byla aktualizována."
       },
       "error": {
-        "invalid_camera_entry_links": "Musí se jednat o objekt JSON mapující ID entit kamer na seznamy ID entit vstupů, např. {{\"camera.driveway\": [\"lock.front_door\"]}}.",
+        "invalid_camera_entry_links": "Musí se jednat o objekt JSON mapující ID entit kamer na seznamy ID entit vstupů, např. klíč \"camera.driveway\" s hodnotou [\"lock.front_door\"].",
         "invalid_pin": "PIN musí mít 4-10 číslic.",
         "quiet_hours_incomplete": "Nastavte čas začátku i konce nočního klidu (nebo obojí nastavte na Zakázáno).",
         "invalid_quiet_hours": "Časy nočního klidu musí být v místních hodinách mezi 0 a 23.",
-        "invalid_rule_entity_exclusions": "Musí se jednat o objekt JSON mapující typ anomálie (nebo \"*\" pro všechny typy) na seznamy ID entit nebo vzory glob (pouze zástupné znaky * a ?, malá písmena ID entit), každý musí obsahovat tečku a alespoň jeden doslovný znak, např. {{\"appliance_power_duration\": [\"sensor.ac_power\"], \"camera_entry_unsecured\": [\"camera.map_*\"]}}. Položky odpovídající všemu, jako například \"*\" nebo \"*.*\", nejsou povoleny — místo toho použijte klíč typu \"*\"."
+        "invalid_rule_entity_exclusions": "Musí se jednat o objekt JSON mapující typ anomálie (nebo \"*\" pro všechny typy) na seznamy ID entit nebo vzory glob (pouze zástupné znaky * a ?, malá písmena ID entit), každý musí obsahovat tečku a alespoň jeden doslovný znak, např. klíč \"appliance_power_duration\" s hodnotou [\"sensor.ac_power\"] nebo klíč \"camera_entry_unsecured\" s hodnotou [\"camera.map_*\"]. Položky odpovídající všemu, jako například \"*\" nebo \"*.*\", nejsou povoleny — místo toho použijte klíč typu \"*\"."
       },
       "initiate_flow": {
         "reconfigure": "Přenastavit Sentinel",
@@ -213,7 +213,7 @@
           "data_description": {
             "sentinel_response_language": "Jazyk, ve kterém LLM generuje vysvětlení nálezu zobrazované v oznámeních, např. „Czech“. Ponechte prázdné pro angličtinu. Název/shrnutí discovery kandidátů a rozhodnutí/reason_code/shrnutí triáže tím nejsou ovlivněny -- ta jsou strojově zpracovávána a vždy zůstávají v angličtině.",
             "sentinel_rule_entity_exclusions_all": "Vyberte entity, které má Sentinel všude ignorovat -- např. šablonový zámek na dotykovém panelu, který jen zrcadlí stav jiné entity. Vyloučené entity se vyřadí z nálezů všech pravidel a už Sentinel neprobouzejí, takže skutečná anomálie, která se jich týká, se zachytí až při dalším cyklu (výchozí 5 minut). Nevylučujte kameru, zámek ani alarm, u kterých chcete okamžitá upozornění.",
-            "sentinel_rule_entity_exclusions": "Pro vyloučení entity jen z jednoho konkrétního pravidla (ne ze všech) a pro vzory se zástupnými znaky, např. camera.map_*, které výběr entit výše neumí uložit. Formát: {{\"id_pravidla\": [\"entita.id\", ...]}}; klíč \"*\" znamená všechna pravidla. Většina lidí tohle nepotřebuje -- použijte výběr entit výše."
+            "sentinel_rule_entity_exclusions": "Pro vyloučení entity jen z jednoho konkrétního pravidla (ne ze všech) a pro vzory se zástupnými znaky, např. camera.map_*, které výběr entit výše neumí uložit. Očekává objekt JSON, jehož klíče jsou typy anomálií a hodnoty seznamy ID entit; klíč \"*\" znamená všechna pravidla. Příklady najdete v dokumentaci Sentinelu. Většina lidí tohle nepotřebuje -- použijte výběr entit výše."
           }
         }
       }

--- a/custom_components/home_generative_agent/translations/en.json
+++ b/custom_components/home_generative_agent/translations/en.json
@@ -146,11 +146,11 @@
         "reconfigure_successful": "Sentinel configuration updated."
       },
       "error": {
-        "invalid_camera_entry_links": "Must be a JSON object mapping camera entity IDs to lists of entry entity IDs, e.g. {{\"camera.driveway\": [\"lock.front_door\"]}}.",
+        "invalid_camera_entry_links": "Must be a JSON object mapping camera entity IDs to lists of entry entity IDs, e.g. a \"camera.driveway\" key with the value [\"lock.front_door\"].",
         "invalid_pin": "PIN must be 4-10 digits.",
         "quiet_hours_incomplete": "Set both quiet hours start and end (or set both to Disabled).",
         "invalid_quiet_hours": "Quiet hours must be local hours between 0 and 23.",
-        "invalid_rule_entity_exclusions": "Must be a JSON object mapping an anomaly type (or \"*\" for all types) to lists of entity IDs or glob patterns (* and ? wildcards only, lowercase entity-ID characters), each containing a dot and at least one literal character, e.g. {{\"appliance_power_duration\": [\"sensor.ac_power\"], \"camera_entry_unsecured\": [\"camera.map_*\"]}}. Match-all entries such as \"*\" or \"*.*\" are not allowed — use the \"*\" type key instead."
+        "invalid_rule_entity_exclusions": "Must be a JSON object mapping an anomaly type (or \"*\" for all types) to lists of entity IDs or glob patterns (* and ? wildcards only, lowercase entity-ID characters), each containing a dot and at least one literal character, e.g. an \"appliance_power_duration\" key with the value [\"sensor.ac_power\"], or a \"camera_entry_unsecured\" key with the value [\"camera.map_*\"]. Match-all entries such as \"*\" or \"*.*\" are not allowed — use the \"*\" type key instead."
       },
       "initiate_flow": {
         "reconfigure": "Reconfigure Sentinel",
@@ -213,7 +213,7 @@
           "data_description": {
             "sentinel_response_language": "Language for the LLM-authored finding explanation shown in notifications, e.g. 'Czech'. Leave empty for English. Discovery candidate title/summary and triage decision/reason_code/summary are unaffected -- those are parsed by code and always stay in English.",
             "sentinel_rule_entity_exclusions_all": "Pick entities Sentinel should ignore everywhere -- e.g. a touch panel's template lock that only mirrors another entity's state. Excluded entities are dropped from every rule's findings and no longer wake Sentinel, so a real anomaly involving them is only caught on the next poll (default 5 minutes). Don't exclude a camera, lock, or alarm panel you still want instant alerts from.",
-            "sentinel_rule_entity_exclusions": "For excluding an entity from one specific rule only (not all of them), and for glob patterns such as camera.map_*, which the picker above cannot hold. Format: {{\"rule_id\": [\"entity.id\", ...]}}; the \"*\" key means all rules. Most people won't need this -- use the picker above instead."
+            "sentinel_rule_entity_exclusions": "For excluding an entity from one specific rule only (not all of them), and for glob patterns such as camera.map_*, which the picker above cannot hold. Expects a JSON object whose keys are anomaly types and whose values are lists of entity IDs; the \"*\" key means all rules. See the Sentinel docs for examples. Most people won't need this -- use the picker above instead."
           }
         }
       }

--- a/custom_components/home_generative_agent/translations/ru.json
+++ b/custom_components/home_generative_agent/translations/ru.json
@@ -199,11 +199,11 @@
         }
       },
       "error": {
-        "invalid_camera_entry_links": "Must be a JSON object mapping camera entity IDs to lists of entry entity IDs, e.g. {{\"camera.driveway\": [\"lock.front_door\"]}}.",
+        "invalid_camera_entry_links": "Must be a JSON object mapping camera entity IDs to lists of entry entity IDs, e.g. a \"camera.driveway\" key with the value [\"lock.front_door\"].",
         "invalid_pin": "PIN must be 4-10 digits.",
         "quiet_hours_incomplete": "Set both quiet hours start and end (or set both to Disabled).",
         "invalid_quiet_hours": "Quiet hours must be local hours between 0 and 23.",
-        "invalid_rule_entity_exclusions": "Must be a JSON object mapping an anomaly type (or \"*\" for all types) to lists of entity IDs or glob patterns (* and ? wildcards only, lowercase entity-ID characters), each containing a dot and at least one literal character, e.g. {{\"appliance_power_duration\": [\"sensor.ac_power\"], \"camera_entry_unsecured\": [\"camera.map_*\"]}}. Match-all entries such as \"*\" or \"*.*\" are not allowed — use the \"*\" type key instead."
+        "invalid_rule_entity_exclusions": "Must be a JSON object mapping an anomaly type (or \"*\" for all types) to lists of entity IDs or glob patterns (* and ? wildcards only, lowercase entity-ID characters), each containing a dot and at least one literal character, e.g. an \"appliance_power_duration\" key with the value [\"sensor.ac_power\"], or a \"camera_entry_unsecured\" key with the value [\"camera.map_*\"]. Match-all entries such as \"*\" or \"*.*\" are not allowed — use the \"*\" type key instead."
       }
     },
     "feature": {

--- a/custom_components/home_generative_agent/translations/tr.json
+++ b/custom_components/home_generative_agent/translations/tr.json
@@ -199,11 +199,11 @@
         }
       },
       "error": {
-        "invalid_camera_entry_links": "Kamera varlık kimliklerini giriş varlık kimliklerinin listesiyle eşleştiren bir JSON nesnesi olmalıdır, ör. {{\"camera.driveway\": [\"lock.front_door\"]}}.",
+        "invalid_camera_entry_links": "Kamera varlık kimliklerini giriş varlık kimliklerinin listesiyle eşleştiren bir JSON nesnesi olmalıdır, ör. değeri [\"lock.front_door\"] olan bir \"camera.driveway\" anahtarı.",
         "invalid_pin": "PIN 4-10 rakam olmalıdır.",
         "quiet_hours_incomplete": "Sessiz saatler için başlangıç ve bitişin ikisini de ayarlayın (veya ikisini de devre dışı bırakın).",
         "invalid_quiet_hours": "Sessiz saatler 0 ile 23 arasında yerel saat olmalıdır.",
-        "invalid_rule_entity_exclusions": "Bir anomali türünü (veya tüm türler için \"*\") her biri nokta ve en az bir sabit karakter içeren varlık kimliği veya glob deseni (yalnızca * ve ? joker karakterleri, küçük harfli varlık kimliği karakterleri) listeleriyle eşleştiren bir JSON nesnesi olmalıdır, ör. {{\"appliance_power_duration\": [\"sensor.ac_power\"], \"camera_entry_unsecured\": [\"camera.map_*\"]}}. \"*\" veya \"*.*\" gibi tümüyle eşleşen girdilere izin verilmez — bunun yerine \"*\" tür anahtarını kullanın."
+        "invalid_rule_entity_exclusions": "Bir anomali türünü (veya tüm türler için \"*\") her biri nokta ve en az bir sabit karakter içeren varlık kimliği veya glob deseni (yalnızca * ve ? joker karakterleri, küçük harfli varlık kimliği karakterleri) listeleriyle eşleştiren bir JSON nesnesi olmalıdır, ör. değeri [\"sensor.ac_power\"] olan bir \"appliance_power_duration\" anahtarı veya değeri [\"camera.map_*\"] olan bir \"camera_entry_unsecured\" anahtarı. \"*\" veya \"*.*\" gibi tümüyle eşleşen girdilere izin verilmez — bunun yerine \"*\" tür anahtarını kullanın."
       }
     },
     "feature": {

--- a/tests/custom_components/home_generative_agent/test_translations.py
+++ b/tests/custom_components/home_generative_agent/test_translations.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import json
 import re
 from pathlib import Path
-from string import Formatter
 from typing import Any
 
 import pytest
@@ -25,10 +24,21 @@ TRANSLATIONS_DIR = COMPONENT_DIR / "translations"
 
 _PLACEHOLDER_RE = re.compile(r"{\w+}")
 
-# Hassfest requires every `{...}` in a translation value to name a valid
-# Python identifier, because Home Assistant renders these through
-# ``str.format``.  A literal brace must be doubled (``{{`` / ``}}``).
+# Two engines read these strings, and they disagree about braces:
+#
+#   * Hassfest validates with ``str.format`` semantics — every ``{x}`` must
+#     name a valid identifier, and a literal brace is doubled (``{{``).
+#   * The HA *frontend* renders the same strings through ICU MessageFormat
+#     (``intl-messageformat``), where ``{{`` is not an escape at all — it is
+#     a malformed argument, and the field shows
+#     "Translation error: MALFORMED_ARGUMENT" instead of the help text.
+#
+# So no brace spelling satisfies both: single braces fail hassfest, doubled
+# braces fail the frontend, and ICU's own apostrophe escape (``'{'``) would
+# fail hassfest in turn.  The only safe text is text with no literal braces —
+# write the JSON example as prose.  Square brackets are fine in both.
 _IDENTIFIER_RE = re.compile(r"[a-zA-Z_][a-zA-Z0-9_]*")
+_BRACED_RE = re.compile(r"\{([^{}]*)\}")
 
 
 def _flatten(data: dict[str, Any], prefix: str = "") -> dict[str, str]:
@@ -61,22 +71,23 @@ def _hassfest_validated_files() -> list[Path]:
 
 def _invalid_placeholders(value: str) -> list[str]:
     """
-    Return the ``{...}`` fields in *value* that hassfest would reject.
+    Return the brace usages in *value* that hassfest or the frontend rejects.
 
-    Mirrors ``str.format`` semantics via ``string.Formatter``, so doubled
-    braces are correctly read as escaped literals rather than placeholders.
-    A value that will not parse at all (a stray unmatched brace) is reported
-    too — hassfest rejects those as well.
+    Enforces the intersection of both engines (see the module-level note):
+    a literal brace is never allowed in either spelling, and every remaining
+    ``{...}`` must name a valid identifier so it is a real placeholder.
     """
-    try:
-        fields = [
-            field
-            for _literal, field, _spec, _conv in Formatter().parse(value)
-            if field is not None
-        ]
-    except ValueError as err:  # unmatched or malformed brace
-        return [f"<unparseable: {err}>"]
-    return [f for f in fields if not _IDENTIFIER_RE.fullmatch(f)]
+    problems: list[str] = []
+    if "{{" in value or "}}" in value:
+        problems.append("{{ or }} — escaped for hassfest, MALFORMED_ARGUMENT in the UI")
+    problems += [
+        f"{{{m.group(1)}}}"
+        for m in _BRACED_RE.finditer(value)
+        if not _IDENTIFIER_RE.fullmatch(m.group(1))
+    ]
+    if value.count("{") != value.count("}"):
+        problems.append("unbalanced braces")
+    return problems
 
 
 def test_en_json_matches_strings_json() -> None:
@@ -120,14 +131,18 @@ def test_translation_values_have_no_surrounding_whitespace(path: Path) -> None:
 @pytest.mark.parametrize("path", _hassfest_validated_files(), ids=lambda p: p.name)
 def test_translation_placeholders_are_valid_identifiers(path: Path) -> None:
     """
-    Every ``{...}`` must name an identifier — literal braces must be doubled.
+    Only real ``{identifier}`` placeholders — never a literal brace.
 
-    Hassfest enforces this and only runs in CI, so an unescaped JSON example
-    in a help string turns the whole integration invalid with a green
-    ``make lint`` and a green ``make test``.  That is exactly how it reached
-    the branch for PR #544: ``Format: {"rule_id": ["entity.id", ...]}`` in the
-    advanced-exclusions ``data_description``, while the sibling error string
-    in the same file already used the doubled-brace escape.
+    Both failure modes have shipped, one after the other, on PR #544:
+
+    * ``Format: {"rule_id": ["entity.id", ...]}`` turned hassfest red, which
+      only runs in CI, so ``make lint`` and ``make test`` stayed green.
+    * Doubling the braces to satisfy hassfest then rendered the field as
+      "Translation error: MALFORMED_ARGUMENT" in the UI, because the frontend
+      parses ICU MessageFormat, where ``{{`` is not an escape.
+
+    Neither spelling works, so neither is allowed: write the JSON example as
+    prose instead.
     """
     bad = {
         key: invalid
@@ -135,19 +150,32 @@ def test_translation_placeholders_are_valid_identifiers(path: Path) -> None:
         if isinstance(value, str) and (invalid := _invalid_placeholders(value))
     }
     assert not bad, (
-        f"{path.name} has braces hassfest will reject (double them to escape "
-        f"a literal brace): {bad}"
+        f"{path.name} has brace usage one of the two engines rejects — write "
+        f"the example as prose rather than literal JSON: {bad}"
     )
 
 
 @pytest.mark.parametrize(
     ("value", "expected"),
     [
-        # The literal string that turned hassfest red on PR #544.
-        ('Format: {"rule_id": ["entity.id", ...]}', ['"rule_id"']),
-        ("{not-an-identifier}", ["not-an-identifier"]),
-        ("{}", [""]),
-        ("{0}", ["0"]),
+        # The string that turned hassfest red on PR #544...
+        (
+            'Format: {"rule_id": ["entity.id", ...]}',
+            ['{"rule_id": ["entity.id", ...]}'],
+        ),
+        # ...and the doubled-brace "fix" that satisfied hassfest but rendered
+        # as MALFORMED_ARGUMENT in the UI. Both must be rejected.
+        (
+            'Format: {{"rule_id": ["entity.id", ...]}}',
+            [
+                "{{ or }} — escaped for hassfest, MALFORMED_ARGUMENT in the UI",
+                '{"rule_id": ["entity.id", ...]}',
+            ],
+        ),
+        ("{not-an-identifier}", ["{not-an-identifier}"]),
+        ("{}", ["{}"]),
+        ("{0}", ["{0}"]),
+        ("stray closing brace }", ["unbalanced braces"]),
     ],
 )
 def test_invalid_placeholders_rejects(value: str, expected: list[str]) -> None:
@@ -155,24 +183,19 @@ def test_invalid_placeholders_rejects(value: str, expected: list[str]) -> None:
     assert _invalid_placeholders(value) == expected
 
 
-def test_invalid_placeholders_reports_unparseable_braces() -> None:
-    """A stray brace is reported rather than crashing the test run."""
-    assert _invalid_placeholders("stray closing brace }")
-
-
 @pytest.mark.parametrize(
     "value",
     [
-        # The fixed form of the PR #544 string, matching the sibling error
-        # string in the same file.
-        'Format: {{"rule_id": ["entity.id", ...]}}',
+        # The shipped fix: the same example written as prose. Square brackets
+        # are literal in both engines, so only the braces had to go.
+        'an "appliance_power_duration" key with the value ["sensor.ac_power"]',
         "no braces at all",
         "a real {placeholder} is fine",
-        "{{escaped}} beside a real {placeholder}",
+        "two {placeholders} in {one} string",
     ],
 )
 def test_invalid_placeholders_accepts(value: str) -> None:
-    """Escaped literals and real placeholders must not be flagged."""
+    """Real placeholders and brace-free prose must not be flagged."""
     assert _invalid_placeholders(value) == []
 
 


### PR DESCRIPTION
The Sentinel settings form renders **`Translation error: MALFORMED_ARGUMENT`** in place of the advanced-exclusions help text, on v3.29.0. Reported from a live install.

## Root cause

Two engines read the integration's translation strings and they disagree about braces:

| | escape for a literal `{` | reads `{{` as |
|---|---|---|
| **Hassfest** (CI) | `{{` | escaped literal — valid |
| **HA frontend** (ICU MessageFormat, via `hass.localize`) | `'{'` | **malformed argument** |

`MALFORMED_ARGUMENT` is an error kind from `@formatjs/icu-messageformat-parser`, which is what the frontend uses to render `data_description`. So a literal JSON example in a translation value can satisfy one engine or the other, never both — and ICU's apostrophe escape would fail hassfest in turn.

The field never worked. #544 shipped it with single braces (hassfest-invalid *and* ICU-malformed); `ca748bf` doubled them to get CI green, which is the spelling released in v3.29.0.

## Fix

Write the JSON examples as prose. Square brackets are literal in both engines, so only the braces had to go:

> …e.g. an `"appliance_power_duration"` key with the value `["sensor.ac_power"]`.

Three keys, across `strings.json` + en/cs/ru/tr:

- `data_description.sentinel_rule_entity_exclusions` — the one in the screenshot.
- `error.invalid_camera_entry_links` and `error.invalid_rule_entity_exclusions` — **pre-existing**, older than #544. Worse in effect: they only render when a user submits a bad value, so the render error would replace the message explaining what was wrong with it.

## Why the existing guard missed it

`test_translation_placeholders_are_valid_identifiers` (added in `c9c0bdd`, one commit before the bad string shipped) encoded hassfest's rule using `string.Formatter` — Python semantics — so it treated `{{` as a correct escape and **passed** the string that breaks the UI.

It now enforces the intersection of both engines: no literal brace in either spelling, and every remaining `{...}` must be an identifier. Checked against `strings.json` and all four translation files.

Verified by restoring the v3.29.0 strings: **all five files fail**, including the two error strings the previous version never flagged.

## Checks

- `make lint` clean, `make typecheck` at the pre-existing `StaticPathConfig` error only
- 2331 tests pass
- The seven real placeholders (`{overwrite_warning}`, `{feature_name}`, …) are single-brace identifiers — valid ICU, untouched

## Reviewer note

My Czech and Turkish edits are mechanical rewrites of the existing sentences (same structure, JSON example turned into prose) and would benefit from a native-speaker check. @hruba202 if you have a moment for the Czech.
