### PR TITLE
fix(stt): keyless local servers fail on openai>=2.45; switch default local model

### DIFF
--- a/custom_components/home_generative_agent/const.py
+++ b/custom_components/home_generative_agent/const.py
@@ -427,12 +427,18 @@ STT_RESPONSE_FORMATS = ("text", "json", "verbose_json", "srt", "vtt")
 # Local (OpenAI-compatible) STT provider, e.g. Speaches serving faster-whisper.
 CONF_STT_BASE_URL = "base_url"
 # Speaches model ID; the flow accepts any custom value, this is only a default.
-RECOMMENDED_LOCAL_STT_MODEL = "Systran/faster-whisper-large-v3-turbo"
-# Keyless local servers get an empty key: the SDK accepts it and then sends
-# no Authorization header at all, matching the flow's validation request. A
-# fabricated placeholder would send a bogus bearer token that auth proxies
-# (e.g. LiteLLM virtual keys) reject even though validation passed.
-LOCAL_STT_KEYLESS_API_KEY = ""
+# Systran's large-v3-turbo repo went private on Hugging Face (2026-09); this is
+# the public CTranslate2 conversion of the same weights, tagged so Speaches'
+# registry accepts it.
+RECOMMENDED_LOCAL_STT_MODEL = "deepdml/faster-whisper-large-v3-turbo-ct2"
+# Keyless local servers get a placeholder key, NOT an empty one: openai>=2.45
+# (the version HA 2026.8+ ships) rejects an empty api_key in the constructor
+# with "Missing credentials". The placeholder never reaches the wire — the
+# runtime strips the Authorization header per request with the SDK's ``Omit``
+# sentinel, matching the flow's keyless validation request. A bogus bearer
+# would be rejected by auth proxies (e.g. LiteLLM virtual keys) even though
+# validation passed.
+LOCAL_STT_KEYLESS_API_KEY = "sk-hga-keyless-local"
 
 # ---------------- Chat model ----------------
 CHAT_MODEL_TOP_P = 1.0

--- a/custom_components/home_generative_agent/stt.py
+++ b/custom_components/home_generative_agent/stt.py
@@ -18,7 +18,7 @@ from homeassistant.components.stt import (
     SpeechToTextEntity,
 )
 from homeassistant.helpers.httpx_client import get_async_client
-from openai import AsyncOpenAI, AuthenticationError, OpenAIError
+from openai import AsyncOpenAI, AuthenticationError, Omit, OpenAIError
 
 from .const import (
     CONF_STT_BASE_URL,
@@ -322,9 +322,10 @@ class HGASttEntity(SpeechToTextEntity):
         """
         Return (api_key, base_url) for the provider, or None if unconfigured.
 
-        Local providers require a base URL and fall back to an empty key —
-        which the SDK turns into no Authorization header, the same shape the
-        flow's validation request used — when the server needs none.
+        Local providers require a base URL and fall back to the keyless
+        placeholder when the server needs none. The placeholder only satisfies
+        the SDK constructor; the stream strips the Authorization header per
+        request so the wire shape matches the flow's validation request.
         """
         if provider_type == "local":
             settings = data.get("settings", {})
@@ -393,6 +394,12 @@ class HGASttEntity(SpeechToTextEntity):
             temperature,
             response_format,
         )
+        if api_key == LOCAL_STT_KEYLESS_API_KEY:
+            # Keyless local server: send no Authorization header at all. The
+            # placeholder exists only because the SDK constructor refuses an
+            # empty key; ``Omit`` drops the header the client would otherwise
+            # add from it.
+            request["extra_headers"] = {"Authorization": Omit()}
 
         # Building the client is inside the try: it now touches hass.data and
         # the SDK constructor, and a failure there should fail this utterance,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -246,7 +246,7 @@ HGA provides a built-in STT engine — no separate STT integration required. Two
    - **OpenAI:** either reuse an existing OpenAI Model Provider subentry or select **Use a separate key** and enter a dedicated API key.
    - **Local:** enter the server URL (e.g. `http://192.168.1.100:8000` — a missing `/v1` suffix is added automatically). The API key is optional; leave it blank for servers without authentication. The endpoint is validated when you submit the form.
 5. On **Model & advanced options**, pick a model and set optional fields:
-   - model: recommended `gpt-4o-mini-transcribe` (OpenAI) or `Systran/faster-whisper-large-v3-turbo` (Local; any custom model ID your server exposes can be typed in)
+   - model: recommended `gpt-4o-mini-transcribe` (OpenAI) or `deepdml/faster-whisper-large-v3-turbo-ct2` (Local; any custom model ID your server exposes can be typed in)
    - `language` (optional): e.g. `en` or `en-US`
    - `prompt` (optional): hints for domain-specific vocabulary
    - `temperature` (optional): 0–1
@@ -257,7 +257,7 @@ HGA provides a built-in STT engine — no separate STT integration required. Two
 
 ### Running a local STT server
 
-Any server exposing the OpenAI `/v1/audio/transcriptions` endpoint works. Speaches is a good fit for a GPU box already running Ollama (`faster-whisper-large-v3-turbo` needs roughly 1.5–2 GB of VRAM):
+Any server exposing the OpenAI `/v1/audio/transcriptions` endpoint works. Speaches is a good fit for a GPU box already running Ollama (`faster-whisper-large-v3-turbo` needs roughly 1.5–2 GB of VRAM). Speaches only serves models that have already been downloaded, so list the model in `PRELOAD_MODELS` (or `POST /v1/models/<model-id>` once) before the first utterance:
 
 ```yaml
 # docker-compose.yaml on the GPU box
@@ -268,6 +268,10 @@ services:
       - "8000:8000"
     volumes:
       - hf-hub-cache:/home/ubuntu/.cache/huggingface/hub
+    environment:
+      - PRELOAD_MODELS=["deepdml/faster-whisper-large-v3-turbo-ct2"]
+      - STT_MODEL_TTL=-1            # keep the model resident; the first utterance after a reload pays several seconds
+      # - WHISPER__COMPUTE_TYPE=int8_float32   # required on Pascal GPUs (GTX 10xx): float16 is not supported there
     deploy:
       resources:
         reservations:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,6 +2,9 @@
 
 homeassistant==2026.8.3
 pytest-homeassistant-custom-component==0.13.357
+# Match HA core's openai_conversation pin for this HA version: the STT platform
+# runs against core's SDK, and its constructor rules change between releases.
+openai==2.45.0
 
 pytest==9.*
 pytest-asyncio==1.*

--- a/tests/custom_components/home_generative_agent/test_stt.py
+++ b/tests/custom_components/home_generative_agent/test_stt.py
@@ -12,6 +12,8 @@ from typing import TYPE_CHECKING, Any, cast
 import httpx
 import pytest
 from homeassistant.components import stt as ha_stt
+from openai import Omit
+from openai._models import FinalRequestOptions
 
 from custom_components.home_generative_agent import stt as hga_stt
 from custom_components.home_generative_agent.const import (
@@ -735,7 +737,7 @@ def _make_local_entity(
 async def test_local_provider_builds_client_with_base_url(
     patched_client: Any,
 ) -> None:
-    """A keyless local provider gets an empty key and sends no auth header."""
+    """A keyless local provider gets the placeholder key and sends no auth header."""
     entity, _ = _make_local_entity()
     result, seen = await _run(entity, [SimpleNamespace(text="hello")])
     assert result.result == ha_stt.SpeechResultState.SUCCESS
@@ -743,12 +745,23 @@ async def test_local_provider_builds_client_with_base_url(
     assert len(patched_client["kwargs"]) == 1
     kwargs = patched_client["kwargs"][0]
     assert kwargs["base_url"] == LOCAL_BASE_URL
+    # openai>=2.45 (HA 2026.8+) raises "Missing credentials" on an empty
+    # api_key, so the constructor must always get a non-empty placeholder.
     assert kwargs["api_key"] == LOCAL_STT_KEYLESS_API_KEY
+    assert LOCAL_STT_KEYLESS_API_KEY
+    assert len(seen["transcriptions"]) == 1
     # The flow validated the endpoint without an Authorization header; runtime
     # must match, or servers that reject unknown bearer tokens 401 every
-    # utterance after a setup that passed.
-    assert patched_client["constructed"][0].auth_headers == {}
-    assert len(seen["transcriptions"]) == 1
+    # utterance after a setup that passed. Prove it on the real request the
+    # installed SDK would send, not on the marker alone.
+    extra_headers = seen["transcriptions"][0]["extra_headers"]
+    assert isinstance(extra_headers["Authorization"], Omit)
+    built = patched_client["constructed"][0]._build_request(
+        FinalRequestOptions(
+            method="post", url="/audio/transcriptions", headers=extra_headers
+        )
+    )
+    assert "authorization" not in built.headers
 
 
 async def test_local_provider_uses_configured_key(patched_client: Any) -> None:
@@ -756,8 +769,14 @@ async def test_local_provider_uses_configured_key(patched_client: Any) -> None:
     entity, _ = _make_local_entity(
         settings={"base_url": LOCAL_BASE_URL, "api_key": "local-key"}
     )
-    await _run(entity, [SimpleNamespace(text="hello")])
+    _, seen = await _run(entity, [SimpleNamespace(text="hello")])
     assert patched_client["kwargs"][0]["api_key"] == "local-key"
+    # A configured key must reach the wire as a bearer token: the keyless
+    # header strip applies only to the placeholder.
+    assert "extra_headers" not in seen["transcriptions"][0]
+    assert patched_client["constructed"][0].auth_headers == {
+        "Authorization": "Bearer local-key"
+    }
 
 
 async def test_local_provider_missing_base_url_builds_no_client(

--- a/tests/custom_components/home_generative_agent/test_subentries.py
+++ b/tests/custom_components/home_generative_agent/test_subentries.py
@@ -333,7 +333,7 @@ async def test_stt_provider_flow_local_keyless(
     assert third.get("type") == "form"
 
     result = await flow.async_step_model(
-        {"model_name": "Systran/faster-whisper-large-v3-turbo"}
+        {"model_name": "deepdml/faster-whisper-large-v3-turbo-ct2"}
     )
     assert result.get("type") == "create_entry"
     result_data = result.get("data")
@@ -342,7 +342,10 @@ async def test_stt_provider_flow_local_keyless(
     assert result_data["settings"]["base_url"] == "http://ollama-box:8000/v1"
     assert result_data["settings"]["api_key"] is None
     assert result_data["settings"]["openai_provider_subentry_id"] is None
-    assert result_data["model"]["model_name"] == "Systran/faster-whisper-large-v3-turbo"
+    assert (
+        result_data["model"]["model_name"]
+        == "deepdml/faster-whisper-large-v3-turbo-ct2"
+    )
 
 
 @pytest.mark.asyncio
@@ -422,11 +425,11 @@ async def test_stt_provider_flow_switch_to_local_resets_openai_state(
     third = await flow.async_step_credentials({"base_url": "http://box:8000"})
     assert third.get("type") == "form"
     assert _schema_marker(third, "model_name").default() == (
-        "Systran/faster-whisper-large-v3-turbo"
+        "deepdml/faster-whisper-large-v3-turbo-ct2"
     )
 
     result = await flow.async_step_model(
-        {"model_name": "Systran/faster-whisper-large-v3-turbo"}
+        {"model_name": "deepdml/faster-whisper-large-v3-turbo-ct2"}
     )
     assert result.get("type") == "update_entry"
     result_data = result.get("data")


### PR DESCRIPTION
## Summary

Two field-found problems with the v3.37.0 local STT provider (#598), both hit on the first real utterance through a Voice PE against a keyless Speaches server:

1. **Every keyless local utterance failed with `Missing credentials`.** HA 2026.8.3 and 2026.9.0 ship `openai==2.45.0`, whose `AsyncOpenAI` constructor now rejects an empty `api_key` (`not self.api_key`, previously `is None`). The review round of #598 verified the empty-key/no-header behavior on the dev venv's openai 2.28.0, not the version core actually runs. The keyless placeholder is now a non-empty sentinel that satisfies the constructor, and the stream strips the `Authorization` header per request with the SDK's `Omit` sentinel — the wire shape stays exactly what #598 intended (no bogus bearer for auth proxies to reject), and still matches the flow's keyless validation request. Verified by hand on openai 1.76.0, 2.28.0 and 2.45.0; the test now proves it on the real request the installed SDK builds, not on a marker.
2. **The shipped default model no longer exists publicly.** `Systran/faster-whisper-large-v3-turbo` returns 401 anonymously on Hugging Face and is gone from Systran's model list. The repo faster-whisper now maps `turbo` to (`mobiuslabsgmbh/…` → `dropbox-dash/…`) has no `ctranslate2` model-card tags, so Speaches' registry refuses it. Default is now `deepdml/faster-whisper-large-v3-turbo-ct2`, the public CT2 conversion of the same weights. Benchmarked on a GTX 1080 Ti: 0.45 s per 4 s utterance, 0.58 s round-trip through Speaches.

Also: `requirements/test.txt` pins `openai` to HA core's `openai_conversation` version so this class of SDK drift fails in `make test` rather than in the field; docs gain Speaches' pre-download requirement (`PRELOAD_MODELS`, it 404s otherwise), the model-TTL tip, and the Pascal `int8_float32` note (float16 hard-fails on compute capability 6.1).

No version bump or CHANGELOG entry — those go in the release commit per repo convention (target v3.37.1).

## Test plan

- [x] `make lint` clean, `make test` 3002 passed / 1 skipped on openai 2.45.0, pyright 0 errors
- [x] Keyless test asserts the placeholder is non-empty and that `_build_request` on the real SDK client emits no `authorization` header; configured-key test asserts the bearer is still sent
- [x] Field: reconfigure the Local STT subentry back to a blank key on the HA box running this build and speak through the Voice PE

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015XTPJG3scUAWWxk1TsRdzk
