### PR TITLE
fix: keep a tool-using turn out of the agent's ingested history (#588)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.33.3] - 2026-08-29
+
+### Fixed
+
+- **The agent no longer learns to stop controlling your home.** When a command was handled by another assistant sharing the conversation — Home Assistant's own built-in one, for instance — the agent read that turn back as if the assistant had simply *said* "Turned on the light" without doing anything. That is a perfect example of the wrong behaviour, and the model copied it: the next command got a confident spoken reply and no action, which was then read back as another example, and so on. Nothing in the log looked wrong, because from the agent's side nothing failed. The whole of a turn that used tools is now kept out of the history rather than just the part that names the tool, so a reply that no longer shows its actions can't be mistaken for one that never needed any ([#588](https://github.com/goruck/home-generative-agent/issues/588)).
+
+  This is more likely to bite smaller local models, which follow the shape of a conversation more readily than the large cloud ones. **Conversations that already went wrong stay wrong** — the old messages are saved with the conversation. Start a new one and it will be clean.
+
 ## [3.33.2] - 2026-08-28
 
 ### Fixed

--- a/custom_components/home_generative_agent/conversation.py
+++ b/custom_components/home_generative_agent/conversation.py
@@ -863,15 +863,34 @@ class HGAConversationEntity(conversation.ConversationEntity, AbstractConversatio
     ) -> list[HumanMessage | AIMessage]:
         """Extract and slice the relevant chat log history."""
         # Include only HA User/Assistant messages not already seen by this entity.
-        # Exclude AssistantContent with tool_calls: those are intermediate LangGraph
-        # turns already persisted in the PostgreSQL checkpointer. Including them would
-        # duplicate messages that LangGraph already manages internally.
-        message_history = [
-            _convert_content(m)
-            for m in chat_log.content
-            if isinstance(m, conversation.UserContent)
-            or (isinstance(m, conversation.AssistantContent) and m.tool_calls is None)
-        ]
+        #
+        # Exclude every part of a turn that used tools, not just the
+        # AssistantContent carrying the tool_calls. A tool-using turn writes
+        # three entries — tool_calls, ToolResultContent, then the spoken text —
+        # and the spoken text alone ("Turned on the light") is indistinguishable
+        # from a turn that answered without acting. Ingesting it teaches the
+        # model that such a request is answered with prose and no tool call:
+        # the conversation then repeats that shape and every device command
+        # silently becomes a lie (issue #588). This matters most for turns
+        # handled by ANOTHER agent sharing the conversation — HA's built-in
+        # agent, say — whose tool calls the checkpointer never saw. HGA's own
+        # tool-using turns are already persisted in full by LangGraph, so
+        # dropping their chat_log echo also removes a duplicate.
+        message_history: list[HumanMessage | AIMessage] = []
+        turn_used_tools = False
+        for m in chat_log.content:
+            if isinstance(m, conversation.UserContent):
+                turn_used_tools = False
+                message_history.append(_convert_content(m))
+            elif isinstance(m, conversation.ToolResultContent):
+                turn_used_tools = True
+            elif isinstance(m, conversation.AssistantContent):
+                # `is not None` keeps the original inclusion predicate exactly;
+                # only the turn-level suppression below is new.
+                if m.tool_calls is not None:
+                    turn_used_tools = True
+                elif not turn_used_tools:
+                    message_history.append(_convert_content(m))
         # The last chat log entry will be the current user request—add it later.
         message_history = message_history[:-1]
 

--- a/custom_components/home_generative_agent/manifest.json
+++ b/custom_components/home_generative_agent/manifest.json
@@ -35,5 +35,5 @@
     "langchain-anthropic==1.4.3"
   ],
   "single_config_entry": true,
-  "version": "3.33.2"
+  "version": "3.33.3"
 }

--- a/tests/custom_components/home_generative_agent/test_conversation_units.py
+++ b/tests/custom_components/home_generative_agent/test_conversation_units.py
@@ -104,6 +104,12 @@ def _ensure_content_classes() -> None:
             pass
 
         conv.UserContent = _StubUserContent
+    if not hasattr(conv, "ToolResultContent"):
+
+        class _StubToolResultContent:
+            pass
+
+        conv.ToolResultContent = _StubToolResultContent
 
 
 def _ensure_conversation_entity_feature() -> None:
@@ -1106,3 +1112,167 @@ def test_control_feature_absent_when_stored_api_list_is_empty() -> None:
         }
     )
     assert not _supported_features(entity) & control
