### PR TITLE
feat: activate the Local (OpenAI-compatible) STT provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Most AI conversation integrations are prompt passthroughs: they forward your wor
 | **Face recognition** | Identify people in camera frames and personalize alerts. |
 | **Long-term memory** | Semantic search over past conversations. The agent remembers your preferences and context. |
 | **Streaming responses** | First tokens appear word-by-word in the HA conversation UI — no waiting for the full response. |
+| **Built-in speech-to-text** | STT provider for Assist pipelines, backed by the OpenAI Whisper API or a fully local OpenAI-compatible server (e.g. [Speaches](https://speaches.ai/) running faster-whisper next to Ollama) — see [STT setup](docs/configuration.md#speech-to-text-stt). |
 | **Cloud and edge models** | Use OpenAI, Gemini, Anthropic, or run everything locally with Ollama or any OpenAI-compatible server. |
 
 ## Screenshots
@@ -103,7 +104,7 @@ You can now open the HA Assist panel and start talking to your home.
 | Guide | Contents |
 | --- | --- |
 | [Installation](docs/installation.md) | HACS install, manual install, optional apps (Ollama, face recognition) |
-| [Configuration](docs/configuration.md) | Model providers, features, per-model thinking/reasoning & budget, Tool Retrieval (RAG), per-tool exclusions & always-included tools, LLM API, STT, YAML mode, Critical Action PIN, camera description language & extra VLM instructions, UI languages (en/cs/ru/tr) |
+| [Configuration](docs/configuration.md) | Model providers, features, per-model thinking/reasoning & budget, Tool Retrieval (RAG), per-tool exclusions & always-included tools, LLM API, STT (OpenAI or local), YAML mode, Critical Action PIN, camera description language & extra VLM instructions, UI languages (en/cs/ru/tr) |
 | [Sentinel](docs/sentinel.md) | Anomaly detection pipeline, built-in rules, triage, baseline, blueprints, notification quiet hours, services API, health sensor |
 | [Camera Entities](docs/camera-entities.md) | Image and sensor entities, dashboards, automations, proactive video analysis, face recognition |
 | [Architecture](docs/architecture.md) | LangGraph agent, model tiers, context management, streaming, latency, tools |

--- a/TODOS.md
+++ b/TODOS.md
@@ -1455,6 +1455,19 @@ window-scoped check could suppress.
 
 ## Speech-to-Text
 
+### Unify the two OpenAI-compatible endpoint conventions (STT flow vs model-provider flow)
+
+**What:** The local STT provider (#598) and the `openai_compatible` model provider store the same concept — an OpenAI-compatible endpoint — in divergent shapes. STT (`flows/stt_provider_subentry_flow.py:_build_local_settings`) normalizes with `/v1` at write time and stores `api_key: None` for keyless servers; the model-provider flow (`flows/model_provider_subentry_flow.py:276-302`) stores the raw `ensure_http_url(...)` and normalizes at read time, and uses the literal `"none"` sentinel for keyless (which `validate_openai_compatible_url` at `core/utils.py:750` special-cases; the STT runtime instead uses `LOCAL_STT_KEYLESS_API_KEY = ""`). `CONF_STT_BASE_URL` and `CONF_OPENAI_COMPATIBLE_BASE_URL` are two constants for the same `base_url`/`openai_compatible_base_url` settings ideas.
+
+**Why:** Flagged by the pre-merge review of #598. Any future change to how an OpenAI-compatible endpoint is validated, authenticated, or normalized must now be made twice in two conventions; miss one and local STT and local chat behave differently for the identical URL the user typed. Not unified in #598 to keep that PR a self-contained STT feature; the model-provider convention has existing stored entries, so unification needs a migration or read-both compatibility.
+
+**How to apply:** Extract a shared "openai-compatible endpoint settings" helper (build + validate + normalize + keyless convention) used by both flows, pick one storage shape (write-time normalized is simpler for readers), and accept the other on read for existing entries. The planned TTS provider (PR B) is the forcing function — do this before adding a third copy there.
+
+**Effort:** M
+**Priority:** P2
+
+---
+
 ### SDK client defaults given up by using HA's shared httpx client
 
 **What:** `_get_client` (stt.py) builds the OpenAI client on Home Assistant's shared httpx client. That is what removes the per-stream SSL-context build (#556), but it also means the SDK's own client defaults no longer apply. Two are currently accepted and documented rather than restored: `follow_redirects` (openai's own client sets `True`; HA leaves httpx's `False`, so a 3xx from an egress proxy or a future endpoint move surfaces as an error instead of being followed), and the SDK's connection limits (HA's pool expires keepalive at 15s, which is what bounds the connection-reuse win to back-to-back utterances). The request timeout was the third and *is* pinned.

--- a/custom_components/home_generative_agent/const.py
+++ b/custom_components/home_generative_agent/const.py
@@ -424,6 +424,13 @@ STT_MODEL_OPENAI_SUPPORTED = Literal[
 RECOMMENDED_OPENAI_STT_MODEL: STT_MODEL_OPENAI_SUPPORTED = "gpt-4o-mini-transcribe"
 STT_RESPONSE_FORMATS = ("text", "json", "verbose_json", "srt", "vtt")
 
+# Local (OpenAI-compatible) STT provider, e.g. Speaches serving faster-whisper.
+CONF_STT_BASE_URL = "base_url"
+# Speaches model ID; the flow accepts any custom value, this is only a default.
+RECOMMENDED_LOCAL_STT_MODEL = "Systran/faster-whisper-large-v3-turbo"
+# AsyncOpenAI requires a non-empty key even for keyless local servers.
+LOCAL_STT_PLACEHOLDER_API_KEY = "sk-local"
+
 # ---------------- Chat model ----------------
 CHAT_MODEL_TOP_P = 1.0
 # *SUPPORTED are used as defaults and fallbacks for Ollama in the UI.

--- a/custom_components/home_generative_agent/const.py
+++ b/custom_components/home_generative_agent/const.py
@@ -428,8 +428,11 @@ STT_RESPONSE_FORMATS = ("text", "json", "verbose_json", "srt", "vtt")
 CONF_STT_BASE_URL = "base_url"
 # Speaches model ID; the flow accepts any custom value, this is only a default.
 RECOMMENDED_LOCAL_STT_MODEL = "Systran/faster-whisper-large-v3-turbo"
-# AsyncOpenAI requires a non-empty key even for keyless local servers.
-LOCAL_STT_PLACEHOLDER_API_KEY = "sk-local"
+# Keyless local servers get an empty key: the SDK accepts it and then sends
+# no Authorization header at all, matching the flow's validation request. A
+# fabricated placeholder would send a bogus bearer token that auth proxies
+# (e.g. LiteLLM virtual keys) reject even though validation passed.
+LOCAL_STT_KEYLESS_API_KEY = ""
 
 # ---------------- Chat model ----------------
 CHAT_MODEL_TOP_P = 1.0

--- a/custom_components/home_generative_agent/flows/stt_provider_subentry_flow.py
+++ b/custom_components/home_generative_agent/flows/stt_provider_subentry_flow.py
@@ -28,6 +28,7 @@ from homeassistant.helpers.selector import (
 )
 
 from ..const import (  # noqa: TID252
+    CONF_STT_BASE_URL,
     CONF_STT_LANGUAGE,
     CONF_STT_MODEL_NAME,
     CONF_STT_OPENAI_PROVIDER_ID,
@@ -35,6 +36,7 @@ from ..const import (  # noqa: TID252
     CONF_STT_RESPONSE_FORMAT,
     CONF_STT_TEMPERATURE,
     CONF_STT_TRANSLATE,
+    RECOMMENDED_LOCAL_STT_MODEL,
     RECOMMENDED_OPENAI_STT_MODEL,
     STT_MODEL_OPENAI_SUPPORTED,
     STT_RESPONSE_FORMATS,
@@ -44,6 +46,8 @@ from ..const import (  # noqa: TID252
 from ..core.utils import (  # noqa: TID252
     CannotConnectError,
     InvalidAuthError,
+    normalize_openai_compatible_base_url,
+    validate_openai_compatible_url,
     validate_openai_key,
 )
 
@@ -128,6 +132,33 @@ async def _build_openai_settings(
     return settings, None
 
 
+async def _build_local_settings(
+    hass: Any, user_input: dict[str, Any]
+) -> tuple[dict[str, Any], str | None]:
+    """Build local (OpenAI-compatible) settings and return error key if any."""
+    base_url = user_input.get(CONF_STT_BASE_URL)
+    if not isinstance(base_url, str) or not base_url.strip():
+        return {}, "cannot_connect"
+    base_url = normalize_openai_compatible_base_url(base_url)
+    api_key = user_input.get(CONF_API_KEY) or None
+
+    try:
+        await validate_openai_compatible_url(hass, base_url, api_key)
+    except InvalidAuthError:
+        return {}, "invalid_auth"
+    except CannotConnectError:
+        return {}, "cannot_connect"
+    except Exception:
+        LOGGER.exception("Unexpected exception validating local STT endpoint")
+        return {}, "unknown"
+
+    return {
+        CONF_STT_BASE_URL: base_url,
+        CONF_API_KEY: api_key,
+        CONF_STT_OPENAI_PROVIDER_ID: None,
+    }, None
+
+
 class SttProviderSubentryFlow(ConfigSubentryFlow):
     """Config flow handler for STT provider subentries."""
 
@@ -167,14 +198,11 @@ class SttProviderSubentryFlow(ConfigSubentryFlow):
         errors: dict[str, str] = {}
         if user_input is not None:
             provider_type = user_input.get("provider_type") or "openai"
-            if provider_type == "local":
-                errors["base"] = "not_supported"
-            else:
-                self._provider_type = provider_type
-                self._name = user_input.get("name") or ProviderNames.get(
-                    provider_type, "STT Provider"
-                )
-                return await self.async_step_credentials()
+            self._provider_type = provider_type
+            self._name = user_input.get("name") or ProviderNames.get(
+                provider_type, "STT Provider"
+            )
+            return await self.async_step_credentials()
 
         provider_type = self._provider_type or "openai"
         default_name = self._name or ProviderNames.get(provider_type, "STT Provider")
@@ -188,7 +216,7 @@ class SttProviderSubentryFlow(ConfigSubentryFlow):
                         options=[
                             SelectOptionDict(label="OpenAI", value="openai"),
                             SelectOptionDict(
-                                label="Local (coming soon)", value="local"
+                                label="Local (OpenAI-compatible)", value="local"
                             ),
                         ],
                         mode=SelectSelectorMode.DROPDOWN,
@@ -216,17 +244,42 @@ class SttProviderSubentryFlow(ConfigSubentryFlow):
         openai_opts = _openai_provider_options(self)
 
         if user_input is not None:
-            if provider_type != "openai":
-                errors["base"] = "not_supported"
-            else:
+            if provider_type == "local":
+                settings, error = await _build_local_settings(self.hass, user_input)
+            elif provider_type == "openai":
                 settings, error = await _build_openai_settings(
                     self.hass, openai_opts, user_input
                 )
-                if error:
-                    errors["base"] = error
-                else:
-                    self._settings = settings
-                    return await self.async_step_model()
+            else:
+                settings, error = {}, "not_supported"
+            if error:
+                errors["base"] = error
+            else:
+                self._settings = settings
+                return await self.async_step_model()
+
+        if provider_type == "local":
+            local_schema = vol.Schema(
+                {
+                    vol.Required(
+                        CONF_STT_BASE_URL,
+                        description={
+                            "suggested_value": self._settings.get(CONF_STT_BASE_URL)
+                        },
+                        default=self._settings.get(CONF_STT_BASE_URL) or "",
+                    ): TextSelector(TextSelectorConfig(type=TextSelectorType.URL)),
+                    vol.Optional(
+                        CONF_API_KEY,
+                        description={
+                            "suggested_value": self._settings.get(CONF_API_KEY)
+                        },
+                        default=self._settings.get(CONF_API_KEY) or "",
+                    ): TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD)),
+                }
+            )
+            return self.async_show_form(
+                step_id="credentials", data_schema=local_schema, errors=errors
+            )
 
         schema_dict: dict[Any, Any] = {}
         if openai_opts:
@@ -295,7 +348,10 @@ class SttProviderSubentryFlow(ConfigSubentryFlow):
             if not errors:
                 payload = {
                     "provider_type": self._provider_type or "openai",
-                    "name": self._name or ProviderNames.get("openai", "STT Provider"),
+                    "name": self._name
+                    or ProviderNames.get(
+                        self._provider_type or "openai", "STT Provider"
+                    ),
                     "settings": self._settings,
                     "model": model_data,
                 }
@@ -315,22 +371,35 @@ class SttProviderSubentryFlow(ConfigSubentryFlow):
                     title=payload["name"],
                 )
 
+        provider_type = self._provider_type or "openai"
+        if provider_type == "local":
+            model_options = [
+                SelectOptionDict(
+                    label=RECOMMENDED_LOCAL_STT_MODEL,
+                    value=RECOMMENDED_LOCAL_STT_MODEL,
+                )
+            ]
+            recommended_model = RECOMMENDED_LOCAL_STT_MODEL
+            allow_custom_model = True
+        else:
+            model_options = [
+                SelectOptionDict(label=model, value=model)
+                for model in get_args(STT_MODEL_OPENAI_SUPPORTED)
+            ]
+            recommended_model = RECOMMENDED_OPENAI_STT_MODEL
+            allow_custom_model = False
+
         schema = vol.Schema(
             {
                 vol.Required(
                     CONF_STT_MODEL_NAME,
-                    default=model_data.get(
-                        CONF_STT_MODEL_NAME, RECOMMENDED_OPENAI_STT_MODEL
-                    ),
+                    default=model_data.get(CONF_STT_MODEL_NAME, recommended_model),
                 ): SelectSelector(
                     SelectSelectorConfig(
-                        options=[
-                            SelectOptionDict(label=model, value=model)
-                            for model in get_args(STT_MODEL_OPENAI_SUPPORTED)
-                        ],
+                        options=model_options,
                         mode=SelectSelectorMode.DROPDOWN,
                         sort=False,
-                        custom_value=False,
+                        custom_value=allow_custom_model,
                     )
                 ),
                 vol.Optional(

--- a/custom_components/home_generative_agent/flows/stt_provider_subentry_flow.py
+++ b/custom_components/home_generative_agent/flows/stt_provider_subentry_flow.py
@@ -198,8 +198,25 @@ class SttProviderSubentryFlow(ConfigSubentryFlow):
         errors: dict[str, str] = {}
         if user_input is not None:
             provider_type = user_input.get("provider_type") or "openai"
+            type_changed = (
+                self._provider_type is not None and provider_type != self._provider_type
+            )
+            submitted_name = user_input.get("name")
+            if type_changed:
+                # Switching provider types must not carry state across.
+                # Settings: the stored OpenAI key would otherwise prefill the
+                # local server's optional key field and be sent to a plaintext
+                # LAN endpoint (the model-provider flow guards the same leak).
+                # Model: the other type's model ID is invalid or a silent 404
+                # for the new one. Name: the pre-filled old default ("STT -
+                # OpenAI") would mislabel the new provider in the Assist
+                # pipeline dropdown; only a deliberately edited name survives.
+                self._settings = {}
+                self._model = {}
+                if submitted_name == self._name:
+                    submitted_name = None
             self._provider_type = provider_type
-            self._name = user_input.get("name") or ProviderNames.get(
+            self._name = submitted_name or ProviderNames.get(
                 provider_type, "STT Provider"
             )
             return await self.async_step_credentials()
@@ -251,6 +268,10 @@ class SttProviderSubentryFlow(ConfigSubentryFlow):
                     self.hass, openai_opts, user_input
                 )
             else:
+                # Unreachable today (the provider select admits only the two
+                # types above, custom_value=False) — kept so a future type
+                # added to the select but not wired here fails visibly
+                # instead of storing an empty credentials payload.
                 settings, error = {}, "not_supported"
             if error:
                 errors["base"] = error
@@ -259,21 +280,24 @@ class SttProviderSubentryFlow(ConfigSubentryFlow):
                 return await self.async_step_model()
 
         if provider_type == "local":
+            # On a validation error, redisplay what was just typed — not the
+            # stored settings — so a retry against a booting server does not
+            # demand retyping the URL, and a corrected typo does not silently
+            # revert to the saved value.
+            prefill = (
+                user_input if user_input is not None and errors else self._settings
+            )
             local_schema = vol.Schema(
                 {
                     vol.Required(
                         CONF_STT_BASE_URL,
-                        description={
-                            "suggested_value": self._settings.get(CONF_STT_BASE_URL)
-                        },
-                        default=self._settings.get(CONF_STT_BASE_URL) or "",
+                        description={"suggested_value": prefill.get(CONF_STT_BASE_URL)},
+                        default=prefill.get(CONF_STT_BASE_URL) or "",
                     ): TextSelector(TextSelectorConfig(type=TextSelectorType.URL)),
                     vol.Optional(
                         CONF_API_KEY,
-                        description={
-                            "suggested_value": self._settings.get(CONF_API_KEY)
-                        },
-                        default=self._settings.get(CONF_API_KEY) or "",
+                        description={"suggested_value": prefill.get(CONF_API_KEY)},
+                        default=prefill.get(CONF_API_KEY) or "",
                     ): TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD)),
                 }
             )

--- a/custom_components/home_generative_agent/strings.json
+++ b/custom_components/home_generative_agent/strings.json
@@ -120,10 +120,15 @@
         },
         "credentials": {
           "title": "Credentials",
-          "description": "Choose how to authenticate the STT provider.",
+          "description": "Choose how to authenticate the STT provider. Local providers connect to an OpenAI-compatible server URL instead.",
           "data": {
             "openai_provider_subentry_id": "Reuse OpenAI model provider",
-            "api_key": "OpenAI API key"
+            "api_key": "API key",
+            "base_url": "Server URL"
+          },
+          "data_description": {
+            "api_key": "Required for OpenAI. Optional for local servers that need no authentication.",
+            "base_url": "OpenAI-compatible endpoint of the local STT server, e.g. a Speaches instance. A missing /v1 suffix is added automatically."
           }
         },
         "model": {

--- a/custom_components/home_generative_agent/stt.py
+++ b/custom_components/home_generative_agent/stt.py
@@ -29,7 +29,7 @@ from .const import (
     CONF_STT_RESPONSE_FORMAT,
     CONF_STT_TEMPERATURE,
     CONF_STT_TRANSLATE,
-    LOCAL_STT_PLACEHOLDER_API_KEY,
+    LOCAL_STT_KEYLESS_API_KEY,
     RECOMMENDED_LOCAL_STT_MODEL,
     RECOMMENDED_OPENAI_STT_MODEL,
     SUBENTRY_TYPE_MODEL_PROVIDER,
@@ -322,8 +322,9 @@ class HGASttEntity(SpeechToTextEntity):
         """
         Return (api_key, base_url) for the provider, or None if unconfigured.
 
-        Local providers require a base URL and fall back to a placeholder key
-        (the SDK insists on one) when the server needs no authentication.
+        Local providers require a base URL and fall back to an empty key —
+        which the SDK turns into no Authorization header, the same shape the
+        flow's validation request used — when the server needs none.
         """
         if provider_type == "local":
             settings = data.get("settings", {})
@@ -336,7 +337,7 @@ class HGASttEntity(SpeechToTextEntity):
             api_key = (
                 configured_key
                 if isinstance(configured_key, str) and configured_key
-                else LOCAL_STT_PLACEHOLDER_API_KEY
+                else LOCAL_STT_KEYLESS_API_KEY
             )
             return api_key, base_url
         api_key = self._resolve_api_key(data)
@@ -399,8 +400,17 @@ class HGASttEntity(SpeechToTextEntity):
         try:
             client = self._get_client(api_key, base_url)
             # Local servers (faster-whisper) serve /audio/translations for any
-            # whisper model; OpenAI only does for whisper-1.
-            if translate and (provider_type == "local" or model_name == "whisper-1"):
+            # whisper model; OpenAI only does for whisper-1. A local non-whisper
+            # model degrades to transcription like the OpenAI path does, rather
+            # than 404ing against an endpoint the server never exposes.
+            if translate and (
+                "whisper" in str(model_name).lower()
+                if provider_type == "local"
+                else model_name == "whisper-1"
+            ):
+                # The translations endpoint always outputs English and has no
+                # language parameter — passing one is a TypeError in the SDK.
+                request.pop("language", None)
                 response = await client.audio.translations.create(**request)
             else:
                 if translate:

--- a/custom_components/home_generative_agent/stt.py
+++ b/custom_components/home_generative_agent/stt.py
@@ -21,6 +21,7 @@ from homeassistant.helpers.httpx_client import get_async_client
 from openai import AsyncOpenAI, AuthenticationError, OpenAIError
 
 from .const import (
+    CONF_STT_BASE_URL,
     CONF_STT_LANGUAGE,
     CONF_STT_MODEL_NAME,
     CONF_STT_OPENAI_PROVIDER_ID,
@@ -28,6 +29,8 @@ from .const import (
     CONF_STT_RESPONSE_FORMAT,
     CONF_STT_TEMPERATURE,
     CONF_STT_TRANSLATE,
+    LOCAL_STT_PLACEHOLDER_API_KEY,
+    RECOMMENDED_LOCAL_STT_MODEL,
     RECOMMENDED_OPENAI_STT_MODEL,
     SUBENTRY_TYPE_MODEL_PROVIDER,
     SUBENTRY_TYPE_STT_PROVIDER,
@@ -198,7 +201,7 @@ class HGASttEntity(SpeechToTextEntity):
         self._attr_unique_id = f"{entry.entry_id}_{subentry_id}"
         self._attr_name = self._subentry.title or "STT"
         self._openai_client: AsyncOpenAI | None = None
-        self._openai_client_api_key: str | None = None
+        self._openai_client_cache_key: tuple[str, str | None] | None = None
 
     @property
     def supported_languages(self) -> list[str]:
@@ -262,16 +265,16 @@ class HGASttEntity(SpeechToTextEntity):
         api_key = settings.get("api_key")
         return api_key if isinstance(api_key, str) and api_key else None
 
-    def _get_client(self, api_key: str) -> AsyncOpenAI:
+    def _get_client(self, api_key: str, base_url: str | None) -> AsyncOpenAI:
         """
-        Return a cached OpenAI client for the resolved API key.
+        Return a cached OpenAI client for the resolved API key and base URL.
 
         The client is built on Home Assistant's shared httpx client so the SDK
         never creates its own SSL context — a blocking read of the certifi
         bundle — on the event loop, and so back-to-back utterances can reuse a
         pooled connection instead of repeating the TLS handshake. The cache is
-        keyed on the API key so reconfiguring the STT subentry or its linked
-        model provider takes effect on the next stream.
+        keyed on the API key and base URL so reconfiguring the STT subentry or
+        its linked model provider takes effect on the next stream.
 
         The httpx client belongs to Home Assistant. Do not close it from here.
         HA also blocks that mistake — it swaps in a warn-only ``aclose`` and only
@@ -291,20 +294,56 @@ class HGASttEntity(SpeechToTextEntity):
         connection limits (HA's pool keeps connections alive for 15s, which is
         what bounds the reuse win above to back-to-back utterances).
 
-        ``api_key`` is the whole cache key because it is the only configurable
-        input to the client: the STT flow admits ``openai`` providers only, so
-        there is no per-subentry ``base_url``. Adding one means keying on it too.
+        The cache is keyed on ``(api_key, base_url)`` — the two configurable
+        inputs to the client. ``base_url`` is ``None`` for the OpenAI provider
+        (SDK default endpoint) and the configured endpoint for ``local``
+        providers, so switching a subentry between provider types or repointing
+        a local server rebuilds the client on the next stream.
         """
-        if self._openai_client is not None and self._openai_client_api_key == api_key:
+        cache_key = (api_key, base_url)
+        if (
+            self._openai_client is not None
+            and self._openai_client_cache_key == cache_key
+        ):
             return self._openai_client
         client = AsyncOpenAI(
             api_key=api_key,
+            base_url=base_url,
             http_client=get_async_client(self.hass),
             timeout=httpx.Timeout(STT_REQUEST_TIMEOUT_S, connect=5.0),
         )
         self._openai_client = client
-        self._openai_client_api_key = api_key
+        self._openai_client_cache_key = cache_key
         return client
+
+    def _resolve_connection(
+        self, provider_type: str, data: dict[str, Any]
+    ) -> tuple[str, str | None] | None:
+        """
+        Return (api_key, base_url) for the provider, or None if unconfigured.
+
+        Local providers require a base URL and fall back to a placeholder key
+        (the SDK insists on one) when the server needs no authentication.
+        """
+        if provider_type == "local":
+            settings = data.get("settings", {})
+            settings = dict(settings) if isinstance(settings, Mapping) else {}
+            base_url = settings.get(CONF_STT_BASE_URL)
+            if not isinstance(base_url, str) or not base_url:
+                LOGGER.warning("Local STT base URL missing for %s", self.entity_id)
+                return None
+            configured_key = settings.get("api_key")
+            api_key = (
+                configured_key
+                if isinstance(configured_key, str) and configured_key
+                else LOCAL_STT_PLACEHOLDER_API_KEY
+            )
+            return api_key, base_url
+        api_key = self._resolve_api_key(data)
+        if not api_key:
+            LOGGER.warning("OpenAI STT API key missing for %s", self.entity_id)
+            return None
+        return api_key, None
 
     async def async_process_audio_stream(  # noqa: PLR0912
         self, metadata: SpeechMetadata, stream: Any
@@ -313,16 +352,22 @@ class HGASttEntity(SpeechToTextEntity):
         result_state = stt.SpeechResultState.ERROR
         text: str | None = None
         data = dict(self._subentry.data)
-        if data.get("provider_type") != "openai":
+        provider_type = data.get("provider_type")
+        if provider_type not in ("openai", "local"):
             return SpeechResult(result=result_state, text=None)
 
-        api_key = self._resolve_api_key(data)
-        if not api_key:
-            LOGGER.warning("OpenAI STT API key missing for %s", self.entity_id)
+        connection = self._resolve_connection(provider_type, data)
+        if connection is None:
             return SpeechResult(result=result_state, text=None)
+        api_key, base_url = connection
 
         model_data = _load_model_settings(data)
-        model_name = model_data.get(CONF_STT_MODEL_NAME, RECOMMENDED_OPENAI_STT_MODEL)
+        default_model = (
+            RECOMMENDED_LOCAL_STT_MODEL
+            if provider_type == "local"
+            else RECOMMENDED_OPENAI_STT_MODEL
+        )
+        model_name = model_data.get(CONF_STT_MODEL_NAME, default_model)
         language = model_data.get(CONF_STT_LANGUAGE)
         prompt = model_data.get(CONF_STT_PROMPT)
         temperature = model_data.get(CONF_STT_TEMPERATURE)
@@ -352,8 +397,10 @@ class HGASttEntity(SpeechToTextEntity):
         # the SDK constructor, and a failure there should fail this utterance,
         # not raise out into the assist pipeline.
         try:
-            client = self._get_client(api_key)
-            if translate and model_name == "whisper-1":
+            client = self._get_client(api_key, base_url)
+            # Local servers (faster-whisper) serve /audio/translations for any
+            # whisper model; OpenAI only does for whisper-1.
+            if translate and (provider_type == "local" or model_name == "whisper-1"):
                 response = await client.audio.translations.create(**request)
             else:
                 if translate:

--- a/custom_components/home_generative_agent/translations/cs.json
+++ b/custom_components/home_generative_agent/translations/cs.json
@@ -120,10 +120,15 @@
         },
         "credentials": {
           "title": "Přihlašovací údaje",
-          "description": "Vyberte způsob autentizace poskytovatele STT.",
+          "description": "Vyberte způsob autentizace poskytovatele STT. Lokální poskytovatelé se místo toho připojují přes URL serveru kompatibilního s OpenAI.",
           "data": {
             "openai_provider_subentry_id": "Znovu použít poskytovatele OpenAI",
-            "api_key": "OpenAI API klíč"
+            "api_key": "API klíč",
+            "base_url": "URL serveru"
+          },
+          "data_description": {
+            "api_key": "Vyžadováno pro OpenAI. Volitelné pro lokální servery bez autentizace.",
+            "base_url": "OpenAI-kompatibilní koncový bod lokálního STT serveru, např. instance Speaches. Chybějící přípona /v1 se doplní automaticky."
           }
         },
         "model": {

--- a/custom_components/home_generative_agent/translations/en.json
+++ b/custom_components/home_generative_agent/translations/en.json
@@ -120,10 +120,15 @@
         },
         "credentials": {
           "title": "Credentials",
-          "description": "Choose how to authenticate the STT provider.",
+          "description": "Choose how to authenticate the STT provider. Local providers connect to an OpenAI-compatible server URL instead.",
           "data": {
             "openai_provider_subentry_id": "Reuse OpenAI model provider",
-            "api_key": "OpenAI API key"
+            "api_key": "API key",
+            "base_url": "Server URL"
+          },
+          "data_description": {
+            "api_key": "Required for OpenAI. Optional for local servers that need no authentication.",
+            "base_url": "OpenAI-compatible endpoint of the local STT server, e.g. a Speaches instance. A missing /v1 suffix is added automatically."
           }
         },
         "model": {

--- a/custom_components/home_generative_agent/translations/ru.json
+++ b/custom_components/home_generative_agent/translations/ru.json
@@ -110,10 +110,15 @@
         },
         "credentials": {
           "title": "Credentials",
-          "description": "Choose how to authenticate the STT provider.",
+          "description": "Choose how to authenticate the STT provider. Local providers connect to an OpenAI-compatible server URL instead.",
           "data": {
             "openai_provider_subentry_id": "Reuse OpenAI model provider",
-            "api_key": "OpenAI API key"
+            "api_key": "API key",
+            "base_url": "Server URL"
+          },
+          "data_description": {
+            "api_key": "Required for OpenAI. Optional for local servers that need no authentication.",
+            "base_url": "OpenAI-compatible endpoint of the local STT server, e.g. a Speaches instance. A missing /v1 suffix is added automatically."
           }
         },
         "model": {

--- a/custom_components/home_generative_agent/translations/tr.json
+++ b/custom_components/home_generative_agent/translations/tr.json
@@ -110,10 +110,15 @@
         },
         "credentials": {
           "title": "Kimlik bilgileri",
-          "description": "STT sağlayıcısı için kimlik doğrulama seçin.",
+          "description": "STT sağlayıcısı için kimlik doğrulama seçin. Yerel sağlayıcılar bunun yerine OpenAI uyumlu bir sunucu URL'sine bağlanır.",
           "data": {
             "openai_provider_subentry_id": "OpenAI model sağlayıcıyı yeniden kullan",
-            "api_key": "OpenAI API anahtarı"
+            "api_key": "API anahtarı",
+            "base_url": "Sunucu URL'si"
+          },
+          "data_description": {
+            "api_key": "OpenAI için zorunludur. Kimlik doğrulaması gerektirmeyen yerel sunucular için isteğe bağlıdır.",
+            "base_url": "Yerel STT sunucusunun OpenAI uyumlu uç noktası, örn. bir Speaches örneği. Eksik /v1 eki otomatik olarak eklenir."
           }
         },
         "model": {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -237,20 +237,49 @@ You can select any combination. Selecting both Assist and one or more MCP APIs m
 
 ## Speech-to-Text (STT)
 
-HGA provides a built-in STT engine using the OpenAI Whisper API — no separate STT integration required.
+HGA provides a built-in STT engine — no separate STT integration required. Two provider types are supported: **OpenAI** (Whisper API) and **Local** (any OpenAI-compatible transcription server, e.g. [Speaches](https://speaches.ai/) serving faster-whisper on the same box as Ollama).
 
 1. Open **Settings → Devices & Services → Home Generative Agent**.
 2. Click **+ STT Provider**.
-3. Choose **OpenAI** and give it a name.
-4. On the **Credentials** step, either reuse an existing OpenAI Model Provider subentry or select **Use a separate key** and enter a dedicated API key.
-5. On **Model & advanced options**, pick a model (recommended: `gpt-4o-mini-transcribe`) and set optional fields:
+3. Choose **OpenAI** or **Local (OpenAI-compatible)** and give it a name.
+4. On the **Credentials** step:
+   - **OpenAI:** either reuse an existing OpenAI Model Provider subentry or select **Use a separate key** and enter a dedicated API key.
+   - **Local:** enter the server URL (e.g. `http://192.168.1.100:8000` — a missing `/v1` suffix is added automatically). The API key is optional; leave it blank for servers without authentication. The endpoint is validated when you submit the form.
+5. On **Model & advanced options**, pick a model and set optional fields:
+   - model: recommended `gpt-4o-mini-transcribe` (OpenAI) or `Systran/faster-whisper-large-v3-turbo` (Local; any custom model ID your server exposes can be typed in)
    - `language` (optional): e.g. `en` or `en-US`
    - `prompt` (optional): hints for domain-specific vocabulary
    - `temperature` (optional): 0–1
-   - `translate`: only supported by `whisper-1`; other models fall back to transcription
-6. Go to **Settings → Voice assistants → Assist pipelines** and select **STT - OpenAI** (or your chosen name) for Speech-to-text.
+   - `translate`: on OpenAI only `whisper-1` supports it (other models fall back to transcription); local whisper servers support it for every model
+6. Go to **Settings → Voice assistants → Assist pipelines** and select **STT - OpenAI** / **STT - Local** (or your chosen name) for Speech-to-text.
 
-**Credential changes take effect on the next utterance.** Each STT entity keeps one OpenAI client, built on Home Assistant's shared HTTP client, and rebuilds it when the resolved API key changes — no restart or integration reload needed. If the entry is linked to a Model Provider subentry, that provider's key is the only one used: linking blanks the separate STT key, so a linked provider without a usable key fails the utterance with an `OpenAI STT API key missing` warning in the log rather than falling back to a stale key.
+**Credential changes take effect on the next utterance.** Each STT entity keeps one OpenAI client, built on Home Assistant's shared HTTP client, and rebuilds it when the resolved API key or server URL changes — no restart or integration reload needed. If the entry is linked to a Model Provider subentry, that provider's key is the only one used: linking blanks the separate STT key, so a linked provider without a usable key fails the utterance with an `OpenAI STT API key missing` warning in the log rather than falling back to a stale key.
+
+### Running a local STT server
+
+Any server exposing the OpenAI `/v1/audio/transcriptions` endpoint works. Speaches is a good fit for a GPU box already running Ollama (`faster-whisper-large-v3-turbo` needs roughly 1.5–2 GB of VRAM):
+
+```yaml
+# docker-compose.yaml on the GPU box
+services:
+  speaches:
+    image: ghcr.io/speaches-ai/speaches:latest-cuda
+    ports:
+      - "8000:8000"
+    volumes:
+      - hf-hub-cache:/home/ubuntu/.cache/huggingface/hub
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+volumes:
+  hf-hub-cache:
+```
+
+> **Tip:** local whisper models occasionally hallucinate short phrases ("Thank you.") from silence or noise. The **Speech input filters** in the integration options (**Configure**) drop such phantom transcriptions before they reach the agent — add the phrases you see under **Ignored exact STT phrases**.
 
 ---
 

--- a/tests/custom_components/home_generative_agent/test_stt.py
+++ b/tests/custom_components/home_generative_agent/test_stt.py
@@ -22,6 +22,8 @@ from custom_components.home_generative_agent.const import (
     CONF_STT_RESPONSE_FORMAT,
     CONF_STT_TEMPERATURE,
     CONF_STT_TRANSLATE,
+    LOCAL_STT_PLACEHOLDER_API_KEY,
+    RECOMMENDED_LOCAL_STT_MODEL,
     SUBENTRY_TYPE_MODEL_PROVIDER,
     SUBENTRY_TYPE_STT_PROVIDER,
 )
@@ -198,8 +200,8 @@ async def _run(
     seen: dict[str, list[Any]] = {}
     original = entity._get_client
 
-    def _wrapped(api_key: str) -> Any:
-        client = original(api_key)
+    def _wrapped(api_key: str, base_url: str | None = None) -> Any:
+        client = original(api_key, base_url)
         seen.update(_stub_responses(client, responses))
         return client
 
@@ -653,7 +655,9 @@ async def test_client_reused_when_key_value_unchanged(patched_client: Any) -> No
     # A literal here would be interned and defeat the point of this test.
     reloaded = "".join(["key", "-", "1"])  # noqa: FLY002
     assert reloaded == "key-1"
-    assert reloaded is not entity._openai_client_api_key
+    cache_key = entity._openai_client_cache_key
+    assert cache_key is not None
+    assert reloaded is not cache_key[0]
     entry.subentries["stt_1"].reconfigure(
         {**entry.subentries["stt_1"].data, "settings": {"api_key": reloaded}}
     )
@@ -711,3 +715,102 @@ async def test_stream_to_bytes_reads_sync_and_coroutine_read_objects() -> None:
 async def test_stream_to_bytes_returns_empty_for_unknown_stream() -> None:
     """An object with none of the three interfaces yields the empty-audio guard."""
     assert await hga_stt._stream_to_bytes(object()) == b""
+
+
+LOCAL_BASE_URL = "http://ollama-box:8000/v1"
+
+
+def _make_local_entity(
+    settings: dict[str, Any] | None = None,
+    model: dict[str, Any] | None = None,
+) -> tuple[HGASttEntity, _FakeEntry]:
+    """Build a local-provider STT entity with a keyless server by default."""
+    return _make_entity(
+        settings=settings if settings is not None else {"base_url": LOCAL_BASE_URL},
+        model=model,
+        provider_type="local",
+    )
+
+
+async def test_local_provider_builds_client_with_base_url(
+    patched_client: Any,
+) -> None:
+    """A local provider passes its base URL and a placeholder key to the SDK."""
+    entity, _ = _make_local_entity()
+    result, seen = await _run(entity, [SimpleNamespace(text="hello")])
+    assert result.result == ha_stt.SpeechResultState.SUCCESS
+    assert result.text == "hello"
+    assert len(patched_client["kwargs"]) == 1
+    kwargs = patched_client["kwargs"][0]
+    assert kwargs["base_url"] == LOCAL_BASE_URL
+    assert kwargs["api_key"] == LOCAL_STT_PLACEHOLDER_API_KEY
+    assert len(seen["transcriptions"]) == 1
+
+
+async def test_local_provider_uses_configured_key(patched_client: Any) -> None:
+    """A configured key on a local provider wins over the placeholder."""
+    entity, _ = _make_local_entity(
+        settings={"base_url": LOCAL_BASE_URL, "api_key": "local-key"}
+    )
+    await _run(entity, [SimpleNamespace(text="hello")])
+    assert patched_client["kwargs"][0]["api_key"] == "local-key"
+
+
+async def test_local_provider_missing_base_url_builds_no_client(
+    patched_client: Any,
+) -> None:
+    """A local provider without a base URL fails the utterance, not the pipeline."""
+    entity, _ = _make_local_entity(settings={})
+    result, _ = await _run(entity, [SimpleNamespace(text="hello")])
+    assert result.result == ha_stt.SpeechResultState.ERROR
+    assert result.text is None
+    assert patched_client["constructed"] == []
+
+
+async def test_client_rebuilt_when_base_url_changes(patched_client: Any) -> None:
+    """Repointing a local subentry at a new server takes effect on the next stream."""
+    entity, entry = _make_local_entity()
+    await _run(entity, [SimpleNamespace(text="one")])
+    first = entity._openai_client
+    assert first is not None
+    entry.subentries["stt_1"].reconfigure(
+        {
+            **entry.subentries["stt_1"].data,
+            "settings": {"base_url": "http://other-box:8000/v1"},
+        }
+    )
+    await _run(entity, [SimpleNamespace(text="two")])
+    assert entity._openai_client is not first
+    assert len(patched_client["constructed"]) == 2
+    assert patched_client["kwargs"][1]["base_url"] == "http://other-box:8000/v1"
+
+
+async def test_local_client_reused_across_streams(patched_client: Any) -> None:
+    """An unchanged local configuration reuses one client across utterances."""
+    entity, _ = _make_local_entity()
+    await _run(entity, [SimpleNamespace(text="one")])
+    await _run(entity, [SimpleNamespace(text="two")])
+    assert len(patched_client["constructed"]) == 1
+
+
+@pytest.mark.usefixtures("patched_client")
+async def test_local_default_model_is_local_recommendation() -> None:
+    """With no model configured, a local provider requests the local default."""
+    entity, _ = _make_local_entity(model={})
+    _, seen = await _run(entity, [SimpleNamespace(text="hello")])
+    assert seen["transcriptions"][0]["model"] == RECOMMENDED_LOCAL_STT_MODEL
+
+
+@pytest.mark.usefixtures("patched_client")
+async def test_local_translate_uses_translations_for_any_model() -> None:
+    """Local servers serve translations for all whisper models, not just whisper-1."""
+    entity, _ = _make_local_entity(
+        model={
+            CONF_STT_MODEL_NAME: "Systran/faster-whisper-large-v3",
+            CONF_STT_TRANSLATE: True,
+        },
+    )
+    result, seen = await _run(entity, [SimpleNamespace(text="hola")])
+    assert result.result == ha_stt.SpeechResultState.SUCCESS
+    assert len(seen["translations"]) == 1
+    assert seen["transcriptions"] == []

--- a/tests/custom_components/home_generative_agent/test_stt.py
+++ b/tests/custom_components/home_generative_agent/test_stt.py
@@ -22,7 +22,7 @@ from custom_components.home_generative_agent.const import (
     CONF_STT_RESPONSE_FORMAT,
     CONF_STT_TEMPERATURE,
     CONF_STT_TRANSLATE,
-    LOCAL_STT_PLACEHOLDER_API_KEY,
+    LOCAL_STT_KEYLESS_API_KEY,
     RECOMMENDED_LOCAL_STT_MODEL,
     SUBENTRY_TYPE_MODEL_PROVIDER,
     SUBENTRY_TYPE_STT_PROVIDER,
@@ -735,7 +735,7 @@ def _make_local_entity(
 async def test_local_provider_builds_client_with_base_url(
     patched_client: Any,
 ) -> None:
-    """A local provider passes its base URL and a placeholder key to the SDK."""
+    """A keyless local provider gets an empty key and sends no auth header."""
     entity, _ = _make_local_entity()
     result, seen = await _run(entity, [SimpleNamespace(text="hello")])
     assert result.result == ha_stt.SpeechResultState.SUCCESS
@@ -743,7 +743,11 @@ async def test_local_provider_builds_client_with_base_url(
     assert len(patched_client["kwargs"]) == 1
     kwargs = patched_client["kwargs"][0]
     assert kwargs["base_url"] == LOCAL_BASE_URL
-    assert kwargs["api_key"] == LOCAL_STT_PLACEHOLDER_API_KEY
+    assert kwargs["api_key"] == LOCAL_STT_KEYLESS_API_KEY
+    # The flow validated the endpoint without an Authorization header; runtime
+    # must match, or servers that reject unknown bearer tokens 401 every
+    # utterance after a setup that passed.
+    assert patched_client["constructed"][0].auth_headers == {}
     assert len(seen["transcriptions"]) == 1
 
 
@@ -802,7 +806,7 @@ async def test_local_default_model_is_local_recommendation() -> None:
 
 
 @pytest.mark.usefixtures("patched_client")
-async def test_local_translate_uses_translations_for_any_model() -> None:
+async def test_local_translate_uses_translations_for_whisper_models() -> None:
     """Local servers serve translations for all whisper models, not just whisper-1."""
     entity, _ = _make_local_entity(
         model={
@@ -814,3 +818,63 @@ async def test_local_translate_uses_translations_for_any_model() -> None:
     assert result.result == ha_stt.SpeechResultState.SUCCESS
     assert len(seen["translations"]) == 1
     assert seen["transcriptions"] == []
+
+
+@pytest.mark.usefixtures("patched_client")
+async def test_translate_drops_language_from_translations_request() -> None:
+    """
+    The translations endpoint has no ``language`` parameter.
+
+    ``Translations.create`` in the SDK is keyword-only without ``language``
+    (output is always English), so forwarding the configured language would
+    raise a TypeError inside the catch-all and fail every utterance for a
+    translate+language configuration.
+    """
+    entity, _ = _make_local_entity(
+        model={
+            CONF_STT_MODEL_NAME: "Systran/faster-whisper-large-v3",
+            CONF_STT_TRANSLATE: True,
+            CONF_STT_LANGUAGE: "en",
+        },
+    )
+    result, seen = await _run(entity, [SimpleNamespace(text="hola")])
+    assert result.result == ha_stt.SpeechResultState.SUCCESS
+    assert len(seen["translations"]) == 1
+    assert "language" not in seen["translations"][0]
+
+
+@pytest.mark.usefixtures("patched_client")
+async def test_openai_whisper1_translate_drops_language() -> None:
+    """The OpenAI whisper-1 translations path drops ``language`` too."""
+    entity, _ = _make_entity(
+        model={
+            CONF_STT_MODEL_NAME: "whisper-1",
+            CONF_STT_TRANSLATE: True,
+            CONF_STT_LANGUAGE: "de",
+        },
+    )
+    result, seen = await _run(entity, [SimpleNamespace(text="hello")])
+    assert result.result == ha_stt.SpeechResultState.SUCCESS
+    assert len(seen["translations"]) == 1
+    assert "language" not in seen["translations"][0]
+
+
+@pytest.mark.usefixtures("patched_client")
+async def test_local_translate_non_whisper_falls_back_to_transcription() -> None:
+    """
+    A local non-whisper model degrades to transcription like the OpenAI path.
+
+    Local servers only expose /audio/translations for whisper models; routing a
+    Parakeet-style model there would 404 and fail the utterance instead of
+    returning untranslated text.
+    """
+    entity, _ = _make_local_entity(
+        model={
+            CONF_STT_MODEL_NAME: "nvidia/parakeet-tdt-0.6b",
+            CONF_STT_TRANSLATE: True,
+        },
+    )
+    result, seen = await _run(entity, [SimpleNamespace(text="hola")])
+    assert result.result == ha_stt.SpeechResultState.SUCCESS
+    assert seen["translations"] == []
+    assert len(seen["transcriptions"]) == 1

--- a/tests/custom_components/home_generative_agent/test_subentries.py
+++ b/tests/custom_components/home_generative_agent/test_subentries.py
@@ -190,20 +190,8 @@ def test_supported_subentry_types() -> None:
     }
 
 
-@pytest.mark.asyncio
-async def test_stt_provider_flow_reuses_openai_provider(
-    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """STT flow can reuse an existing OpenAI model provider."""
-    entry = DummyEntry()
-    openai_provider = DummySubentry(
-        "openai1",
-        SUBENTRY_TYPE_MODEL_PROVIDER,
-        "Cloud-LLM OpenAI",
-        {"provider_type": "openai", "settings": {"api_key": "sk-reused"}},
-    )
-    entry.subentries[openai_provider.subentry_id] = openai_provider
-
+def _make_stt_flow(hass: HomeAssistant, entry: DummyEntry) -> SttProviderSubentryFlow:
+    """Build an STT subentry flow with the usual test doubles attached."""
     flow = SttProviderSubentryFlow()
     flow.hass = hass
     flow.async_show_form = lambda **kwargs: {  # type: ignore[assignment]
@@ -220,8 +208,40 @@ async def test_stt_provider_flow_reuses_openai_provider(
         "type": "abort",
         "reason": kwargs.get("reason"),
     }
+    flow.async_update_and_abort = lambda *_args, **kwargs: {  # type: ignore[assignment]
+        "type": "update_entry",
+        "title": kwargs.get("title"),
+        "data": kwargs.get("data"),
+    }
     flow._schedule_reload = lambda: None  # type: ignore[assignment]
     _patch_entry(flow, entry)
+    return flow
+
+
+def _schema_marker(form: Any, field: str) -> Any:
+    """Return the voluptuous marker for a field of a shown form's schema."""
+    for key in form["data_schema"].schema:
+        if getattr(key, "schema", None) == field:
+            return key
+    msg = f"field {field} not in schema"
+    raise AssertionError(msg)
+
+
+@pytest.mark.asyncio
+async def test_stt_provider_flow_reuses_openai_provider(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """STT flow can reuse an existing OpenAI model provider."""
+    entry = DummyEntry()
+    openai_provider = DummySubentry(
+        "openai1",
+        SUBENTRY_TYPE_MODEL_PROVIDER,
+        "Cloud-LLM OpenAI",
+        {"provider_type": "openai", "settings": {"api_key": "sk-reused"}},
+    )
+    entry.subentries[openai_provider.subentry_id] = openai_provider
+
+    flow = _make_stt_flow(hass, entry)
 
     async def _noop_validate(*_args: Any, **_kwargs: Any) -> None:
         return None
@@ -259,24 +279,7 @@ async def test_stt_provider_flow_uses_separate_key(
 ) -> None:
     """STT flow stores a separate API key when no providers exist."""
     entry = DummyEntry()
-    flow = SttProviderSubentryFlow()
-    flow.hass = hass
-    flow.async_show_form = lambda **kwargs: {  # type: ignore[assignment]
-        "type": "form",
-        "data_schema": kwargs["data_schema"],
-        "errors": kwargs.get("errors"),
-    }
-    flow.async_create_entry = lambda **kwargs: {  # type: ignore[assignment]
-        "type": "create_entry",
-        "title": kwargs.get("title"),
-        "data": kwargs.get("data"),
-    }
-    flow.async_abort = lambda **kwargs: {  # type: ignore[assignment]
-        "type": "abort",
-        "reason": kwargs.get("reason"),
-    }
-    flow._schedule_reload = lambda: None  # type: ignore[assignment]
-    _patch_entry(flow, entry)
+    flow = _make_stt_flow(hass, entry)
 
     async def _noop_validate(*_args: Any, **_kwargs: Any) -> None:
         return None
@@ -303,29 +306,6 @@ async def test_stt_provider_flow_uses_separate_key(
     assert result_data is not None
     assert result_data["settings"]["api_key"] == "sk-separate"
     assert result_data["settings"]["openai_provider_subentry_id"] is None
-
-
-def _make_stt_flow(hass: HomeAssistant, entry: DummyEntry) -> SttProviderSubentryFlow:
-    """Build an STT subentry flow with the usual test doubles attached."""
-    flow = SttProviderSubentryFlow()
-    flow.hass = hass
-    flow.async_show_form = lambda **kwargs: {  # type: ignore[assignment]
-        "type": "form",
-        "data_schema": kwargs["data_schema"],
-        "errors": kwargs.get("errors"),
-    }
-    flow.async_create_entry = lambda **kwargs: {  # type: ignore[assignment]
-        "type": "create_entry",
-        "title": kwargs.get("title"),
-        "data": kwargs.get("data"),
-    }
-    flow.async_abort = lambda **kwargs: {  # type: ignore[assignment]
-        "type": "abort",
-        "reason": kwargs.get("reason"),
-    }
-    flow._schedule_reload = lambda: None  # type: ignore[assignment]
-    _patch_entry(flow, entry)
-    return flow
 
 
 @pytest.mark.asyncio
@@ -384,6 +364,80 @@ async def test_stt_provider_flow_local_unreachable_server(
     result = await flow.async_step_credentials({"base_url": "http://down-box:8000"})
     assert result.get("type") == "form"
     assert (result.get("errors") or {}).get("base") == "cannot_connect"
+    # The re-shown form keeps what was just typed — retrying against a booting
+    # server must not demand retyping the URL.
+    assert _schema_marker(result, "base_url").default() == "http://down-box:8000"
+
+
+@pytest.mark.asyncio
+async def test_stt_provider_flow_switch_to_local_resets_openai_state(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Reconfiguring openai -> local carries no key, model, or stale title across.
+
+    The stored OpenAI secret must never prefill the local server's optional key
+    field (it would be sent as a bearer token to a plaintext LAN endpoint), the
+    OpenAI model name must not become the local default, and an untouched
+    pre-filled name must follow the new provider type.
+    """
+    entry = DummyEntry()
+    entry.subentries["stt1"] = DummySubentry(
+        "stt1",
+        SUBENTRY_TYPE_STT_PROVIDER,
+        "STT - OpenAI",
+        {
+            "provider_type": "openai",
+            "name": "STT - OpenAI",
+            "settings": {
+                "api_key": "sk-proj-real",
+                "openai_provider_subentry_id": None,
+            },
+            "model": {"model_name": "gpt-4o-mini-transcribe"},
+        },
+    )
+    flow = _make_stt_flow(hass, entry)
+    cast("Any", flow)._subentry_id = "stt1"
+
+    async def _noop_validate(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(
+        "custom_components.home_generative_agent.flows.stt_provider_subentry_flow.validate_openai_compatible_url",
+        _noop_validate,
+    )
+
+    first = await flow.async_step_user()
+    assert first.get("type") == "form"
+
+    # Submit the pre-filled name untouched, as a user tabbing past it would.
+    second = await flow.async_step_provider(
+        {"provider_type": "local", "name": "STT - OpenAI"}
+    )
+    assert second.get("type") == "form"
+    key_marker = _schema_marker(second, "api_key")
+    assert key_marker.default() == ""
+    assert (key_marker.description or {}).get("suggested_value") is None
+
+    third = await flow.async_step_credentials({"base_url": "http://box:8000"})
+    assert third.get("type") == "form"
+    assert _schema_marker(third, "model_name").default() == (
+        "Systran/faster-whisper-large-v3-turbo"
+    )
+
+    result = await flow.async_step_model(
+        {"model_name": "Systran/faster-whisper-large-v3-turbo"}
+    )
+    assert result.get("type") == "update_entry"
+    result_data = result.get("data")
+    assert result_data is not None
+    assert result_data["provider_type"] == "local"
+    assert result_data["name"] == "STT - Local"
+    assert result_data["settings"] == {
+        "base_url": "http://box:8000/v1",
+        "api_key": None,
+        "openai_provider_subentry_id": None,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/custom_components/home_generative_agent/test_subentries.py
+++ b/tests/custom_components/home_generative_agent/test_subentries.py
@@ -305,6 +305,87 @@ async def test_stt_provider_flow_uses_separate_key(
     assert result_data["settings"]["openai_provider_subentry_id"] is None
 
 
+def _make_stt_flow(hass: HomeAssistant, entry: DummyEntry) -> SttProviderSubentryFlow:
+    """Build an STT subentry flow with the usual test doubles attached."""
+    flow = SttProviderSubentryFlow()
+    flow.hass = hass
+    flow.async_show_form = lambda **kwargs: {  # type: ignore[assignment]
+        "type": "form",
+        "data_schema": kwargs["data_schema"],
+        "errors": kwargs.get("errors"),
+    }
+    flow.async_create_entry = lambda **kwargs: {  # type: ignore[assignment]
+        "type": "create_entry",
+        "title": kwargs.get("title"),
+        "data": kwargs.get("data"),
+    }
+    flow.async_abort = lambda **kwargs: {  # type: ignore[assignment]
+        "type": "abort",
+        "reason": kwargs.get("reason"),
+    }
+    flow._schedule_reload = lambda: None  # type: ignore[assignment]
+    _patch_entry(flow, entry)
+    return flow
+
+
+@pytest.mark.asyncio
+async def test_stt_provider_flow_local_keyless(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Local STT flow stores a normalized base URL and no key or linked provider."""
+    flow = _make_stt_flow(hass, DummyEntry())
+
+    async def _noop_validate(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(
+        "custom_components.home_generative_agent.flows.stt_provider_subentry_flow.validate_openai_compatible_url",
+        _noop_validate,
+    )
+
+    second = await flow.async_step_provider(
+        {"provider_type": "local", "name": "STT - Local"}
+    )
+    assert second.get("type") == "form"
+
+    # Entered without /v1 on purpose: normalization must add it.
+    third = await flow.async_step_credentials({"base_url": "http://ollama-box:8000"})
+    assert third.get("type") == "form"
+
+    result = await flow.async_step_model(
+        {"model_name": "Systran/faster-whisper-large-v3-turbo"}
+    )
+    assert result.get("type") == "create_entry"
+    result_data = result.get("data")
+    assert result_data is not None
+    assert result_data["provider_type"] == "local"
+    assert result_data["settings"]["base_url"] == "http://ollama-box:8000/v1"
+    assert result_data["settings"]["api_key"] is None
+    assert result_data["settings"]["openai_provider_subentry_id"] is None
+    assert result_data["model"]["model_name"] == "Systran/faster-whisper-large-v3-turbo"
+
+
+@pytest.mark.asyncio
+async def test_stt_provider_flow_local_unreachable_server(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unreachable local server keeps the user on the credentials form."""
+    flow = _make_stt_flow(hass, DummyEntry())
+
+    async def _fail_validate(*_args: Any, **_kwargs: Any) -> None:
+        raise CannotConnectError
+
+    monkeypatch.setattr(
+        "custom_components.home_generative_agent.flows.stt_provider_subentry_flow.validate_openai_compatible_url",
+        _fail_validate,
+    )
+
+    await flow.async_step_provider({"provider_type": "local", "name": "STT - Local"})
+    result = await flow.async_step_credentials({"base_url": "http://down-box:8000"})
+    assert result.get("type") == "form"
+    assert (result.get("errors") or {}).get("base") == "cannot_connect"
+
+
 @pytest.mark.asyncio
 async def test_sentinel_subentry_flow_hashes_level_increase_pin(
     hass: HomeAssistant,


### PR DESCRIPTION
## Summary

The STT subentry flow has offered **Local (coming soon)** since STT shipped; it errored with `not_supported`. This PR activates it, so any OpenAI-compatible transcription server — e.g. [Speaches](https://speaches.ai/) running faster-whisper on the same GPU box as Ollama — can serve Assist speech-to-text fully locally.

## Changes

- **Flow** (`flows/stt_provider_subentry_flow.py`): local providers take a server URL (normalized to end in `/v1`, validated against `/v1/models` on submit via the existing `validate_openai_compatible_url`) and an optional API key. The model step becomes free-text for local (server model IDs are not enumerable), defaulting to `Systran/faster-whisper-large-v3-turbo`. The OpenAI path is unchanged, including linked-provider reuse.
- **Entity** (`stt.py`): accepts `provider_type: local`, passes the base URL to the SDK, and keys the cached client on `(api_key, base_url)` — the exact extension the `_get_client` docstring prescribed. Keyless servers get a placeholder key the SDK insists on. Connection resolution is extracted into `_resolve_connection`.
- **Translate**: local providers use `/audio/translations` for any model when translate is on (faster-whisper serves it for all whisper models); OpenAI keeps the `whisper-1`-only gate.
- **Translations**: `strings.json` + en/cs/ru/tr get the `base_url` field, provider-neutral `api_key` label, and `data_description` hints.
- **Docs**: README feature row; `docs/configuration.md` gains local STT setup with a Speaches compose example and a pointer to the Speech input filters for whisper's silence hallucinations ("Thank you.").

## Tests

- 7 new entity tests: base_url/placeholder-key client construction, configured-key precedence, missing-base_url soft-fail, cache rebuild on base_url change, cache reuse, local default model, local translate routing.
- 2 new flow tests: keyless local create path with URL normalization, unreachable-server error handling.
- Full suite: 2990 passed; ruff + pyright clean.

## Follow-up

PR B (planned): a `tts.py` platform + `tts_provider` subentry speaking the OpenAI `/v1/audio/speech` API, so one Speaches container serves both directions of a fully local voice pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThzYKhWyrZugjiKv8Tm5WV