### PR TITLE
fix: clear the five pyright errors

### DIFF
--- a/custom_components/home_generative_agent/__init__.py
+++ b/custom_components/home_generative_agent/__init__.py
@@ -18,7 +18,7 @@ import httpx
 import voluptuous as vol
 from homeassistant.components import media_source
 from homeassistant.components.camera.const import DOMAIN as CAMERA_DOMAIN
-from homeassistant.components.http import StaticPathConfig
+from homeassistant.components.http.server import StaticPathConfig
 from homeassistant.config_entries import (
     SIGNAL_CONFIG_ENTRY_CHANGED,
     ConfigEntry,

--- a/tests/custom_components/home_generative_agent/test_conversation_units.py
+++ b/tests/custom_components/home_generative_agent/test_conversation_units.py
@@ -1012,7 +1012,7 @@ async def test_index_tools_poisoned_tool_does_not_starve_neighbors() -> None:
 
     llm_api = _loaded_llm_api("HassStartTimer", "HassPauseTimer")
     # Poison the first tool: json.dumps cannot serialize an object() schema.
-    llm_api.apis["assist"].tools[0].parameters = {"bad": object()}
+    llm_api.apis["assist"].tools[0].parameters = {"bad": object()}  # type: ignore[assignment]
 
     with (
         patch(f"{_CONV}.async_dispatcher_send"),

--- a/tests/custom_components/home_generative_agent/test_snapshot_schema.py
+++ b/tests/custom_components/home_generative_agent/test_snapshot_schema.py
@@ -120,7 +120,7 @@ def test_extract_camera_activity_carries_recognition_last_event() -> None:
     # Camera attribute wins the generic last_activity slot...
     assert activity["last_activity"] == "2026-02-01T12:59:00+00:00"
     # ...but the sighting timestamp is preserved separately.
-    assert activity["recognition_last_event"] == "2026-02-01T12:00:00+00:00"
+    assert activity.get("recognition_last_event") == "2026-02-01T12:00:00+00:00"
     assert activity["recognized_people"] == ["Unknown Person"]
 
 
@@ -137,7 +137,7 @@ def test_extract_camera_activity_last_event_fallback_fills_last_activity() -> No
     )
     activity = extract_camera_activity(camera, None, image)  # type: ignore[arg-type]
     assert activity["last_activity"] == "2026-02-01T12:00:00+00:00"
-    assert activity["recognition_last_event"] == "2026-02-01T12:00:00+00:00"
+    assert activity.get("recognition_last_event") == "2026-02-01T12:00:00+00:00"
 
 
 def test_validate_snapshot_accepts_recognition_last_event() -> None:
@@ -158,6 +158,6 @@ def test_validate_snapshot_accepts_recognition_last_event() -> None:
     ]
     validated = validate_snapshot(snapshot)
     assert (
-        validated["camera_activity"][0]["recognition_last_event"]
+        validated["camera_activity"][0].get("recognition_last_event")
         == "2026-02-01T12:00:00+00:00"
     )


### PR DESCRIPTION
`make typecheck` was failing with 5 errors. This clears all of them; no behavior change.

## Fixes

**`custom_components/home_generative_agent/__init__.py:21`** — `StaticPathConfig` is not re-exported from `homeassistant.components.http` (`reportPrivateImportUsage`). Imported from `homeassistant.components.http.server`, where HA actually defines it — verified importable in the venv.

**`tests/.../test_conversation_units.py:1015`** — `test_index_tools_poisoned_tool_does_not_starve_neighbors` deliberately assigns a non-serializable dict to `Tool.parameters` (typed `Schema`) to poison the schema. The bad value *is* the test, so it's suppressed with `# type: ignore[assignment]` rather than reshaped.

**`tests/.../test_snapshot_schema.py:123,140,161`** — `recognition_last_event` is a `NotRequired` key on the `CameraActivity` TypedDict, so subscripting it trips `reportTypedDictNotRequiredAccess`. Switched the three assertions to `.get()`; a missing key still fails the assertion, so coverage is unchanged.

## Verification

- `make typecheck` → `0 errors, 0 warnings, 2273 informations` (the informations are `reportUnknownVariableType`-class diagnostics from untyped LangChain/pytest surfaces and do not fail the target)
- `make lint` → ruff format + check clean, manifest up to date
- `make test` → 2888 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhU3C8AkecjNhiGFmv7Fvh