+
+
+# ---------------------------------------------------------------------------
+# _async_get_message_history: a tool-using turn must not be ingested as prose
+# ---------------------------------------------------------------------------
+
+
+def _mk_content(cls: Any, **kwargs: Any) -> Any:
+    """
+    Build a chat_log content object for the real class or the module stub.
+
+    The real HA classes are frozen dataclasses (constructor works, setattr does
+    not); the suite's lean stubs are bare classes (constructor takes nothing).
+    """
+    try:
+        return cls(**kwargs)
+    except TypeError:
+        obj = cls()
+        for key, value in kwargs.items():
+            object.__setattr__(obj, key, value)
+        return obj
+
+
+def _history(content: list) -> list:
+    """Run _async_get_message_history against a fresh entity counter."""
+    fake_self = cast("Any", types.SimpleNamespace(message_history_len=0))
+    chat_log = cast("Any", types.SimpleNamespace(content=content))
+    return HGAConversationEntity._async_get_message_history(fake_self, chat_log)
+
+
+def test_message_history_drops_spoken_text_of_a_tool_using_turn() -> None:
+    """
+    A turn that used tools is not ingested as a bare assistant reply.
+
+    Regression for issue #588. When another agent sharing the conversation
+    (Home Assistant's built-in agent) handles a device command, chat_log gets
+    three entries: the tool_calls, the ToolResultContent, then the spoken
+    "Turned on the light". Ingesting only the third teaches the model that
+    "turn on the light" is answered with prose and no tool call — after which
+    the model repeats that shape and every device command silently becomes a
+    lie. The whole turn must be dropped, not just its tool_calls entry.
+    """
+    content = [
+        _mk_content(ha_conversation.UserContent, content="Turn on the garage light."),
+        _mk_content(
+            ha_conversation.AssistantContent,
+            agent_id="conversation.home_assistant",
+            content=None,
+            tool_calls=[object()],
+        ),
+        _mk_content(
+            ha_conversation.ToolResultContent,
+            agent_id="conversation.home_assistant",
+            tool_call_id="01M16N286Y2A5T0BVZ163SMKT7",
+            tool_name="HassTurnOn",
+            tool_result={"speech": {"plain": {"speech": "Turned on the light"}}},
+        ),
+        _mk_content(
+            ha_conversation.AssistantContent,
+            agent_id="conversation.home_assistant",
+            content="Turned on the light",
+            tool_calls=None,
+        ),
+        _mk_content(ha_conversation.UserContent, content="Turn off the garage light."),
+    ]
+
+    history = _history(content)
+
+    assert [type(m).__name__ for m in history] == ["HumanMessage"], (
+        "the spoken tail of a tool-using turn must not reach the model"
+    )
+    assert history[0].content == "Turn on the garage light."
+    assert not any("Turned on the light" in str(m.content) for m in history), (
+        "an assistant reply with the tool call erased is the poison itself"
+    )
+
+
+def test_message_history_keeps_a_genuine_toolless_reply() -> None:
+    """A turn that really answered without tools is still ingested."""
+    content = [
+        _mk_content(ha_conversation.UserContent, content="what can you do?"),
+        _mk_content(
+            ha_conversation.AssistantContent,
+            agent_id="conversation.home_generative_agent",
+            content="I can control your home.",
+            tool_calls=None,
+        ),
+        _mk_content(ha_conversation.UserContent, content="Turn off the garage light."),
+    ]
+
+    history = _history(content)
+
+    assert [type(m).__name__ for m in history] == ["HumanMessage", "AIMessage"], (
+        "over-filtering would strip ordinary conversational context"
+    )
+    assert history[1].content == "I can control your home."
+
+
+def test_message_history_tool_flag_resets_on_the_next_user_turn() -> None:
+    """One tool-using turn must not suppress every later reply."""
+    content = [
+        _mk_content(ha_conversation.UserContent, content="Turn on the garage light."),
+        _mk_content(
+            ha_conversation.AssistantContent,
+            agent_id="conversation.home_assistant",
+            content=None,
+            tool_calls=[object()],
+        ),
+        _mk_content(
+            ha_conversation.ToolResultContent,
+            agent_id="conversation.home_assistant",
+            tool_call_id="call_1",
+            tool_name="HassTurnOn",
+            tool_result={},
+        ),
+        _mk_content(
+            ha_conversation.AssistantContent,
+            agent_id="conversation.home_assistant",
+            content="Turned on the light",
+            tool_calls=None,
+        ),
+        _mk_content(ha_conversation.UserContent, content="thanks"),
+        _mk_content(
+            ha_conversation.AssistantContent,
+            agent_id="conversation.home_generative_agent",
+            content="You're welcome.",
+            tool_calls=None,
+        ),
+        _mk_content(ha_conversation.UserContent, content="Turn off the garage light."),
+    ]
+
+    history = _history(content)
+
+    assert [type(m).__name__ for m in history] == [
+        "HumanMessage",
+        "HumanMessage",
+        "AIMessage",
+    ], "the tool flag must clear at the next user message"
+    assert history[2].content == "You're welcome."
+
+
+def test_message_history_non_none_tool_calls_still_excluded() -> None:
+    """
+    An empty-but-present tool_calls list is excluded, as it always was.
+
+    The inclusion predicate stays `tool_calls is None`, so this fix changes
+    only which *other* entries a tool-using turn suppresses. Guards against
+    quietly widening the filter while fixing #588.
+    """
+    content = [
+        _mk_content(ha_conversation.UserContent, content="hello"),
+        _mk_content(
+            ha_conversation.AssistantContent,
+            agent_id="conversation.home_generative_agent",
+            content="Hi there.",
+            tool_calls=[],
+        ),
+        _mk_content(ha_conversation.UserContent, content="Turn off the garage light."),
+    ]
+
+    history = _history(content)
+
+    assert [type(m).__name__ for m in history] == ["HumanMessage"]
+    assert history[0].content == "hello"


