### PR TITLE
v3.33.0 fix: keep the Gemini API key out of logs and stop token-count failures killing the turn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.33.0] - 2026-08-27
+
+### Fixed
+
+- **A Gemini conversation no longer dies because Google declined to count its tokens.** Before each reply the integration asks Gemini how large the conversation is, so it knows how much history to trim. When that call failed — an unavailable model, a rejected key, an unreachable Google — nothing caught it and the failure took the entire reply down with it, leaving `Unexpected error in streaming task` in the log and no answer on screen. Counting now falls back to an estimate and the conversation carries on. The exact counter is then set aside for five minutes, because it is called many times per message and a failing endpoint would otherwise be re-dialled on each one. Reported by [@Xornop](https://github.com/Xornop) ([#575](https://github.com/goruck/home-generative-agent/issues/575)).
+- **Your Gemini API key no longer appears in Home Assistant's logs.** The key was sent as part of the request URL, and Python quotes the whole URL in any error it raises — so one failed request wrote the key verbatim into the log, into the traceback Home Assistant shows in the UI, and from there into screenshots and bug reports. The key now travels in a request header, which no error message repeats, and anything key-shaped is stripped from these messages as a second line of defence. **If a `generativelanguage.googleapis.com` error has ever appeared in your log, treat that key as public: delete it at [Google AI Studio](https://aistudio.google.com/apikey) and issue a new one.** The key check run when you save your Gemini settings was doing the same thing and is fixed alongside it.
+- **A failed Gemini request now says what went wrong.** Google puts the reason in the body of its reply — which model it could not find, which quota you crossed, that the key is disabled — and the integration threw that away and reported only the status number. The reason is now included, with any credential removed, so a 404 names the model instead of leaving you to guess.
+- **A rejected Gemini key is reported as an authentication problem rather than a connection one.** Google answers a bad or blocked key with 400 or 403, never 401, and only 401 was recognised — so entering an invalid key told you Home Assistant could not reach Google, sending you after a network fault you did not have.
+- **Approximate token counting for Ollama no longer insists on an Ollama URL.** The URL was required on every count even though only the exact-counting mode ever uses it.
+
+### Added
+
+- **Gemini 3 models can be selected** for chat, image analysis, and summarization: `gemini-3.7-flash`, `gemini-3.5-flash`, `gemini-3.5-flash-lite`, and `gemini-3.1-flash-lite`, alongside the 2.5 models already offered. Defaults are unchanged. Google does not grant every account access to every model, so if one reports "not found", choose another from the list.
+
 ## [3.32.1] - 2026-08-27
 
 ### Fixed

--- a/custom_components/home_generative_agent/agent/token_counter.py
+++ b/custom_components/home_generative_agent/agent/token_counter.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterable, Mapping, Sequence
+import re
+import time
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from functools import lru_cache
 from typing import Any, Literal
 
@@ -16,12 +18,58 @@ from ..const import (  # noqa: TID252
     CONF_GEMINI_API_KEY,
     CONF_OLLAMA_CHAT_URL,
     CONF_OLLAMA_URL,
+    HTTP_STATUS_BAD_REQUEST,
     OLLAMA_EXACT_TOKEN_COUNT,
 )
 
 OPENAI_PREFIXES: tuple[str, ...] = ("gpt",)
 
 LOGGER = logging.getLogger(__name__)
+
+# Longest provider error body we keep when reporting a failed remote count.
+_MAX_ERROR_BODY_CHARS = 500
+
+# Remote token counters can fail for reasons the user cannot fix mid-conversation
+# (model unavailable to the key's project, revoked key, host unreachable). When
+# that happens we fall back to approximate counting rather than taking the whole
+# conversation down, and stop calling the remote counter for a cooldown period --
+# `trim_messages` invokes the counter many times per turn and each retry would pay
+# the full request timeout.
+REMOTE_COUNT_COOLDOWN_S = 300.0
+_remote_count_disabled_until: dict[str, float] = {}
+
+# Anything shaped like an API key that could ride along in a URL or error body.
+_SECRET_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"AIzaSy[A-Za-z0-9_\-]{20,}"),
+    re.compile(r"(?i)([?&](?:key|api_key|apikey|access_token)=)[^&\s\"']+"),
+)
+
+
+def _redact_secrets(text: str) -> str:
+    """Strip anything key-shaped so credentials never reach a log or traceback."""
+    out = _SECRET_PATTERNS[0].sub("<redacted>", text)
+    return _SECRET_PATTERNS[1].sub(r"\1<redacted>", out)
+
+
+def _remote_count_suppressed(key: str) -> bool:
+    """Return True while a failing remote counter is still in its cooldown."""
+    deadline = _remote_count_disabled_until.get(key)
+    return deadline is not None and time.monotonic() < deadline
+
+
+def _suppress_remote_count(key: str, exc: Exception) -> None:
+    """Disable a remote counter for a cooldown, warning once per outage."""
+    already_suppressed = _remote_count_suppressed(key)
+    _remote_count_disabled_until[key] = time.monotonic() + REMOTE_COUNT_COOLDOWN_S
+    if not already_suppressed:
+        LOGGER.warning(
+            "Exact token counting for %s failed; using approximate counts for the "
+            "next %.0f seconds. Conversation continues. Cause: %s",
+            key,
+            REMOTE_COUNT_COOLDOWN_S,
+            _redact_secrets(str(exc)),
+        )
+
 
 # ---- Providers ----
 Provider = Literal["openai", "openai_compatible", "gemini", "ollama", "anthropic"]
