### PR TITLE
fix: flatten top-level tool-schema unions for Anthropic too (#585)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.33.2] - 2026-08-28
+
+### Fixed
+
+- **Claude no longer fails a turn because of how Home Assistant describes its timer commands.** Two of Assist's built-in commands — start a timer and shorten a timer — say "give me hours, or minutes, or seconds" in a form Anthropic's API refuses to accept, and it refuses the whole request rather than the one command, so any turn that happened to offer Claude one of those two tools died with `input_schema does not support oneOf, allOf, or anyOf at the top level` and the user heard an error. The requirement is now restated in the tool's own description before the request is sent, exactly as is already done for OpenAI and Gemini, so Claude still knows a duration is needed. **If you excluded the `Hass*` tools to work around this, you can restore them.** Reported by [@a4bell64](https://github.com/a4bell64) ([#585](https://github.com/goruck/home-generative-agent/issues/585)).
+- **One tool a provider refuses to accept no longer takes the whole reply down with it.** Providers validate every tool before reading the conversation, so a single schema they dislike fails the turn. When that happens the offending tool is now dropped and the turn is retried without it — a lost tool instead of a lost answer.
+- **The log now names the tool a provider rejected.** Providers identify it only by its position in the request ("tools.3"), and because the set of tools sent changes from turn to turn that position points at something different each time. The name is now resolved and written to the log, so the tool to exclude is stated outright instead of having to be deduced.
+
 ## [3.33.1] - 2026-08-28
 
 ### Changed

--- a/custom_components/home_generative_agent/agent/graph.py
+++ b/custom_components/home_generative_agent/agent/graph.py
@@ -1425,9 +1425,13 @@ _TOP_LEVEL_UNION_KEYS = ("oneOf", "anyOf", "allOf")
 
 # Providers whose function-calling validator rejects oneOf/anyOf/allOf at the
 # top level of `parameters`. openai_compatible is included because those
-# endpoints proxy or emulate OpenAI's validation; the schema loss is recovered
-# via the description hint either way.
-_FLATTEN_UNION_PROVIDERS = ("openai", "openai_compatible")
+# endpoints proxy or emulate OpenAI's validation. Anthropic's Messages API
+# rejects the same shape on its own account ("tools.N.custom.input_schema:
+# input_schema does not support oneOf, allOf, or anyOf at the top level",
+# issue #585) — Home Assistant's built-in Anthropic integration strips those
+# keys outright before dispatch. The schema loss is recovered via the
+# description hint either way.
+_FLATTEN_UNION_PROVIDERS = ("anthropic", "openai", "openai_compatible")
 
 
 def _merge_conjunctive_required(
@@ -1460,12 +1464,15 @@ def _flatten_top_level_union(schema: dict[str, Any]) -> dict[str, Any]:
     OpenAI's function-calling validator rejects oneOf/anyOf/allOf/enum/
     const/not at the top level of ``parameters`` ("schema must have type
     'object' and not have 'oneOf'/'anyOf'/'allOf'/'enum'/'const'/'not' at
-    the top level"). On HA 2026.8.1 exactly two assist tools carry that
-    shape — HassStartTimer and HassDecreaseTimer, whose
+    the top level"), and Anthropic's Messages API rejects the union keys
+    the same way ("tools.N.custom.input_schema: input_schema does not
+    support oneOf, allOf, or anyOf at the top level"). On HA 2026.8.2
+    exactly two assist tools carry that shape — HassStartTimer and
+    HassDecreaseTimer, whose
     ``vol.Required(vol.Any("hours", "minutes", "seconds"))`` slot converts
     to a top-level ``anyOf`` of bare ``{"required": [...]}`` variants — and
     both are exposed only for timer-capable satellite devices, so the 400
-    surfaces only on voice requests from such a device.
+    surfaces only on turns whose tool set includes one of them.
 
     Every variant's ``properties`` are unioned into one object schema
     (pre-existing top-level properties win).  ``anyOf``/``oneOf`` variant
@@ -1543,10 +1550,10 @@ def _format_and_dedupe_tools(
         if not isinstance(parameters, dict):
             parameters = {"type": "object", "properties": {}}
         else:
-            # OpenAI rejects oneOf/anyOf/allOf at the top level of
-            # `parameters` (HassStartTimer / HassDecreaseTimer). Subtractive,
-            # so gated — Anthropic/Ollama honour the union and keep it, and
-            # the Gemini pass below needs the anyOf intact to restate it.
+            # OpenAI and Anthropic both reject oneOf/anyOf/allOf at the top
+            # level of `parameters` (HassStartTimer / HassDecreaseTimer).
+            # Subtractive, so gated — Ollama honours the union and keeps it,
+            # and the Gemini pass below needs the anyOf intact to restate it.
             if provider in _FLATTEN_UNION_PROVIDERS:
                 flattened = _flatten_top_level_union(parameters)
                 if flattened is not parameters:
@@ -1922,7 +1929,7 @@ async def _retrieve_tools(  # noqa: PLR0915
             )
 
     # 4. Format and deduplicate. The provider drives the subtractive schema
-    # normalisation passes: the OpenAI top-level-union flatten
+    # normalisation passes: the OpenAI/Anthropic top-level-union flatten
     # (_flatten_top_level_union) and the Gemini anyOf-required sanitizer
     # (_sanitize_any_of_required).
     provider_raw = opts.get(CONF_CHAT_MODEL_PROVIDER)
@@ -2090,6 +2097,130 @@ async def _invoke_chat_model_with_sampling_rebind(  # noqa: PLR0913
         return await _invoke_model(stripped, messages, config, drop_unsupported=False)
 
 
+# A provider that refuses a tool's JSON Schema names the offender by its
+# position in the request's tool array, never by name — Anthropic reports
+# "tools.3.custom.input_schema: input_schema does not support oneOf, allOf,
+# or anyOf at the top level" (issue #585), Gemini reports
+# "...function_declarations[1].parameters...". Both indices address the tool
+# list in the order it was bound, so they map back onto selected_tools.
+_TOOL_SCHEMA_REJECTION_RE = re.compile(
+    r"\b(?:tools\.(\d+)\.|function_declarations\[(\d+)\])"
+)
+
+# Tools dropped per turn before giving up. Only two HA assist schemas have
+# ever carried a rejected shape, so a small budget covers a novel offender
+# without letting a mis-parsed index strip the whole tool set.
+_MAX_TOOL_SCHEMA_DROPS = 3
+
+# Longest run of digits accepted as a tool position, so a mis-parsed message
+# cannot turn into an unbounded int().
+_MAX_TOOL_INDEX_DIGITS = 4
+
+
+def _rejected_tool_index(err: BaseException, max_depth: int = 10) -> int | None:
+    """Return the tool position a provider rejected for its schema, if any."""
+    current: BaseException | None = err
+    for _ in range(max_depth):
+        if current is None:
+            return None
+        message = str(current)
+        if "schema" in message and (match := _TOOL_SCHEMA_REJECTION_RE.search(message)):
+            index = match.group(1) or match.group(2)
+            if len(index) <= _MAX_TOOL_INDEX_DIGITS:
+                return int(index)
+        current = current.__cause__
+    return None
+
+
+def _rejected_tool_name(selected_tools: list[Any], index: int | None) -> str | None:
+    """Return the name of the tool at ``index``, or None if unresolvable."""
+    if index is None or not 0 <= index < len(selected_tools):
+        return None
+    entry = selected_tools[index]
+    if not isinstance(entry, dict):
+        return None
+    function = entry.get("function")
+    if not isinstance(function, dict):
+        return None
+    name = function.get("name")
+    return name if isinstance(name, str) else None
+
+
+async def _invoke_chat_model_with_schema_recovery(  # noqa: PLR0913
+    hass: Any,
+    base_model: Any,
+    model: Any,
+    messages: list[AnyMessage],
+    config: RunnableConfig,
+    selected_tools: list[Any],
+    *,
+    disable_reasoning: bool,
+) -> Any:
+    """
+    Invoke the chat model, dropping tools whose schema the provider rejects.
+
+    A provider validates every tool schema before it reads the conversation,
+    so one unsupported tool fails the whole turn — the user hears an error
+    even though nothing about their request was wrong (issue #585: Anthropic
+    rejects the top-level ``anyOf`` HA's timer intents emit). The schema
+    normalisation in ``_format_and_dedupe_tools()`` is the real fix for the
+    shapes we know about; this is the net under it for the ones we do not.
+
+    The rejection names the offender only by position, so resolve that to a
+    tool name, log it, drop it and retry: losing one tool beats losing the
+    turn. When the position cannot be resolved the original error is raised
+    untouched, and when retries run out the tool name is added to it so the
+    log names what to exclude.
+    """
+    tools = list(selected_tools)
+    dropped = 0
+    while True:
+        try:
+            return await _invoke_chat_model_with_sampling_rebind(
+                hass,
+                base_model,
+                model,
+                messages,
+                config,
+                tools,
+                disable_reasoning=disable_reasoning,
+            )
+        except HomeAssistantError as err:
+            index = _rejected_tool_index(err)
+            name = _rejected_tool_name(tools, index)
+            if index is None or name is None:
+                raise
+            if dropped == _MAX_TOOL_SCHEMA_DROPS:
+                msg = (
+                    f"Model invocation failed: the provider rejected the schema "
+                    f"of tool '{name}' and dropping it did not clear the error. "
+                    f"{err}"
+                )
+                raise HomeAssistantError(msg) from err
+            LOGGER.warning(
+                "Provider rejected the schema of tool '%s' (position %d); "
+                "dropping it and retrying the turn without it. Exclude the tool "
+                "to avoid the retry. %s",
+                name,
+                index,
+                err,
+            )
+            del tools[index]
+            dropped += 1
+            model = (
+                await hass.async_add_executor_job(
+                    partial(
+                        _bind_model_tools,
+                        base_model,
+                        tools,
+                        disable_reasoning=disable_reasoning,
+                    )
+                )
+                if tools
+                else base_model
+            )
+
+
 def _bind_model_tools(
     model: Any, selected_tools: list[Any], *, disable_reasoning: bool
 ) -> Any:
@@ -2197,7 +2328,7 @@ async def _call_model(
     if llm_api and hasattr(llm_api, "routing_map"):
         llm_api.routing_map = routing_map
 
-    raw_response = await _invoke_chat_model_with_sampling_rebind(
+    raw_response = await _invoke_chat_model_with_schema_recovery(
         hass,
         base_model,
         model,

--- a/custom_components/home_generative_agent/manifest.json
+++ b/custom_components/home_generative_agent/manifest.json
@@ -35,5 +35,5 @@
     "langchain-anthropic==1.4.3"
   ],
   "single_config_entry": true,
-  "version": "3.33.1"
+  "version": "3.33.2"
 }

--- a/tests/custom_components/home_generative_agent/test_graph_helpers.py
+++ b/tests/custom_components/home_generative_agent/test_graph_helpers.py
@@ -11,6 +11,8 @@ from custom_components.home_generative_agent.agent.graph import (
     _ensure_array_items,
     _flatten_top_level_union,
     _format_and_dedupe_tools,
+    _rejected_tool_index,
+    _rejected_tool_name,
     _sanitize_any_of_required,
 )
 from custom_components.home_generative_agent.const import CONF_ANTHROPIC_CHAT_MODEL
@@ -492,11 +494,11 @@ def test_format_and_dedupe_tools_union_capable_keeps_any_of_required() -> None:
     Union-capable providers keep HA's at-least-one-target constraint intact.
 
     Both sanitizers are subtractive: running either unconditionally would
-    hand Anthropic/Ollama a vacuous schema, letting the model emit a
-    targetless call that HA's own voluptuous validation then rejects.
-    Unknown/unset providers (None) also keep the schema untouched.
+    hand Ollama a vacuous schema, letting the model emit a targetless call
+    that HA's own voluptuous validation then rejects. Unknown/unset
+    providers (None) also keep the schema untouched.
     """
-    for provider in ("anthropic", "ollama", None):
+    for provider in ("ollama", None):
         selected, _ = _format_and_dedupe_tools(_target_tool(), provider)
         params = selected[0]["function"]["parameters"]
         assert params["anyOf"] == [
@@ -529,6 +531,24 @@ def test_format_and_dedupe_tools_openai_flattens_any_of_with_hint() -> None:
         assert params["description"] == (
             "At least one of: name, area, floor is required."
         ), "constraint must be preserved as guidance"
+
+
+def test_format_and_dedupe_tools_anthropic_flattens_any_of_with_hint() -> None:
+    """
+    Anthropic gets the top-level anyOf flattened with a hint (issue #585).
+
+    The Messages API refuses the union keys outright — "tools.N.custom
+    .input_schema: input_schema does not support oneOf, allOf, or anyOf at
+    the top level" — and rejects the request before the model sees the
+    turn, so the constraint has to survive as description guidance instead.
+    """
+    selected, _ = _format_and_dedupe_tools(_target_tool(), "anthropic")
+    params = selected[0]["function"]["parameters"]
+    assert "anyOf" not in params, "Anthropic must not receive a top-level anyOf"
+    assert set(params["properties"]) == {"name", "area", "floor"}
+    assert params["description"] == (
+        "At least one of: name, area, floor is required."
+    ), "constraint must be preserved as guidance"
 
 
 def test_determine_model_name_anthropic_returns_configured_model() -> None:
@@ -869,9 +889,31 @@ def test_format_and_dedupe_tools_openai_flattens_hass_start_timer() -> None:
         ), f"provider {provider!r} must keep the constraint as guidance"
 
 
+def test_format_and_dedupe_tools_anthropic_flattens_hass_start_timer() -> None:
+    """
+    End-to-end regression: HassStartTimer no longer 400s on Anthropic.
+
+    Reproduces issue #585 — anthropic.BadRequestError "tools.3.custom
+    .input_schema: input_schema does not support oneOf, allOf, or anyOf at
+    the top level" — with the schema HA 2026.8.2 actually emits.
+    langchain_anthropic copies ``parameters`` into ``input_schema``
+    verbatim, so an unflattened union reaches the API untouched.
+    """
+    selected, _ = _format_and_dedupe_tools(_timer_tool(), "anthropic")
+    params = selected[0]["function"]["parameters"]
+    assert params["type"] == "object"
+    assert not {"anyOf", "oneOf", "allOf"} & set(params)
+    assert params["properties"] == _HASS_START_TIMER_SCHEMA["properties"], (
+        "Anthropic must keep every property schema intact"
+    )
+    assert params["description"] == (
+        "At least one of: hours, minutes, seconds is required."
+    ), "Anthropic must keep the constraint as guidance"
+
+
 def test_format_and_dedupe_tools_union_capable_keeps_hass_start_timer() -> None:
-    """Anthropic/Ollama/unset keep the timer union schema fully intact."""
-    for provider in ("anthropic", "ollama", None):
+    """Ollama/unset providers keep the timer union schema fully intact."""
+    for provider in ("ollama", None):
         selected, _ = _format_and_dedupe_tools(_timer_tool(), provider)
         params = selected[0]["function"]["parameters"]
         assert params == _HASS_START_TIMER_SCHEMA, (
@@ -959,3 +1001,65 @@ def test_format_and_dedupe_tools_openai_plain_schema_untouched() -> None:
         assert selected[0]["function"]["parameters"] == schema, (
             f"provider {provider!r} must not modify a plain object schema"
         )
+
+
+# ----- Tool-schema rejection parsing (issue #585) -----
+
+
+def _named_tool(name: str) -> dict:
+    """Return a formatted tool entry carrying only the name."""
+    return {"type": "function", "function": {"name": name, "parameters": {}}}
+
+
+def test_rejected_tool_index_reads_anthropic_position() -> None:
+    """The Anthropic 400 names the offending tool only by position."""
+    err = Exception(
+        "Error code: 400 - {'type': 'error', 'error': {'type': "
+        "'invalid_request_error', 'message': 'tools.3.custom.input_schema: "
+        "input_schema does not support oneOf, allOf, or anyOf at the top "
+        "level'}}"
+    )
+    assert _rejected_tool_index(err) == 3
+
+
+def test_rejected_tool_index_reads_gemini_position() -> None:
+    """Gemini reports the same class of failure with a bracketed index."""
+    err = Exception(
+        "GenerateContentRequest.tools[0].function_declarations[1].parameters"
+        ".any_of[0].required: only allowed for OBJECT type; invalid schema"
+    )
+    assert _rejected_tool_index(err) == 1
+
+
+def test_rejected_tool_index_walks_the_cause_chain() -> None:
+    """The provider error arrives wrapped in a HomeAssistantError."""
+    cause = Exception("tools.2.custom.input_schema: bad schema")
+    wrapper = Exception("Model invocation failed")
+    wrapper.__cause__ = cause
+    assert _rejected_tool_index(wrapper) == 2
+
+
+def test_rejected_tool_index_ignores_unrelated_errors() -> None:
+    """Errors that are not about a tool schema must not trigger a drop."""
+    assert _rejected_tool_index(Exception("connection reset by peer")) is None
+    assert _rejected_tool_index(Exception("tools.2 were slow to run")) is None, (
+        "a positional match without 'schema' is not a schema rejection"
+    )
+
+
+def test_rejected_tool_index_rejects_absurd_position() -> None:
+    """A mis-parsed message cannot turn into an unbounded int()."""
+    err = Exception(f"tools.{'9' * 40}.custom.input_schema: bad schema")
+    assert _rejected_tool_index(err) is None
+
+
+def test_rejected_tool_name_resolves_and_guards() -> None:
+    """Positions map back onto the bound tool list; bad ones return None."""
+    tools = [_named_tool("GetLiveContext"), _named_tool("HassStartTimer")]
+    assert _rejected_tool_name(tools, 1) == "HassStartTimer"
+    assert _rejected_tool_name(tools, None) is None
+    assert _rejected_tool_name(tools, 2) is None, "out-of-range index"
+    assert _rejected_tool_name(tools, -1) is None, "negative index must not wrap"
+    assert _rejected_tool_name(["not_a_dict"], 0) is None
+    assert _rejected_tool_name([{"function": "not_a_dict"}], 0) is None
+    assert _rejected_tool_name([{"function": {"name": 7}}], 0) is None

--- a/tests/custom_components/home_generative_agent/test_regressions.py
+++ b/tests/custom_components/home_generative_agent/test_regressions.py
@@ -736,3 +736,188 @@ async def test_sampling_rebind_recovers_tool_bound_chat_model(
     assert result.content == "ok"
     # Exactly two API calls: baked 0.2 rejected once, rebind with None succeeds.
     assert seen_temperatures == [0.2, None]
+
+
+@pytest.mark.asyncio
+async def test_schema_recovery_drops_tool_rejected_by_provider(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    A tool the provider refuses to validate is dropped, not the whole turn.
+
+    Regression for issue #585: Anthropic validates every tool schema before
+    it reads the conversation, so one bad schema 400s the request and the
+    user hears an error. The provider names the offender only by position
+    ("tools.1.custom.input_schema: ..."), so the graph must map that back to
+    the bound tool list, drop it and retry.
+    """
+    monkeypatch.setattr(agent_graph, "_LLM_INVOKE_TIMEOUT_S", 5.0)
+
+    seen_tool_sets: list[list[str]] = []
+
+    class _SchemaPickyChatModel(BaseChatModel):
+        """400s while a tool named HassStartTimer is bound."""
+
+        # pydantic model field: the default is copied per instance.
+        bound_tools: list[Any] = []  # noqa: RUF012
+
+        @property
+        def _llm_type(self) -> str:
+            return "schema_picky"
+
+        def bind_tools(self, tools: Any, **_kwargs: Any) -> Any:
+            return self.model_copy(update={"bound_tools": list(tools)})
+
+        def _generate(
+            self,
+            messages: Any,
+            stop: Any = None,
+            run_manager: Any = None,
+            **kwargs: Any,
+        ) -> ChatResult:
+            names = [t["function"]["name"] for t in self.bound_tools]
+            seen_tool_sets.append(names)
+            if "HassStartTimer" in names:
+                index = names.index("HassStartTimer")
+                msg = (
+                    f"tools.{index}.custom.input_schema: input_schema does not "
+                    "support oneOf, allOf, or anyOf at the top level"
+                )
+                raise ValueError(msg)
+            return ChatResult(
+                generations=[ChatGeneration(message=AIMessage(content="ok"))]
+            )
+
+    selected_tools = [
+        {"type": "function", "function": {"name": "GetLiveContext"}},
+        {"type": "function", "function": {"name": "HassStartTimer"}},
+    ]
+    base_model = _SchemaPickyChatModel()
+    hass = MagicMock()
+    hass.async_add_executor_job = AsyncMock(side_effect=lambda fn: fn())
+
+    bound = agent_graph._bind_model_tools(
+        base_model, selected_tools, disable_reasoning=False
+    )
+
+    with caplog.at_level(logging.WARNING):
+        result = await agent_graph._invoke_chat_model_with_schema_recovery(
+            hass,
+            base_model,
+            bound,
+            [HumanMessage(content="hi")],
+            {},
+            selected_tools,
+            disable_reasoning=False,
+        )
+
+    assert result.content == "ok"
+    assert seen_tool_sets == [
+        ["GetLiveContext", "HassStartTimer"],
+        ["GetLiveContext"],
+    ], "exactly one retry, with only the rejected tool removed"
+    assert "HassStartTimer" in caplog.text, "the log must name the dropped tool"
+    assert selected_tools[1]["function"]["name"] == "HassStartTimer", (
+        "the caller's tool list must not be mutated"
+    )
+
+
+@pytest.mark.asyncio
+async def test_schema_recovery_names_the_tool_when_retries_run_out(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    An unrecoverable schema rejection still names the tool it blames.
+
+    The reporter of issue #585 lost hours to a 400 that identified the tool
+    only as `tools.3`; with a retrieval limit of five that index points at a
+    different tool every turn. Whatever else happens, the error must name it.
+    """
+    monkeypatch.setattr(agent_graph, "_LLM_INVOKE_TIMEOUT_S", 5.0)
+
+    class _AlwaysRejects(BaseChatModel):
+        """Blames position 0 no matter which tools are bound."""
+
+        # pydantic model field: the default is copied per instance.
+        bound_tools: list[Any] = []  # noqa: RUF012
+
+        @property
+        def _llm_type(self) -> str:
+            return "always_rejects"
+
+        def bind_tools(self, tools: Any, **_kwargs: Any) -> Any:
+            return self.model_copy(update={"bound_tools": list(tools)})
+
+        def _generate(
+            self,
+            messages: Any,
+            stop: Any = None,
+            run_manager: Any = None,
+            **kwargs: Any,
+        ) -> ChatResult:
+            msg = "tools.0.custom.input_schema: unsupported schema"
+            raise ValueError(msg)
+
+    selected_tools = [
+        {"type": "function", "function": {"name": f"Tool{i}"}} for i in range(5)
+    ]
+    base_model = _AlwaysRejects()
+    hass = MagicMock()
+    hass.async_add_executor_job = AsyncMock(side_effect=lambda fn: fn())
+    bound = agent_graph._bind_model_tools(
+        base_model, selected_tools, disable_reasoning=False
+    )
+
+    with pytest.raises(HomeAssistantError, match="Tool3"):
+        await agent_graph._invoke_chat_model_with_schema_recovery(
+            hass,
+            base_model,
+            bound,
+            [HumanMessage(content="hi")],
+            {},
+            selected_tools,
+            disable_reasoning=False,
+        )
+
+
+@pytest.mark.asyncio
+async def test_schema_recovery_passes_through_unrelated_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An error that is not a tool-schema rejection is raised untouched."""
+    monkeypatch.setattr(agent_graph, "_LLM_INVOKE_TIMEOUT_S", 5.0)
+
+    class _Broken(BaseChatModel):
+        @property
+        def _llm_type(self) -> str:
+            return "broken"
+
+        def bind_tools(self, tools: Any, **_kwargs: Any) -> Any:
+            return self
+
+        def _generate(
+            self,
+            messages: Any,
+            stop: Any = None,
+            run_manager: Any = None,
+            **kwargs: Any,
+        ) -> ChatResult:
+            msg = "upstream connect error"
+            raise ValueError(msg)
+
+    hass = MagicMock()
+    hass.async_add_executor_job = AsyncMock(side_effect=lambda fn: fn())
+    selected_tools = [{"type": "function", "function": {"name": "GetLiveContext"}}]
+
+    with pytest.raises(HomeAssistantError, match="upstream connect error"):
+        await agent_graph._invoke_chat_model_with_schema_recovery(
+            hass,
+            _Broken(),
+            _Broken(),
+            [HumanMessage(content="hi")],
+            {},
+            selected_tools,
+            disable_reasoning=False,
+        )
+    assert hass.async_add_executor_job.await_count == 0, "no rebind on a non-schema 400"


### PR DESCRIPTION
Fixes #585. Reported by @a4bell64, whose report identified the cause, the two-line fix, and both fallbacks — this PR implements all three.

## The bug

Anthropic's Messages API rejects `oneOf`/`allOf`/`anyOf` at the top level of a tool's `input_schema`, exactly as OpenAI's validator does:

```
tools.3.custom.input_schema: input_schema does not support oneOf, allOf, or anyOf at the top level
```

Validation runs before the model reads the turn, so one such tool 400s the entire request and the user hears an error.

`_flatten_top_level_union()` has handled this since #546 — but only for `openai` and `openai_compatible`. The gate excluded `anthropic` on the untested assumption that it honours the union. It does not; Home Assistant's own built-in Anthropic integration strips the keys outright before dispatch (`components/anthropic/entity.py::_format_tool`).

## Which tools actually carry the shape

Checked against the installed HA 2026.8.2, converting each intent's real slot schema through `voluptuous_openapi`: **two**, not 25.

| Tool | Top-level union |
|---|---|
| `HassStartTimer` | `anyOf` |
| `HassDecreaseTimer` | `anyOf` |
| `HassCancelTimer`, `HassIncreaseTimer`, `HassPauseTimer`, `HassUnpauseTimer`, `HassTimerStatus`, `HassCancelAllTimers` | none |
| `HassTurnOn`-style target tools | none |

Only `vol.Required(vol.Any("hours", "minutes", "seconds"))` produces it. The bare `vol.Any("name", "area", "floor")` marker key that the target tools use converts to plain optional properties. The report's exclusion experiment is consistent with this: excluding the 18 action tools left the timer group in place, and the timer group is where both offenders live.

## The fix

`_FLATTEN_UNION_PROVIDERS` gains `anthropic`. The dropped constraint survives as the description hint the OpenAI and Gemini paths already use, so the model is still told a duration is required.

Verified end to end against the real 2026.8.2 schemas through `langchain_anthropic.convert_to_anthropic_tool` — which copies `parameters` into `input_schema` verbatim, hence the passthrough:

```
HassStartTimer     union_keys: []  description: "At least one of: hours, minutes, seconds is required."
HassDecreaseTimer  union_keys: []  description: "At least one of: hours, minutes, seconds is required."
```

## The two fallbacks, also from the report

- **A rejected tool no longer takes the turn down.** `_invoke_chat_model_with_schema_recovery()` drops the offending tool, rebinds and retries (bounded at 3 drops). The schema normalisation is the fix for the shapes we know about; this is the net under it for the ones we do not.
- **The tool is named.** Providers identify it only by position, and with `tool_retrieval_limit: 5` that position addresses a different tool each turn — which is what made this a multi-hour diagnosis. The index is now resolved against the bound tool list before it is logged or re-raised. Handles Anthropic's `tools.N.` and Gemini's `function_declarations[N]` forms; anything unrecognised is re-raised untouched.

## For the reporter

The `assist::Hass*` `tool_exclusions` workaround can be removed once this is released.

## Testing

- 2865 tests pass; `make lint` clean; pyright unchanged (5 pre-existing errors on `main`, same 5 here).
- New: Anthropic flatten coverage (target schema + real `HassStartTimer` end to end), rejection-index parsing (Anthropic/Gemini forms, cause-chain walk, unrelated-error and absurd-index guards), and three recovery tests — drop-and-retry against a real `bind_tools` chain, tool named when retries run out, unrelated errors passed through without a rebind.
- The two `union_capable_keeps_*` guard tests now cover `ollama`/unset only; Anthropic moved to the flatten side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhU3C8AkecjNhiGFmv7Fvh