### PR DESCRIPTION
Fixes #588. Found while running Ollama (`qwen3.8:latest`) as the conversation model on the live box: every device command silently became a no-op.

## Root cause

`_async_get_message_history` ingests HA's `chat_log` with `UserContent, or AssistantContent whose tool_calls is None`. A tool-using turn writes three entries; two are dropped and the third is kept:

```
AssistantContent(content=None, tool_calls=[HassTurnOn{'name':'Garage Light'}])  -> dropped (has tool_calls)
ToolResultContent(tool_name='HassTurnOn', tool_result={...})                    -> dropped (neither User nor Assistant)
AssistantContent(content='Turned on the light', tool_calls=None)                -> KEPT
```

The spoken tail of a tool-using turn therefore lands in the agent's history as `AIMessage('Turned on the light')` with the tool call and result erased — indistinguishable from a turn that answered without acting. The model copies the shape, and each failure appends another identical pair, so it never recovers.

The first bad entry comes from another agent sharing the conversation. Here it was a Voice PE on a pipeline pointed at `conversation.home_assistant`, which matched the sentence locally, called `HassTurnOn`, and said "Turned on the light" — a tool call HGA's checkpointer never saw.

The exclusion was written to skip HGA's own intermediate turns (LangGraph already persists them). It excluded the entry carrying `tool_calls` but not the spoken text of the same turn.

## Evidence

Same model, same system prompt, same tools, against the live Ollama server. History is the only variable:

| History | stream=true | stream=false |
|---|---|---|
| A: 5 prior `user -> "Turned on the light"` pairs | NO TOOL CALL x3 | NO TOOL CALL x3 |
| B: empty | `HassTurnOn` x3 | `HassTurnOn` x3 |
| C: post-fix shape | `HassTurnOn` x3 | `HassTurnOn` x3 |

12/12 deterministic before the fix, 6/6 correct on the exact shape the fix produces. Streaming is not a factor.

Ruled out: model tool capability (`/api/show` reports `tools`), Ollama version (0.32.13), context truncation (262144 ctx vs a 3532-token prompt), and pruning of tool messages from LangGraph state (`graph.py:2359` stores `tool_calls` faithfully; only summarization removes messages and no summary existed).

## The fix

Track tool activity per turn and suppress the whole turn. The inclusion predicate stays `tool_calls is None`, so only which *other* entries a tool-using turn suppresses changes — `test_message_history_non_none_tool_calls_still_excluded` guards against widening the filter while fixing this.

The user's message survives, so the context of what was asked is kept; only the assistant reply that lies by omission is dropped. Consecutive `HumanMessage`s are safe on Anthropic — `langchain_anthropic._merge_messages` collapses runs of human messages.

## Testing

- 2869 pass (4 new); `make lint` clean; pyright unchanged (5 pre-existing errors on `main`, same 5 here).
- 2 of the 4 new tests fail on `main` and pass here — verified by stashing the fix and re-running.
- Coverage: the #588 shape end to end, the over-filtering guard (a genuine tool-less reply is still ingested), the flag resetting at the next user message, and the unchanged `tool_calls is None` predicate.

## Note for anyone hitting this

**Existing conversations stay poisoned.** The bad messages are in the LangGraph Postgres checkpoint under `thread_id = conversation_id` (`conversation.py:1377`). Start a new conversation for a clean thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhU3C8AkecjNhiGFmv7Fvh