@@ -155,14 +203,29 @@ def _count_gemini_tokens(
     }
 
     try:
+        # The key goes in a header, never the query string: a query-string key
+        # ends up verbatim in tracebacks and Home Assistant logs, which users
+        # then paste into bug reports.
         response = requests.post(
-            url, params={"key": gemini_api_key}, json=payload, timeout=timeout
+            url,
+            headers={"x-goog-api-key": gemini_api_key},
+            json=payload,
+            timeout=timeout,
         )
-        response.raise_for_status()
+        if response.status_code >= HTTP_STATUS_BAD_REQUEST:
+            # Google explains *why* in the body ("model not found for API version
+            # v1beta", quota, disabled key). raise_for_status() drops it, leaving
+            # a bare status code nobody can act on.
+            detail = response.text.strip()[:_MAX_ERROR_BODY_CHARS]
+            msg = (
+                f"Gemini countTokens failed for model {model!r}: "
+                f"HTTP {response.status_code}. {detail}"
+            )
+            raise RuntimeError(_redact_secrets(msg))
         data = response.json()
     except requests.RequestException as exc:
-        msg = f"Gemini countTokens failed: {exc!s}"
-        raise RuntimeError(msg) from exc
+        msg = f"Gemini countTokens failed for model {model!r}: {exc!s}"
+        raise RuntimeError(_redact_secrets(msg)) from exc
 
     val = data.get("totalTokens", data.get("total_tokens"))
     if isinstance(val, int):
@@ -266,6 +329,29 @@ def _looks_like_openai_model(name: str) -> bool:
     return any(n.startswith(p) for p in OPENAI_PREFIXES)
 
 
