### PR TITLE
fix: follow core's OpenAPI schema converter, gone missing on HA 2026.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Most AI conversation integrations are prompt passthroughs: they forward your wor
 
 | Requirement | Notes |
 | --- | --- |
-| Home Assistant | 2025.5.0 minimum; 2026.4.0+ for streaming responses |
+| Home Assistant | 2025.5.0 minimum; 2026.4.0+ for streaming responses; 2026.9 (probatio schema core) supported |
 | HACS | Required for the recommended install path; manual install is also supported |
 | PostgreSQL with pgvector | Provided as a bundled HA app (step 1 below) |
 | Model provider | At least one of: OpenAI, Gemini, Anthropic, Ollama, or any OpenAI-compatible server |

--- a/custom_components/home_generative_agent/agent/graph.py
+++ b/custom_components/home_generative_agent/agent/graph.py
@@ -1370,6 +1370,36 @@ def _append_requirement_hint(
     }
 
 
+def _strip_additional_properties(schema: dict[str, Any]) -> dict[str, Any]:
+    """
+    Remove ``additionalProperties`` keys from a tool schema, recursively.
+
+    Probatio's ``to_openapi`` (the converter on HA 2026.9 cores) emits
+    ``additionalProperties: false`` on every closed object schema —
+    voluptuous-openapi never did. langchain-google-genai marshals tool
+    schemas into the gapic ``Schema`` proto, which has no such field, and
+    logs a WARNING per unrecognised key, so on a 2026.9 core every Gemini
+    turn floods the HA log with one warning per bound tool. The key is
+    purely advisory for Gemini (the proto cannot express it either way), so
+    stripping loses nothing. Gated to Gemini in
+    ``_format_and_dedupe_tools()`` because other providers accept the key —
+    OpenAI's strict mode even requires it.
+    """
+
+    def _strip(node: Any) -> Any:
+        if isinstance(node, dict):
+            return {
+                key: _strip(value)
+                for key, value in node.items()
+                if key != "additionalProperties"
+            }
+        if isinstance(node, list):
+            return [_strip(item) for item in node]
+        return node
+
+    return _strip(schema)
+
+
 def _sanitize_any_of_required(schema: dict[str, Any]) -> dict[str, Any]:
     """
     Recursively strip ``required`` entries that Gemini's validation rejects.
@@ -1500,11 +1530,14 @@ def _flatten_top_level_union(schema: dict[str, Any]) -> dict[str, Any]:
     ``_FLATTEN_UNION_PROVIDERS``.
 
     Scope: only the union keywords are handled, and only variant
-    ``properties``/``required`` survive the merge. voluptuous_openapi always
-    wraps tool schemas in a top-level object, so OpenAI's other forbidden
-    top-level keywords (enum/const/not) and richer variant keywords
-    (additionalProperties, dependentRequired, discriminator const, ...)
-    never occur in this pipeline's input and are deliberately not handled.
+    ``properties``/``required`` survive the merge. Both converters wrap tool
+    schemas in a top-level object, so OpenAI's other forbidden top-level
+    keywords (enum/const/not) and richer variant keywords (dependentRequired,
+    discriminator const, ...) never occur in this pipeline's input and are
+    deliberately not handled. ``additionalProperties`` is the exception:
+    probatio (HA 2026.9) emits it on every closed object, and
+    ``_strip_additional_properties()`` removes it for Gemini in
+    ``_format_and_dedupe_tools()``.
     """
     merged_keys = [k for k in _TOP_LEVEL_UNION_KEYS if isinstance(schema.get(k), list)]
     if not merged_keys:
@@ -1600,6 +1633,7 @@ def _format_and_dedupe_tools(
         # for providers that can honour it — so it is gated on the provider.
         if provider == "gemini":
             parameters = _sanitize_any_of_required(parameters)
+            parameters = _strip_additional_properties(parameters)
         selected_tools.append(
             {
                 "type": "function",

--- a/custom_components/home_generative_agent/agent/helpers.py
+++ b/custom_components/home_generative_agent/agent/helpers.py
@@ -13,7 +13,21 @@ import voluptuous as vol
 from homeassistant.const import CONF_LLM_HASS_API
 from homeassistant.helpers import llm
 from homeassistant.util import ulid
-from voluptuous_openapi import UNSUPPORTED, convert
+
+# Home Assistant 2026.9 swapped voluptuous for probatio and voluptuous-openapi
+# for probatio's ``to_openapi``, aliasing probatio under the ``voluptuous`` name
+# (``install_as_voluptuous()`` in ``homeassistant/__init__.py``) for everything
+# that still imports voluptuous -- ``vol`` above included. The converter has to
+# match the library the schemas actually come from, since neither one renders
+# the other's ``Schema``, so let ``vol`` say which core this is. Neither library
+# is declared in our manifest on purpose: core installs exactly the one it uses.
+if vol.Schema.__module__.startswith("probatio"):
+    from probatio import UNSUPPORTED  # pyright: ignore[reportMissingImports]
+    from probatio import (  # pyright: ignore[reportMissingImports]
+        to_openapi as convert,
+    )
+else:  # Home Assistant <= 2026.8
+    from voluptuous_openapi import UNSUPPORTED, convert
 
 from custom_components.home_generative_agent.const import (
     ACTUATION_LANGCHAIN_TOOLS,
@@ -33,6 +47,24 @@ if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
 LOGGER = logging.getLogger(__name__)
+
+# Home Assistant's own serializers (``llm.selector_serializer`` and the
+# ``custom_serializer`` an APIInstance carries) return the sentinel of the
+# library core was built against. That is the one imported above on every
+# supported core, but the two are compared by identity, and a mismatch would
+# read "I cannot render this" as a rendered schema, so accept either. What we
+# hand back stays ours, so the converter in use recognises it.
+_CORE_UNSUPPORTED = getattr(llm, "UNSUPPORTED", UNSUPPORTED)
+_UNSUPPORTED_SENTINELS: tuple[Any, ...] = (
+    (UNSUPPORTED,)
+    if _CORE_UNSUPPORTED is UNSUPPORTED
+    else (UNSUPPORTED, _CORE_UNSUPPORTED)
+)
+
+
+def _is_unsupported(value: Any) -> bool:
+    """Return True if a serializer deferred rather than returning a schema."""
+    return any(value is sentinel for sentinel in _UNSUPPORTED_SENTINELS)
 
 
 def active_llm_api_ids(options: Mapping[str, Any]) -> list[str]:
@@ -245,7 +277,7 @@ def safe_convert(
 
     def robust_serializer(obj: Any) -> Any:
         """Robustly handle HA types that might be unhashable or need mapping."""
-        # 0. Skip basic types that voluptuous_openapi handles natively.
+        # 0. Skip basic types that the schema converter handles natively.
         # vol.Schema, dict, and list are unhashable but handled by the library.
         if isinstance(obj, (vol.Schema, dict, list)):
             return UNSUPPORTED
@@ -256,7 +288,7 @@ def safe_convert(
                 res = custom_serializer(obj)
                 # If external serializer returns non-None/UNSUPPORTED, use it.
                 # Some HA serializers might return None for unhandled types.
-                if res is not None and res is not UNSUPPORTED:
+                if res is not None and not _is_unsupported(res):
                     return res
             except Exception:  # noqa: BLE001, S110
                 # Fallback to the robust serializer if custom_serializer fails.
@@ -279,7 +311,7 @@ def safe_convert(
         if hasattr(obj, "config") or (isinstance(obj, dict) and "selector" in obj):
             return {"type": "string"}
 
-        # 4. General unhashable safety net to prevent voluptuous_openapi crash
+        # 4. General unhashable safety net to prevent a converter crash
         try:
             hash(obj)
         except TypeError:

--- a/custom_components/home_generative_agent/agent/helpers.py
+++ b/custom_components/home_generative_agent/agent/helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 import logging
 import re
 from dataclasses import replace
@@ -13,21 +14,6 @@ import voluptuous as vol
 from homeassistant.const import CONF_LLM_HASS_API
 from homeassistant.helpers import llm
 from homeassistant.util import ulid
-
-# Home Assistant 2026.9 swapped voluptuous for probatio and voluptuous-openapi
-# for probatio's ``to_openapi``, aliasing probatio under the ``voluptuous`` name
-# (``install_as_voluptuous()`` in ``homeassistant/__init__.py``) for everything
-# that still imports voluptuous -- ``vol`` above included. The converter has to
-# match the library the schemas actually come from, since neither one renders
-# the other's ``Schema``, so let ``vol`` say which core this is. Neither library
-# is declared in our manifest on purpose: core installs exactly the one it uses.
-if vol.Schema.__module__.startswith("probatio"):
-    from probatio import UNSUPPORTED  # pyright: ignore[reportMissingImports]
-    from probatio import (  # pyright: ignore[reportMissingImports]
-        to_openapi as convert,
-    )
-else:  # Home Assistant <= 2026.8
-    from voluptuous_openapi import UNSUPPORTED, convert
 
 from custom_components.home_generative_agent.const import (
     ACTUATION_LANGCHAIN_TOOLS,
@@ -48,18 +34,67 @@ if TYPE_CHECKING:
 
 LOGGER = logging.getLogger(__name__)
 
-# Home Assistant's own serializers (``llm.selector_serializer`` and the
-# ``custom_serializer`` an APIInstance carries) return the sentinel of the
-# library core was built against. That is the one imported above on every
-# supported core, but the two are compared by identity, and a mismatch would
-# read "I cannot render this" as a rendered schema, so accept either. What we
-# hand back stays ours, so the converter in use recognises it.
-_CORE_UNSUPPORTED = getattr(llm, "UNSUPPORTED", UNSUPPORTED)
-_UNSUPPORTED_SENTINELS: tuple[Any, ...] = (
-    (UNSUPPORTED,)
-    if _CORE_UNSUPPORTED is UNSUPPORTED
-    else (UNSUPPORTED, _CORE_UNSUPPORTED)
-)
+
+def _resolve_converter() -> tuple[Any, Any]:
+    """
+    Return the (converter, deferral sentinel) pair matching the running core.
+
+    Home Assistant 2026.9 swapped voluptuous for probatio and
+    voluptuous-openapi for probatio's ``to_openapi``, aliasing probatio under
+    the ``voluptuous`` name (``install_as_voluptuous()`` in
+    ``homeassistant/__init__.py``) for everything that still imports
+    voluptuous — ``vol`` here included. The converter has to match the
+    library the schemas actually come from, since neither one renders the
+    other's ``Schema``. Core's ``llm`` helper imports exactly the pair the
+    running core was built against (``convert`` + ``UNSUPPORTED`` from
+    voluptuous-openapi on <= 2026.8; ``to_openapi`` + ``UNSUPPORTED`` from
+    probatio on 2026.9+), so prefer those re-exports — they cannot diverge
+    from core by construction, where sniffing ``vol.Schema.__module__``
+    breaks the day probatio stamps a voluptuous-compatible ``__module__`` on
+    its shim. The sniff survives only as a fallback for a core that stops
+    re-exporting them. Neither library is declared in our manifest on
+    purpose: core installs exactly the one it uses.
+    """
+    core_convert = getattr(llm, "to_openapi", None) or getattr(llm, "convert", None)
+    core_unsupported = getattr(llm, "UNSUPPORTED", None)
+    if core_convert is not None and core_unsupported is not None:
+        return core_convert, core_unsupported
+    if vol.Schema.__module__.startswith("probatio"):
+        module = importlib.import_module("probatio")
+        return module.to_openapi, module.UNSUPPORTED
+    module = importlib.import_module("voluptuous_openapi")
+    return module.convert, module.UNSUPPORTED
+
+
+convert, UNSUPPORTED = _resolve_converter()
+
+
+def _collect_unsupported_sentinels() -> tuple[Any, ...]:
+    """
+    Return every deferral sentinel a serializer might hand back.
+
+    ``UNSUPPORTED`` above is core's own, but ``APIInstance.custom_serializer``
+    is a public field a third-party ``llm.API`` can set with a serializer
+    built against the sibling library — pip does not uninstall
+    voluptuous-openapi when a core upgrade brings probatio — and sentinels
+    compare by identity, so a foreign one would read "I cannot render this"
+    as a rendered schema. Accept the sentinel of every importable converter
+    library; what we hand back stays ours, so the converter in use always
+    recognises it.
+    """
+    sentinels: list[Any] = [UNSUPPORTED]
+    for module_name in ("voluptuous_openapi", "probatio"):
+        try:
+            module = importlib.import_module(module_name)
+        except ImportError:
+            continue
+        sentinel = getattr(module, "UNSUPPORTED", None)
+        if sentinel is not None and all(sentinel is not seen for seen in sentinels):
+            sentinels.append(sentinel)
+    return tuple(sentinels)
+
+
+_UNSUPPORTED_SENTINELS: tuple[Any, ...] = _collect_unsupported_sentinels()
 
 
 def _is_unsupported(value: Any) -> bool:

--- a/tests/custom_components/home_generative_agent/test_graph_helpers.py
+++ b/tests/custom_components/home_generative_agent/test_graph_helpers.py
@@ -183,6 +183,49 @@ def test_format_and_dedupe_tools_gemini_array_items_injected() -> None:
     assert domain_schema["items"] == {"type": "string"}
 
 
+# The shape probatio's to_openapi emits on HA 2026.9: additionalProperties:
+# false on every closed object, at every nesting level. langchain-google-genai
+# logs a WARNING per unrecognised key when marshaling to the gapic proto, so
+# for Gemini the key must be stripped everywhere; other providers accept it.
+_CLOSED_OBJECT_SCHEMA = (
+    '{"type": "object", "additionalProperties": false, "properties": {'
+    '"target": {"type": "object", "additionalProperties": false, '
+    '"properties": {"name": {"type": "string"}}}}}'
+)
+
+
+def _closed_tool() -> list:
+    """Build a raw tool carrying a probatio-style closed-object schema."""
+    return [
+        {
+            "name": "HassTurnOn",
+            "api_id": "test",
+            "description": "Turns on a device",
+            "parameters": _CLOSED_OBJECT_SCHEMA,
+            "is_actuation": True,
+        }
+    ]
+
+
+def test_format_and_dedupe_tools_gemini_strips_additional_properties() -> None:
+    """Gemini: additionalProperties is removed at every nesting level."""
+    selected, _ = _format_and_dedupe_tools(_closed_tool(), provider="gemini")
+    parameters = selected[0]["function"]["parameters"]
+    assert "additionalProperties" not in parameters
+    target = parameters["properties"]["target"]
+    assert "additionalProperties" not in target
+    assert target["properties"] == {"name": {"type": "string"}}
+
+
+def test_format_and_dedupe_tools_keeps_additional_properties_elsewhere() -> None:
+    """Non-Gemini providers keep additionalProperties (OpenAI strict needs it)."""
+    for provider in ("openai", "anthropic", "ollama", None):
+        selected, _ = _format_and_dedupe_tools(_closed_tool(), provider=provider)
+        parameters = selected[0]["function"]["parameters"]
+        assert parameters["additionalProperties"] is False
+        assert parameters["properties"]["target"]["additionalProperties"] is False
+
+
 # The shape voluptuous_openapi emits for Home Assistant's "at least one target"
 # pattern, vol.Required(vol.Any("name", "area", "floor")): parent-level
 # properties plus bare-'required' anyOf variants. Valid JSON Schema; only

--- a/tests/custom_components/home_generative_agent/test_openapi_backend.py
+++ b/tests/custom_components/home_generative_agent/test_openapi_backend.py
@@ -1,0 +1,96 @@
+# ruff: noqa: S101
+"""
+Tests for picking the OpenAPI schema converter.
+
+Home Assistant 2026.9 swapped voluptuous-openapi for probatio and aliased
+probatio under the ``voluptuous`` name, so the converter has to follow whichever
+library the running core builds its schemas with.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from types import ModuleType
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+import voluptuous_openapi
+from homeassistant.helpers import llm
+
+from custom_components.home_generative_agent.agent import helpers
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    import pytest
+
+# Core re-exports the sentinel of whichever converter library it was built
+# against, and that is exactly the object its own serializers hand back.
+_CORE_UNSUPPORTED: Any = llm.UNSUPPORTED  # pyright: ignore[reportPrivateImportUsage]
+
+
+class _Opaque:
+    """A hashable object no branch of the robust serializer claims."""
+
+
+def test_voluptuous_openapi_is_used_on_a_voluptuous_core() -> None:
+    """A core whose ``vol`` is real voluptuous renders with voluptuous-openapi."""
+    assert not vol.Schema.__module__.startswith("probatio")
+    assert helpers.convert is voluptuous_openapi.convert
+    assert helpers.UNSUPPORTED is voluptuous_openapi.UNSUPPORTED
+
+
+def test_core_sentinel_counts_as_a_deferral() -> None:
+    """Core's own sentinel is recognised even if it comes from the other lib."""
+    assert helpers._is_unsupported(helpers.UNSUPPORTED)
+    assert helpers._is_unsupported(_CORE_UNSUPPORTED)
+    assert not helpers._is_unsupported({"type": "string"})
+    assert not helpers._is_unsupported(None)
+
+
+def test_probatio_is_used_when_core_aliases_it_as_voluptuous(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 2026.9 core renders with probatio, and foreign sentinels still defer."""
+    probatio = ModuleType("probatio")
+    probatio.UNSUPPORTED = object()  # type: ignore[attr-defined]
+    seen: list[Callable[[Any], Any]] = []
+
+    def to_openapi(
+        schema: Any,  # noqa: ARG001
+        *,
+        custom_serializer: Callable[[Any], Any] | None = None,
+    ) -> dict[str, Any]:
+        if custom_serializer is not None:
+            seen.append(custom_serializer)
+        return {"type": "object"}
+
+    probatio.to_openapi = to_openapi  # type: ignore[attr-defined]
+
+    class _ProbatioSchema:
+        """Stand-in for the ``Schema`` core's aliased ``voluptuous`` exposes."""
+
+    _ProbatioSchema.__module__ = "probatio.schema"
+    aliased_vol = ModuleType("voluptuous")
+    aliased_vol.Schema = _ProbatioSchema  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "probatio", probatio)
+    monkeypatch.setitem(sys.modules, "voluptuous", aliased_vol)
+    importlib.reload(helpers)
+    try:
+        assert helpers.convert is probatio.to_openapi
+        assert helpers.UNSUPPORTED is probatio.UNSUPPORTED
+
+        # A serializer built against the *other* library hands back its own
+        # sentinel; treating that as a rendered schema would corrupt the tool.
+        helpers.safe_convert(
+            _ProbatioSchema(), custom_serializer=lambda _obj: _CORE_UNSUPPORTED
+        )
+        robust = seen[-1]
+        assert robust(_Opaque()) is probatio.UNSUPPORTED
+    finally:
+        monkeypatch.undo()
+        importlib.reload(helpers)
+
+    assert helpers.convert is voluptuous_openapi.convert

--- a/tests/custom_components/home_generative_agent/test_openapi_backend.py
+++ b/tests/custom_components/home_generative_agent/test_openapi_backend.py
@@ -4,7 +4,13 @@ Tests for picking the OpenAPI schema converter.
 
 Home Assistant 2026.9 swapped voluptuous-openapi for probatio and aliased
 probatio under the ``voluptuous`` name, so the converter has to follow whichever
-library the running core builds its schemas with.
+library the running core builds its schemas with. ``helpers`` prefers core's
+own ``llm`` re-exports (which cannot diverge from core) and falls back to
+sniffing ``vol.Schema.__module__`` on a core that stops re-exporting them.
+
+These tests must collect and pass on BOTH cores: nothing here may import
+voluptuous_openapi or probatio at module level — whichever one the running
+core was not built against may be absent from the environment.
 """
 
 from __future__ import annotations
@@ -14,8 +20,8 @@ import sys
 from types import ModuleType
 from typing import TYPE_CHECKING, Any
 
+import pytest
 import voluptuous as vol
-import voluptuous_openapi
 from homeassistant.helpers import llm
 
 from custom_components.home_generative_agent.agent import helpers
@@ -23,22 +29,43 @@ from custom_components.home_generative_agent.agent import helpers
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    import pytest
-
 # Core re-exports the sentinel of whichever converter library it was built
 # against, and that is exactly the object its own serializers hand back.
 _CORE_UNSUPPORTED: Any = llm.UNSUPPORTED  # pyright: ignore[reportPrivateImportUsage]
+
+_IS_PROBATIO_CORE = vol.Schema.__module__.startswith("probatio")
 
 
 class _Opaque:
     """A hashable object no branch of the robust serializer claims."""
 
 
+def test_converter_and_sentinel_match_core_llm_exports() -> None:
+    """On any supported core, the converter pair is core's own re-exports."""
+    core_convert = getattr(llm, "to_openapi", None) or getattr(llm, "convert", None)
+    assert core_convert is not None
+    assert helpers.convert is core_convert
+    assert helpers.UNSUPPORTED is _CORE_UNSUPPORTED
+
+
+@pytest.mark.skipif(
+    _IS_PROBATIO_CORE, reason="core is probatio; the voluptuous-openapi path is n/a"
+)
 def test_voluptuous_openapi_is_used_on_a_voluptuous_core() -> None:
     """A core whose ``vol`` is real voluptuous renders with voluptuous-openapi."""
-    assert not vol.Schema.__module__.startswith("probatio")
+    voluptuous_openapi = pytest.importorskip("voluptuous_openapi")
     assert helpers.convert is voluptuous_openapi.convert
     assert helpers.UNSUPPORTED is voluptuous_openapi.UNSUPPORTED
+
+
+@pytest.mark.skipif(
+    not _IS_PROBATIO_CORE, reason="core is voluptuous; the probatio path is n/a"
+)
+def test_probatio_is_used_on_a_probatio_core() -> None:
+    """A 2026.9 core renders with probatio's ``to_openapi``."""
+    probatio = pytest.importorskip("probatio")
+    assert helpers.convert is probatio.to_openapi
+    assert helpers.UNSUPPORTED is probatio.UNSUPPORTED
 
 
 def test_core_sentinel_counts_as_a_deferral() -> None:
@@ -49,10 +76,29 @@ def test_core_sentinel_counts_as_a_deferral() -> None:
     assert not helpers._is_unsupported(None)
 
 
-def test_probatio_is_used_when_core_aliases_it_as_voluptuous(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A 2026.9 core renders with probatio, and foreign sentinels still defer."""
+def test_sibling_library_sentinel_counts_as_a_deferral() -> None:
+    """
+    The sentinel of every importable converter library is accepted.
+
+    A third-party ``APIInstance.custom_serializer`` can be built against the
+    sibling library (pip does not uninstall voluptuous-openapi when a core
+    upgrade brings probatio); its sentinel must read as a deferral, not as a
+    rendered schema.
+    """
+    for module_name in ("voluptuous_openapi", "probatio"):
+        module = sys.modules.get(module_name)
+        if module is None:
+            try:
+                module = importlib.import_module(module_name)
+            except ImportError:
+                continue
+        sentinel = getattr(module, "UNSUPPORTED", None)
+        if sentinel is not None:
+            assert helpers._is_unsupported(sentinel)
+
+
+def _fake_probatio_core() -> tuple[ModuleType, ModuleType, list[Callable[[Any], Any]]]:
+    """Build fake ``probatio`` and aliased ``voluptuous`` modules."""
     probatio = ModuleType("probatio")
     probatio.UNSUPPORTED = object()  # type: ignore[attr-defined]
     seen: list[Callable[[Any], Any]] = []
@@ -74,18 +120,62 @@ def test_probatio_is_used_when_core_aliases_it_as_voluptuous(
     _ProbatioSchema.__module__ = "probatio.schema"
     aliased_vol = ModuleType("voluptuous")
     aliased_vol.Schema = _ProbatioSchema  # type: ignore[attr-defined]
+    return probatio, aliased_vol, seen
 
-    monkeypatch.setitem(sys.modules, "probatio", probatio)
-    monkeypatch.setitem(sys.modules, "voluptuous", aliased_vol)
-    importlib.reload(helpers)
+
+def test_llm_exports_win_over_the_module_sniff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Core's ``llm`` re-exports beat the ``__module__`` heuristic.
+
+    This is the divergence-proofing: even if a future probatio stamps a
+    voluptuous-compatible ``__module__`` on its shim (or vice versa), the
+    converter still matches core because it IS core's.
+    """
+    probatio, aliased_vol, _seen = _fake_probatio_core()
     try:
+        # The reload sits inside the try: if it raises partway, the finally
+        # still restores a coherent helpers module for the rest of the session.
+        monkeypatch.setitem(sys.modules, "probatio", probatio)
+        monkeypatch.setitem(sys.modules, "voluptuous", aliased_vol)
+        importlib.reload(helpers)
+        core_convert = getattr(llm, "to_openapi", None) or getattr(llm, "convert", None)
+        assert helpers.convert is core_convert
+        assert helpers.UNSUPPORTED is _CORE_UNSUPPORTED
+        # The fake probatio's sentinel is importable, so it is accepted too.
+        assert helpers._is_unsupported(probatio.UNSUPPORTED)
+    finally:
+        monkeypatch.undo()
+        importlib.reload(helpers)
+
+    assert helpers.UNSUPPORTED is _CORE_UNSUPPORTED
+
+
+def test_module_sniff_fallback_when_llm_stops_reexporting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Without the ``llm`` re-exports, the sniff picks the aliasing library.
+
+    Foreign sentinels still defer: a serializer built against the *other*
+    library hands back its own sentinel, and treating that as a rendered
+    schema would corrupt the tool.
+    """
+    probatio, aliased_vol, seen = _fake_probatio_core()
+    try:
+        monkeypatch.setitem(sys.modules, "probatio", probatio)
+        monkeypatch.setitem(sys.modules, "voluptuous", aliased_vol)
+        monkeypatch.delattr(llm, "convert", raising=False)
+        monkeypatch.delattr(llm, "to_openapi", raising=False)
+        monkeypatch.delattr(llm, "UNSUPPORTED", raising=False)
+        importlib.reload(helpers)
         assert helpers.convert is probatio.to_openapi
         assert helpers.UNSUPPORTED is probatio.UNSUPPORTED
 
-        # A serializer built against the *other* library hands back its own
-        # sentinel; treating that as a rendered schema would corrupt the tool.
         helpers.safe_convert(
-            _ProbatioSchema(), custom_serializer=lambda _obj: _CORE_UNSUPPORTED
+            aliased_vol.Schema(),  # type: ignore[attr-defined]
+            custom_serializer=lambda _obj: _CORE_UNSUPPORTED,
         )
         robust = seen[-1]
         assert robust(_Opaque()) is probatio.UNSUPPORTED
@@ -93,4 +183,4 @@ def test_probatio_is_used_when_core_aliases_it_as_voluptuous(
         monkeypatch.undo()
         importlib.reload(helpers)
 
-    assert helpers.convert is voluptuous_openapi.convert
+    assert helpers.UNSUPPORTED is _CORE_UNSUPPORTED


### PR DESCRIPTION
Home Assistant 2026.9 swapped voluptuous for probatio: core aliases probatio under the ``voluptuous`` name (``install_as_voluptuous()`` in ``homeassistant/__init__.py``), renders schemas with probatio's ``to_openapi``, and voluptuous-openapi is gone from core's requirements.txt and package_constraints.txt. We imported voluptuous_openapi directly and never declared it -- it only ever resolved because core happened to install it -- so setup on 2026.9 dies with "No module named 'voluptuous_openapi'" before the integration loads at all (#599).

The converter is now chosen by what ``vol`` itself resolves to, because neither library renders the other's ``Schema``: probatio's ``to_openapi`` raises TypeError on a voluptuous ``Schema``, so "probatio if it imports" would break a 2026.8 install that has probatio present for any other reason. Neither library is added to the manifest on purpose: core installs exactly the one it uses, and pulling in the other would run a second copy of the schema machinery core is not using.

The UNSUPPORTED sentinel gets the same care. The ``custom_serializer`` an APIInstance carries is core's own ``llm.selector_serializer``, which returns the sentinel of the library core was built against; that sentinel is compared by identity, and reading it as a rendered schema would hand the model a corrupt tool, so a deferral from either library is now recognised.

Verified against both arrangements: with probatio aliased as ``voluptuous``, a schema carrying selectors, vol.All/Coerce/Range and a vol.Any-keyed requirement renders identically to the voluptuous-openapi output apart from probatio's own ``additionalProperties: false``.


Claude-Session: https://claude.ai/code/session_01PgsmNkdiXf3YvmUk9TMBFi