### PR TITLE
chore: file the deferred #570 review findings

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -149,6 +149,33 @@ And two writer-consistency gaps: (7) `_mark_tool_index_stale` (embedding-provide
 
 ---
 
+### Translation parity is enforced for cs only, not ru/tr
+
+**What:** The translation parity test checks `cs` against `en` for missing keys, while `ru` and `tr` are only checked for *unknown* keys. A PR can therefore ship a new `en` string with no `ru`/`tr` counterpart and CI stays green; the user silently sees English in an otherwise translated form.
+
+**Why:** Surfaced during the #570 ship review (v3.32.0) when all four locales happened to be updated together. Not a regression — the asymmetry predates that change — but it means the completeness of `ru`/`tr` decays invisibly rather than failing loudly.
+
+**How to apply:** Extend the missing-key assertion to every locale in `translations/`, or make the locale list explicit and require a deliberate opt-out for any locale intentionally kept partial. Expect an initial batch of failures for keys that are already missing.
+
+**Effort:** S
+**Priority:** P4
+
+---
+
+### Excluded-tools picker: label trust markers and identity are forgeable
+
+**What:** Five findings deferred from the #570 ship review (v3.32.0), all in the options-form exclusion picker. (1) **Marker forgery is narrowed, not closed** — `_label_text` rewrites `(`/`)` to brackets so a tool named `x (not currently available)` cannot imitate the trusted suffix, but that matches only U+0028/U+0029; fullwidth (U+FF08/09), small (U+FE59/5A), white (U+2985/86), superscript and tortoise-shell parens all survive `sanitize_tool_text` and read as parentheses. (2) **Duplicate labels** — `seen` dedupes on value, never on label, so two MCP servers both reporting `serverInfo.name = "Files"` with a `delete_file` each render byte-identical rows; the operator ticks one and leaves the other live. (3) **entry_id churn** — MCP api ids are `mcp-<entry_id>` and `entry_id` is regenerated on delete-and-re-add, so every stored exclusion for that server becomes an orphan that the UI still shows ticked while the new entry's identical tools enumerate unexcluded. (4) **No cardinality cap** — nothing bounds the number of `SelectOptionDict`s or the indexed-key union, and index rows are never evicted, so one server advertising tens of thousands of tools poisons the form permanently. (5) **Permissive `__eq__`** — `filter_excluded_tools` keeps a non-str `.name` (isinstance fails) while `APIInstance.async_call_tool` dispatches on `tool.name == tool_input.tool_name`, so a custom `llm.API` could register an object that is kept by the filter and dispatched by the caller.
+
+**Why:** All five are deceptions or losses in the UI of a *security control* — the user believes a tool is switched off when it is not — but none is reachable through the stock MCP integration by a merely buggy server, and (1) and (2) need a design decision rather than a patch: an in-band lexical marker in a flat label string cannot be made forgery-proof by escaping, because the adversary controls the surrounding text. Documented honestly in `docs/configuration.md` rather than silently carried. Deferred at the 3-cycle review bound after two rounds of fixes each introduced new bugs.
+
+**How to apply:** For (1)+(2) together, stop concatenating remote text with trust markers: put the state in a non-remote position (prefix `[unavailable] Server: tool`, rejecting a leading `[` in sanitized text) and disambiguate colliding labels with the api id, which is unique by construction. Alternatively NFKC-fold the remote half and match the Unicode Ps/Pe categories, which closes (1) only. For (3), consider matching on server name as a secondary key, or warn when an orphaned exclusion's tool name matches a live tool of another api — any auto-migration is a guess about identity, so surface it rather than silently remap. For (4), cap the total choice count and the indexed-key union, and label index-sourced entries distinctly from live-enumerated ones. For (5), one line of honesty in the comment plus an equality-based rather than isinstance-based keep test.
+
+**Effort:** M
+**Priority:** P3
+**Depends on:** v3.32.0
+
+---
+
 ### Tool-name collision hardening for force-injection guard
 
 **What:** The step-3d injection guard and `_format_and_dedupe_tools` key on bare tool name. A remote (e.g. MCP) API exposing a tool named `add_automation` would suppress injection of the local tool and route automation YAML to the foreign tool (first-seen-wins dedupe predates v3.20.2). Consider `(api_id, name)` matching for the guard and explicit precedence in dedupe.


### PR DESCRIPTION
Records the six findings from the v3.32.0 review (#574) that were consciously deferred at the 3-cycle fix bound, so they live in the backlog rather than only in the PR body and docs.

Five in the excluded-tools picker:

- **Marker forgery narrowed, not closed** — the paren rewrite matches only U+0028/U+0029; fullwidth, small, white and tortoise-shell variants all survive. Needs a design change (move the marker out of the flat label), not a wider character class.
- **Duplicate labels** — dedupe is on value, never on label, so two servers reporting the same name render identical rows.
- **entry_id churn** — re-adding an MCP server orphans its exclusions while the UI still shows them ticked.
- **No cardinality cap** on picker choices or the indexed-key union.
- **Permissive `__eq__`** — kept by the filter (isinstance), dispatched by the caller (equality).

Plus one pre-existing gap noticed in passing: translation parity is enforced for `cs` only, so a new `en` string can ship without `ru`/`tr` and CI stays green.

Docs-only change — no code, no tests affected.

Refs #570

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TsMC9cBnJ8pw263K8N9xPz