+def _count_remote_or_approximate(
+    key: str,
+    messages: Sequence[MessageLike],
+    exact: Callable[[], int],
+) -> int:
+    """
+    Run an exact remote count, falling back to an approximate one on failure.
+
+    Token counting runs on the hot path of every chat turn, so a provider outage
+    or an unavailable model must degrade the count, not abort the conversation.
+    After a failure the remote counter is skipped for `REMOTE_COUNT_COOLDOWN_S`.
+    """
+    if not _remote_count_suppressed(key):
+        try:
+            return exact()
+        except (RuntimeError, ValueError) as exc:
+            _suppress_remote_count(key, exc)
+
+    approx = count_tokens_approximately(_as_message_reprs(messages))
+    LOGGER.debug("Token count for %s (approx fallback): %d", key, approx)
+    return approx
+
+
 def count_tokens_cross_provider(
     messages: Sequence[MessageLike],
     model: str,
@@ -281,6 +367,9 @@ def count_tokens_cross_provider(
     gemini  -> REST models/{model}:countTokens
     ollama  -> If model looks like OpenAI (e.g., gpt-oss), use tiktoken;
                otherwise /api/tokenize (fast) or /api/generate with (exact)
+
+    Remote counters (Gemini, Ollama) degrade to an approximate count rather than
+    raising, so a provider failure cannot take the conversation down with it.
     """
     if provider in ("openai", "openai_compatible"):
         return _count_tokens_tiktoken(messages, model=model)
@@ -290,34 +379,50 @@ def count_tokens_cross_provider(
         return _count_tokens_tiktoken(messages, model="gpt-4o")
 
     if provider == "gemini":
-        gemini_api_key_any = options.get(CONF_GEMINI_API_KEY)
-        if not isinstance(gemini_api_key_any, str) or not gemini_api_key_any.strip():
-            msg = "Gemini API key must be a non-empty string in options."
-            raise ValueError(msg)
-        gemini_api_key: str = gemini_api_key_any
-        return _count_gemini_tokens(
-            messages, model=model, gemini_api_key=gemini_api_key
-        )
+
+        def _gemini_exact() -> int:
+            gemini_api_key_any = options.get(CONF_GEMINI_API_KEY)
+            if (
+                not isinstance(gemini_api_key_any, str)
+                or not gemini_api_key_any.strip()
+            ):
+                msg = "Gemini API key must be a non-empty string in options."
+                raise ValueError(msg)
+            return _count_gemini_tokens(
+                messages, model=model, gemini_api_key=gemini_api_key_any
+            )
+
+        return _count_remote_or_approximate(f"gemini/{model}", messages, _gemini_exact)
 
     # Provider "ollama"
     # If Ollama is hosting an OpenAI-style GPT (e.g., gpt-oss), prefer tiktoken.
     if _looks_like_openai_model(model):
         return _count_tokens_tiktoken(messages, model=model)
 
-    ollama_base_url_any = options.get(CONF_OLLAMA_CHAT_URL) or options.get(
-        CONF_OLLAMA_URL
-    )
-    if not isinstance(ollama_base_url_any, str) or not ollama_base_url_any.strip():
-        msg = "Ollama base URL must be a non-empty string in options."
-        raise ValueError(msg)
-    ollama_base_url: str = ollama_base_url_any
-
     if OLLAMA_EXACT_TOKEN_COUNT:
-        n = _count_ollama_tokens(
-            messages, model=model, base_url=ollama_base_url, options=chat_model_options
-        )
-        LOGGER.debug("Ollama token count (exact): %d", n)
-        return n
+
+        def _ollama_exact() -> int:
+            # Only the exact path needs a reachable Ollama host, so the URL is
+            # required here rather than for every count.
+            ollama_base_url_any = options.get(CONF_OLLAMA_CHAT_URL) or options.get(
+                CONF_OLLAMA_URL
+            )
+            if (
+                not isinstance(ollama_base_url_any, str)
+                or not ollama_base_url_any.strip()
+            ):
+                msg = "Ollama base URL must be a non-empty string in options."
+                raise ValueError(msg)
+            n = _count_ollama_tokens(
+                messages,
+                model=model,
+                base_url=ollama_base_url_any,
+                options=chat_model_options,
+            )
+            LOGGER.debug("Ollama token count (exact): %d", n)
+            return n
+
+        return _count_remote_or_approximate(f"ollama/{model}", messages, _ollama_exact)
 
     approx = count_tokens_approximately(_as_message_reprs(messages))
     LOGGER.debug("Ollama token count (approx): %d", approx)

--- a/custom_components/home_generative_agent/const.py
+++ b/custom_components/home_generative_agent/const.py
@@ -17,6 +17,7 @@ SUBENTRY_TYPE_STT_PROVIDER = "stt_provider"
 SUBENTRY_TYPE_SENTINEL = "sentinel"
 
 HTTP_STATUS_UNAUTHORIZED = 401
+HTTP_STATUS_FORBIDDEN = 403
 HTTP_STATUS_BAD_REQUEST = 400
 HTTP_STATUS_WEBPAGE_NOT_FOUND = 404
 HTTP_STATUS_OK = 200
@@ -406,7 +407,13 @@ CHAT_MODEL_OPENAI_SUPPORTED = Literal[
     "gpt-5", "gpt-5-mini", "gpt-5-nano", "gpt-4o", "gpt-4.1", "o4-mini"
 ]
 CHAT_MODEL_GEMINI_SUPPORTED = Literal[
-    "gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite"
+    "gemini-3.7-flash",
+    "gemini-3.5-flash",
+    "gemini-3.5-flash-lite",
+    "gemini-3.1-flash-lite",
+    "gemini-2.5-pro",
+    "gemini-2.5-flash",
+    "gemini-2.5-flash-lite",
 ]
 CHAT_MODEL_ANTHROPIC_SUPPORTED = Literal[
     "claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5-20251001"
@@ -461,7 +468,13 @@ VLM_TOP_P = 1.0
 VLM_OLLAMA_SUPPORTED = Literal["qwen2.5vl:7b", "qwen3-vl:8b", "gemma3:4b"]
 VLM_OPENAI_SUPPORTED = Literal["gpt-5-nano", "gpt-4.1", "gpt-4.1-nano"]
 VLM_GEMINI_SUPPORTED = Literal[
-    "gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite"
+    "gemini-3.7-flash",
+    "gemini-3.5-flash",
+    "gemini-3.5-flash-lite",
+    "gemini-3.1-flash-lite",
+    "gemini-2.5-pro",
+    "gemini-2.5-flash",
+    "gemini-2.5-flash-lite",
 ]
 VLM_ANTHROPIC_SUPPORTED = Literal[
     "claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5-20251001"
@@ -579,7 +592,13 @@ SUMMARIZATION_MODEL_TOP_P = 1.0
 SUMMARIZATION_MODEL_OLLAMA_SUPPORTED = Literal["qwen3:1.7b", "qwen3:8b"]
 SUMMARIZATION_MODEL_OPENAI_SUPPORTED = Literal["gpt-5-nano", "gpt-4.1", "gpt-4.1-nano"]
 SUMMARIZATION_MODEL_GEMINI_SUPPORTED = Literal[
-    "gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite"
+    "gemini-3.7-flash",
+    "gemini-3.5-flash",
+    "gemini-3.5-flash-lite",
+    "gemini-3.1-flash-lite",
+    "gemini-2.5-pro",
+    "gemini-2.5-flash",
+    "gemini-2.5-flash-lite",
 ]
 SUMMARIZATION_MODEL_ANTHROPIC_SUPPORTED = Literal[
     "claude-sonnet-4-6", "claude-haiku-4-5-20251001"

--- a/custom_components/home_generative_agent/core/utils.py
+++ b/custom_components/home_generative_agent/core/utils.py
@@ -25,6 +25,7 @@ from ..const import (  # noqa: TID252
     CONF_OLLAMA_URL,
     EMBEDDING_MODEL_DIMS,
     HTTP_STATUS_BAD_REQUEST,
+    HTTP_STATUS_FORBIDDEN,
     HTTP_STATUS_UNAUTHORIZED,
     OLLAMA_BOOL_HINT_TAGS,
     OLLAMA_CATEGORY_URL_KEYS,
@@ -786,14 +787,24 @@ async def validate_gemini_key(
     client = get_async_client(hass)
     try:
         async with asyncio.timeout(timeout_s):
+            # Key goes in a header, not the query string: a key in the URL leaks
+            # into every exception message and log line that quotes the request.
             resp = await client.get(
-                f"https://generativelanguage.googleapis.com/v1/models?key={api_key}"
+                "https://generativelanguage.googleapis.com/v1/models",
+                headers={"x-goog-api-key": api_key},
             )
     except (TimeoutError, httpx.RequestError) as err:
         LOGGER.debug("Gemini connectivity exception: %s", err)
         raise CannotConnectError from err
     else:
-        if resp.status_code == HTTP_STATUS_UNAUTHORIZED:
+        # Google reports a bad, blocked or unauthorized key as 400/401/403 --
+        # reporting those as "cannot connect" sends users hunting a network
+        # problem they do not have.
+        if resp.status_code in (
+            HTTP_STATUS_BAD_REQUEST,
+            HTTP_STATUS_UNAUTHORIZED,
+            HTTP_STATUS_FORBIDDEN,
+        ):
             raise InvalidAuthError
         if resp.status_code >= HTTP_STATUS_BAD_REQUEST:
             raise CannotConnectError

--- a/custom_components/home_generative_agent/manifest.json
+++ b/custom_components/home_generative_agent/manifest.json
@@ -35,5 +35,5 @@
     "langchain-anthropic==1.4.3"
   ],
   "single_config_entry": true,
-  "version": "3.32.1"
+  "version": "3.33.0"
 }

--- a/docs/constants.md
+++ b/docs/constants.md
@@ -55,7 +55,7 @@ This document covers the named constants that affect integration behaviour, orga
 |---|---|
 | `CHAT_MODEL_OLLAMA_SUPPORTED` | `gpt-oss`, `qwen2.5:32b`, `qwen3:32b`, `qwen3:8b` |
 | `CHAT_MODEL_OPENAI_SUPPORTED` | `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-4o`, `gpt-4.1`, `o4-mini` |
-| `CHAT_MODEL_GEMINI_SUPPORTED` | `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite` |
+| `CHAT_MODEL_GEMINI_SUPPORTED` | `gemini-3.7-flash`, `gemini-3.5-flash`, `gemini-3.5-flash-lite`, `gemini-3.1-flash-lite`, `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite` |
 | `CHAT_MODEL_ANTHROPIC_SUPPORTED` | `claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5-20251001` |
 
 ---
@@ -95,7 +95,7 @@ This document covers the named constants that affect integration behaviour, orga
 |---|---|
 | `VLM_OLLAMA_SUPPORTED` | `qwen2.5vl:7b`, `qwen3-vl:8b`, `gemma3:4b` |
 | `VLM_OPENAI_SUPPORTED` | `gpt-5-nano`, `gpt-4.1`, `gpt-4.1-nano` |
-| `VLM_GEMINI_SUPPORTED` | `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite` |
+| `VLM_GEMINI_SUPPORTED` | `gemini-3.7-flash`, `gemini-3.5-flash`, `gemini-3.5-flash-lite`, `gemini-3.1-flash-lite`, `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite` |
 | `VLM_ANTHROPIC_SUPPORTED` | `claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5-20251001` |
 
 ---
@@ -131,7 +131,7 @@ This document covers the named constants that affect integration behaviour, orga
 |---|---|
 | `SUMMARIZATION_MODEL_OLLAMA_SUPPORTED` | `qwen3:1.7b`, `qwen3:8b` |
 | `SUMMARIZATION_MODEL_OPENAI_SUPPORTED` | `gpt-5-nano`, `gpt-4.1`, `gpt-4.1-nano` |
-| `SUMMARIZATION_MODEL_GEMINI_SUPPORTED` | `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite` |
+| `SUMMARIZATION_MODEL_GEMINI_SUPPORTED` | `gemini-3.7-flash`, `gemini-3.5-flash`, `gemini-3.5-flash-lite`, `gemini-3.1-flash-lite`, `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite` |
 | `SUMMARIZATION_MODEL_ANTHROPIC_SUPPORTED` | `claude-sonnet-4-6`, `claude-haiku-4-5-20251001` |
 
 ---

--- a/tests/custom_components/home_generative_agent/test_token_counter.py
+++ b/tests/custom_components/home_generative_agent/test_token_counter.py
@@ -1,21 +1,48 @@
 # ruff: noqa: S101
-"""Unit tests for agent/token_counter.py — Anthropic provider branch."""
+"""Unit tests for agent/token_counter.py."""
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
+import pytest
+import requests
 from langchain_core.messages import HumanMessage
 
+from custom_components.home_generative_agent.agent import token_counter
 from custom_components.home_generative_agent.agent.token_counter import (
+    _count_gemini_tokens,
+    _redact_secrets,
     count_tokens_cross_provider,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+FAKE_KEY = "AIzaSyFAKEKEYFAKEKEYFAKEKEYFAKEKEY0000"
+
+
+@pytest.fixture(autouse=True)
+def _clear_remote_count_cooldown() -> Iterator[None]:
+    """Keep the fail-open cooldown from leaking between tests."""
+    token_counter._remote_count_disabled_until.clear()
+    yield
+    token_counter._remote_count_disabled_until.clear()
 
 
 def _make_fake_encoding(token_count: int = 5) -> MagicMock:
     enc = MagicMock()
     enc.encode.return_value = list(range(token_count))
     return enc
+
+
+def _make_response(status_code: int, *, text: str = "", json_body: object = None):  # noqa: ANN202
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = text
+    resp.json.return_value = json_body
+    return resp
 
 
 def test_count_tokens_cross_provider_anthropic_returns_int() -> None:
@@ -51,3 +78,106 @@ def test_count_tokens_cross_provider_anthropic_empty_messages() -> None:
         )
     assert isinstance(result, int)
     assert result == 0
+
+
+def test_gemini_count_sends_key_as_header_not_query_param() -> None:
+    """The API key must never ride in the URL, where tracebacks would expose it."""
+    with patch.object(
+        token_counter.requests,
+        "post",
+        return_value=_make_response(200, json_body={"totalTokens": 42}),
+    ) as mock_post:
+        result = _count_gemini_tokens(
+            [HumanMessage(content="hi")],
+            model="gemini-2.5-flash-lite",
+            gemini_api_key=FAKE_KEY,
+        )
+
+    assert result == 42
+    url = mock_post.call_args.args[0]
+    assert FAKE_KEY not in url
+    assert "key=" not in url
+    assert mock_post.call_args.kwargs["headers"] == {"x-goog-api-key": FAKE_KEY}
+    assert mock_post.call_args.kwargs.get("params") is None
+
+
+def test_gemini_count_error_includes_body_and_hides_key() -> None:
+    """An HTTP error reports Google's reason without leaking the credential."""
+    body = '{"error": {"message": "models/gemini-2.5-flash-lite is not found"}}'
+    with (
+        patch.object(
+            token_counter.requests, "post", return_value=_make_response(404, text=body)
+        ),
+        pytest.raises(RuntimeError) as excinfo,
+    ):
+        _count_gemini_tokens(
+            [HumanMessage(content="hi")],
+            model="gemini-2.5-flash-lite",
+            gemini_api_key=FAKE_KEY,
+        )
+
+    message = str(excinfo.value)
+    assert "is not found" in message
+    assert "404" in message
+    assert FAKE_KEY not in message
+
+
+def test_gemini_count_failure_falls_back_to_approximate() -> None:
+    """A failing countTokens call degrades the count instead of killing the turn."""
+    messages = [HumanMessage(content="Hello, how are you?")]
+    with patch.object(
+        token_counter.requests, "post", return_value=_make_response(404, text="nope")
+    ):
+        result = count_tokens_cross_provider(
+            messages,
+            model="gemini-2.5-flash-lite",
+            provider="gemini",
+            options={"gemini_api_key": FAKE_KEY},
+            chat_model_options={},
+        )
+
+    assert isinstance(result, int)
+    assert result > 0
+
+
+def test_gemini_count_failure_suppresses_further_requests() -> None:
+    """After a failure the remote counter is skipped for the cooldown window."""
+    messages = [HumanMessage(content="Hello, how are you?")]
+    with patch.object(
+        token_counter.requests,
+        "post",
+        side_effect=requests.ConnectionError("unreachable"),
+    ) as mock_post:
+        for _ in range(5):
+            count_tokens_cross_provider(
+                messages,
+                model="gemini-2.5-flash-lite",
+                provider="gemini",
+                options={"gemini_api_key": FAKE_KEY},
+                chat_model_options={},
+            )
+
+    assert mock_post.call_count == 1
+
+
+def test_gemini_missing_key_falls_back_instead_of_raising() -> None:
+    """A missing key is reported by the chat call, not by crashing the trimmer."""
+    result = count_tokens_cross_provider(
+        [HumanMessage(content="Hello, how are you?")],
+        model="gemini-2.5-flash-lite",
+        provider="gemini",
+        options={},
+        chat_model_options={},
+    )
+    assert isinstance(result, int)
+    assert result > 0
+
+
+def test_redact_secrets_scrubs_keys_and_query_params() -> None:
+    """Both bare keys and any `?key=`-style parameter are scrubbed."""
+    text = (
+        f"404 for url: https://example.com/v1beta/models/m:countTokens?key={FAKE_KEY}"
+    )
+    redacted = _redact_secrets(text)
+    assert FAKE_KEY not in redacted
+    assert "<redacted>" in redacted


### PR DESCRIPTION
Refs #575.

## Why

[#575](https://github.com/goruck/home-generative-agent/issues/575) reported a 404 from Gemini's `countTokens` endpoint that took down the whole conversation. The report contained the user's Google API key in plain text, because we put it in the request URL and `requests` quotes the full URL in every error it raises.

The reported 404 itself is most likely per-account model access, not retirement — `gemini-2.5-flash-lite` is still listed as stable in [Google's model docs](https://ai.google.dev/gemini-api/docs/models). We cannot say for certain, and that is itself one of the defects fixed here: we discarded the response body that contains Google's explanation.

## What

**Credential leak (the reason the key in #575 became public).** The Gemini key moves from a `?key=` query parameter to an `x-goog-api-key` header, in both `_count_gemini_tokens` and `validate_gemini_key`. A header never appears in an exception message. Anything key-shaped is also scrubbed from the messages we raise, as a second line of defence.

**Token counting no longer aborts the turn.** `_count_gemini_tokens` raised out through `_trim_messages_for_model` into the streaming task, producing `Unexpected error in streaming task` and no reply. Counting now degrades to `count_tokens_approximately`. Because `trim_messages` calls the counter many times per turn, a failure also suppresses the remote counter for `REMOTE_COUNT_COOLDOWN_S` (300s) — otherwise a hanging endpoint would pay its full timeout on every call, which is a worse failure than the crash it replaces.

**Errors say what went wrong.** `raise_for_status()` dropped Google's response body — where "model not found for API version v1beta", quota messages, and disabled-key notices live. The body is now included, truncated to 500 chars and redacted.

**Invalid keys are reported as invalid.** Google answers a bad or blocked key with 400/403, never 401, and only 401 was mapped to `InvalidAuthError` — so entering a bad key told the user Home Assistant could not reach Google.

**Ollama:** the base URL was required on every count although only the exact-counting path (`OLLAMA_EXACT_TOKEN_COUNT`, off by default) uses it.

**Gemini 3 models** added to the chat, VLM and summarization lists: `gemini-3.7-flash`, `gemini-3.5-flash`, `gemini-3.5-flash-lite`, `gemini-3.1-flash-lite`. Defaults unchanged — `gemini-2.5-flash-lite` is still current.

## Testing

- 6 new tests in `test_token_counter.py`: header-not-query-param, error body included with key absent, fail-open to approximate, cooldown suppresses repeat calls, missing key falls back rather than raising, and the redaction helper.
- `make test` — 2854 passed.
- `make lint` — clean.
- `make typecheck` — 5 errors, identical to `main`; none introduced here.

## Follow-up

The user's leaked key has been redacted from the issue body and they have been asked to rotate it. GitHub's edit history still holds the original and needs a manual revision delete in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TsMC9cBnJ8pw263K8N9xPz
