### PR TITLE
feat(tts): built-in text-to-speech platform (OpenAI + local OpenAI-compatible)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,11 +47,11 @@ After changing `manifest.json`: run `make runtimedeps` (or `python scripts/gen_m
 - **`sentinel/`** — Anomaly detection engine: rules evaluation, LLM-based triage & discovery, baseline statistics, notifications, audit trail
 - **`snapshot/`** — Authoritative JSON representation of home state (entities + derived context + camera activity); consumed by Sentinel and explain flows
 - **`explain/`** — LLM-backed explanation generation and discovery prompt templates
-- **`core/`** — Video analysis, DB utilities, schema migrations, face recognition helpers, config subentry resolution, config-entry lifecycle helpers (startup-deferred engine start and camera discovery)
-- **`flows/`** — Home Assistant config flow subentries (model providers, features, database, STT, Sentinel)
+- **`core/`** — Video analysis, DB utilities, schema migrations, face recognition helpers, config subentry resolution, config-entry lifecycle helpers (startup-deferred engine start and camera discovery), shared OpenAI audio-client runtime for the STT/TTS platforms (`openai_endpoint.py`)
+- **`flows/`** — Home Assistant config flow subentries (model providers, features, database, STT, TTS, Sentinel); `openai_compatible_endpoint.py` holds the credential steps the STT and TTS flows share
 - **`notify/`** — Mobile push + persistent notification dispatch with snooze/action buttons
 
-Top-level platform files: `conversation.py`, `sensor.py`, `image.py`, `stt.py`, `http.py`, `config_flow.py`.
+Top-level platform files: `conversation.py`, `sensor.py`, `image.py`, `stt.py`, `tts.py`, `http.py`, `config_flow.py`.
 
 ### Agent Graph (`agent/graph.py`)
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Most AI conversation integrations are prompt passthroughs: they forward your wor
 | **Long-term memory** | Semantic search over past conversations. The agent remembers your preferences and context. |
 | **Streaming responses** | First tokens appear word-by-word in the HA conversation UI — no waiting for the full response. |
 | **Built-in speech-to-text** | STT provider for Assist pipelines, backed by the OpenAI Whisper API or a fully local OpenAI-compatible server (e.g. [Speaches](https://speaches.ai/) running faster-whisper next to Ollama) — see [STT setup](docs/configuration.md#speech-to-text-stt). |
+| **Built-in text-to-speech** | TTS provider for Assist pipelines, backed by the OpenAI speech API or the same local OpenAI-compatible server (Speaches serving Kokoro or piper voices), so the whole voice pipeline can stay on your network — see [TTS setup](docs/configuration.md#text-to-speech-tts). |
 | **Cloud and edge models** | Use OpenAI, Gemini, Anthropic, or run everything locally with Ollama or any OpenAI-compatible server. |
 
 ## Screenshots
@@ -104,7 +105,7 @@ You can now open the HA Assist panel and start talking to your home.
 | Guide | Contents |
 | --- | --- |
 | [Installation](docs/installation.md) | HACS install, manual install, optional apps (Ollama, face recognition) |
-| [Configuration](docs/configuration.md) | Model providers, features, per-model thinking/reasoning & budget, Tool Retrieval (RAG), per-tool exclusions & always-included tools, LLM API, STT (OpenAI or local), YAML mode, Critical Action PIN, camera description language & extra VLM instructions, UI languages (en/cs/ru/tr) |
+| [Configuration](docs/configuration.md) | Model providers, features, per-model thinking/reasoning & budget, Tool Retrieval (RAG), per-tool exclusions & always-included tools, LLM API, STT and TTS (OpenAI or local), YAML mode, Critical Action PIN, camera description language & extra VLM instructions, UI languages (en/cs/ru/tr) |
 | [Sentinel](docs/sentinel.md) | Anomaly detection pipeline, built-in rules, triage, baseline, blueprints, notification quiet hours, services API, health sensor |
 | [Camera Entities](docs/camera-entities.md) | Image and sensor entities, dashboards, automations, proactive video analysis, face recognition |
 | [Architecture](docs/architecture.md) | LangGraph agent, model tiers, context management, streaming, latency, tools |

--- a/TODOS.md
+++ b/TODOS.md
@@ -1455,6 +1455,30 @@ window-scoped check could suppress.
 
 ## Speech-to-Text
 
+### Fold the STT and TTS provider flow skeletons into one base class
+
+**What:** `flows/stt_provider_subentry_flow.py` and `flows/tts_provider_subentry_flow.py` share the
+credential step through `flows/openai_compatible_endpoint.py`, but the rest of the skeleton is
+duplicated character-for-character with `Stt`→`Tts`: `__init__` state, `_schedule_reload` (also a copy in
+the model-provider, feature, and sentinel flows — `hass.config_entries.async_schedule_reload` already
+de-duplicates), `async_step_user`/`reconfigure` hydration, the provider step with its type-switch reset,
+the credentials dispatch, and the create-vs-`async_update_and_abort` tail with the
+`SOURCE_RECONFIGURE`→`SOURCE_USER` rewrite (~170 of ~330 lines each). Flagged by the /code-review pass
+on the TTS PR.
+
+**Why:** The next skeleton change (a third backend type, the `_source` rewrite breaking on an HA release,
+a `current_subentry` disambiguation fix) has to be made and tested twice; drift is already visible in
+the comments the two copies carry.
+
+**How to apply:** An `OpenAICompatibleProviderSubentryFlow(ConfigSubentryFlow)` base in
+`flows/openai_compatible_endpoint.py` parameterised by `subentry_type`, `provider_names`,
+`fallback_name`, and `provider_id_key`, with an abstract `async_step_model`; each concrete flow keeps
+only its model step (~40 lines). Swap `_schedule_reload` for `async_schedule_reload` in all five flows
+while there.
+
+**Effort:** M
+**Priority:** P3
+
 ### STT entities are not bound to their subentry in the entity registry
 
 **What:** `stt.py::async_setup_entry` calls `async_add_entities(entities)` without
@@ -1492,9 +1516,10 @@ platform, but the orphan is visible after a delete.
 ### Migrate the model-provider `openai_compatible` flow onto the shared endpoint helper
 
 **What:** The STT and TTS provider flows now share one copy of the OpenAI-compatible endpoint
-convention — `flows/openai_compatible_endpoint.py` (normalize `/v1` at write time, `api_key: None`
-for keyless, `CONF_OPENAI_COMPATIBLE_ENDPOINT_BASE_URL`, runtime placeholder `LOCAL_KEYLESS_API_KEY`
-+ per-request `Omit()` header strip). The model-provider flow's `openai_compatible` type still uses
+convention — `flows/openai_compatible_endpoint.py` on the flow side (normalize `/v1` at write time,
+`api_key: None` for keyless, `CONF_OPENAI_COMPATIBLE_ENDPOINT_BASE_URL`) and `core/openai_endpoint.py`
+on the runtime side (linked-provider key resolution, placeholder `LOCAL_KEYLESS_API_KEY` + per-request
+`Omit()` header strip, cached no-retry client on HA's shared httpx client). The model-provider flow's `openai_compatible` type still uses
 the older shape: raw `ensure_http_url(...)` stored and normalized at read time
 (`__init__.py` ChatOpenAI/OpenAIEmbeddings construction), and the literal `"none"` keyless sentinel,
 which is written in three places (`flows/model_provider_subentry_flow.py`, `core/subentry_resolver.py`

--- a/TODOS.md
+++ b/TODOS.md
@@ -1455,7 +1455,27 @@ window-scoped check could suppress.
 
 ## Speech-to-Text
 
-### Add-flow provider name pre-fills for the default type, not the selected one
+### STT entities are not bound to their subentry in the entity registry
+
+**What:** `stt.py::async_setup_entry` calls `async_add_entities(entities)` without
+`config_subentry_id=`, while `tts.py` (added later) passes it, following core's
+`openai_conversation` platforms. Without the binding, deleting an STT provider subentry leaves an
+orphaned entity-registry entry (restored as unavailable) until the next reload prunes it, and the
+entity is not listed under its subentry in the UI.
+
+**Why:** Parity with TTS and core; cosmetic today because the flow's `_schedule_reload()` rebuilds the
+platform, but the orphan is visible after a delete.
+
+**How to apply:** Loop the subentries and add each entity with
+`config_subentry_id=subentry.subentry_id` (type the callback as
+`AddConfigEntryEntitiesCallback`), mirroring `tts.py`; add a setup test like
+`test_tts.py::test_setup_entry_adds_one_entity_per_tts_subentry`.
+
+**Effort:** S
+**Priority:** P3
+
+
+### ~~Add-flow provider name pre-fills for the default type, not the selected one~~ (DONE in the TTS PR)
 
 **What:** The STT provider step's name field defaults to `ProviderNames["openai"]` ("STT - OpenAI") because the form renders before the user touches the provider dropdown, and HA forms do not live-update one field from another. A user who switches the dropdown to **Local (OpenAI-compatible)** and submits without editing the name gets a local provider labeled "STT - OpenAI" in the Assist pipeline dropdown. The reconfigure path already resets a stale default name on a type *switch* (v3.37.0 review fix); the add path has no previous type to compare against, so `type_changed` never fires.
 
@@ -1465,16 +1485,35 @@ window-scoped check could suppress.
 
 **Effort:** S
 **Priority:** P3
+**Status:** Fixed in `flows/openai_compatible_endpoint.py::resolve_provider_name` (shared by the STT and TTS flows) with add-flow tests for both. A submitted name equal to another type's default is treated as the stale pre-fill; typed names survive.
 
 ---
 
-### Unify the two OpenAI-compatible endpoint conventions (STT flow vs model-provider flow)
+### Migrate the model-provider `openai_compatible` flow onto the shared endpoint helper
 
-**What:** The local STT provider (#598) and the `openai_compatible` model provider store the same concept — an OpenAI-compatible endpoint — in divergent shapes. STT (`flows/stt_provider_subentry_flow.py:_build_local_settings`) normalizes with `/v1` at write time and stores `api_key: None` for keyless servers; the model-provider flow (`flows/model_provider_subentry_flow.py:276-302`) stores the raw `ensure_http_url(...)` and normalizes at read time, and uses the literal `"none"` sentinel for keyless (which `validate_openai_compatible_url` at `core/utils.py:750` special-cases; the STT runtime instead uses `LOCAL_STT_KEYLESS_API_KEY = ""`). `CONF_STT_BASE_URL` and `CONF_OPENAI_COMPATIBLE_BASE_URL` are two constants for the same `base_url`/`openai_compatible_base_url` settings ideas.
+**What:** The STT and TTS provider flows now share one copy of the OpenAI-compatible endpoint
+convention — `flows/openai_compatible_endpoint.py` (normalize `/v1` at write time, `api_key: None`
+for keyless, `CONF_OPENAI_COMPATIBLE_ENDPOINT_BASE_URL`, runtime placeholder `LOCAL_KEYLESS_API_KEY`
++ per-request `Omit()` header strip). The model-provider flow's `openai_compatible` type still uses
+the older shape: raw `ensure_http_url(...)` stored and normalized at read time
+(`__init__.py` ChatOpenAI/OpenAIEmbeddings construction), and the literal `"none"` keyless sentinel,
+which is written in three places (`flows/model_provider_subentry_flow.py`, `core/subentry_resolver.py`
+`_apply_openai_compatible_to_category`, `__init__.py` runtime fallback) and handed to `SecretStr` as a
+real bearer token — `validate_openai_compatible_url` special-cases it (`core/utils.py`).
 
-**Why:** Flagged by the pre-merge review of #598. Any future change to how an OpenAI-compatible endpoint is validated, authenticated, or normalized must now be made twice in two conventions; miss one and local STT and local chat behave differently for the identical URL the user typed. Not unified in #598 to keep that PR a self-contained STT feature; the model-provider convention has existing stored entries, so unification needs a migration or read-both compatibility.
+**Why:** Two conventions for the identical URL a user typed; a change to validation, auth, or
+normalization must still be made twice. Deferred from the TTS PR on purpose: the model-provider
+convention has stored entries in the field and its `"none"` sentinel reaches the SDK at runtime, so
+the migration needs read-both compatibility (`normalize_openai_compatible_base_url` is idempotent, so
+the URL half is safe; the key half needs the placeholder + `Omit()` treatment or a non-empty
+placeholder wherever `SecretStr(...)` is built) and the reconfigure prefill must map the sentinel to an
+empty password field instead of showing literal `none`.
 
-**How to apply:** Extract a shared "openai-compatible endpoint settings" helper (build + validate + normalize + keyless convention) used by both flows, pick one storage shape (write-time normalized is simpler for readers), and accept the other on read for existing entries. The planned TTS provider (PR B) is the forcing function — do this before adding a third copy there.
+**How to apply:** Have the model-provider flow's `openai_compatible` branch call
+`build_local_endpoint_settings` / `local_endpoint_schema`; coerce `None`/`""`/`"none"` on every read
+site listed above; keep `validate_openai_compatible_url` accepting both; migrate the four
+`test_subentries.py` assertions that pin the un-normalized / `"none"` shape; settle on one translation
+label pair ("Server URL" vs "Base URL").
 
 **Effort:** M
 **Priority:** P2

--- a/custom_components/home_generative_agent/__init__.py
+++ b/custom_components/home_generative_agent/__init__.py
@@ -326,7 +326,7 @@ LOGGER = logging.getLogger(__name__)
 
 _SERVICE_RESPONSE_ONLY = SupportsResponse.ONLY
 
-PLATFORMS = (Platform.CONVERSATION, Platform.STT, "image", "sensor")
+PLATFORMS = (Platform.CONVERSATION, Platform.STT, Platform.TTS, "image", "sensor")
 
 SERVICE_ENROLL_PERSON = "enroll_person"
 SERVICE_GET_AUDIT_RECORDS = "get_audit_records"

--- a/custom_components/home_generative_agent/config_flow.py
+++ b/custom_components/home_generative_agent/config_flow.py
@@ -86,6 +86,7 @@ from .const import (
     SUBENTRY_TYPE_MODEL_PROVIDER,
     SUBENTRY_TYPE_SENTINEL,
     SUBENTRY_TYPE_STT_PROVIDER,
+    SUBENTRY_TYPE_TTS_PROVIDER,
     VIDEO_ANALYZER_MODE_ALWAYS_NOTIFY,
     VIDEO_ANALYZER_MODE_DISABLE,
     VIDEO_ANALYZER_MODE_NOTIFY_ON_ANOMALY,
@@ -101,6 +102,7 @@ from .flows.feature_subentry_flow import FeatureSubentryFlow
 from .flows.model_provider_subentry_flow import ModelProviderSubentryFlow
 from .flows.sentinel_subentry_flow import SentinelSubentryFlow
 from .flows.stt_provider_subentry_flow import SttProviderSubentryFlow
+from .flows.tts_provider_subentry_flow import TtsProviderSubentryFlow
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -780,6 +782,7 @@ class HomeGenerativeAgentConfigFlow(ConfigFlow, domain=DOMAIN):
             SUBENTRY_TYPE_MODEL_PROVIDER: ModelProviderSubentryFlow,
             SUBENTRY_TYPE_FEATURE: FeatureSubentryFlow,
             SUBENTRY_TYPE_STT_PROVIDER: SttProviderSubentryFlow,
+            SUBENTRY_TYPE_TTS_PROVIDER: TtsProviderSubentryFlow,
             SUBENTRY_TYPE_SENTINEL: SentinelSubentryFlow,
         }
 

--- a/custom_components/home_generative_agent/const.py
+++ b/custom_components/home_generative_agent/const.py
@@ -407,6 +407,20 @@ GEMINI_3_RECOMMENDED_TEMPERATURE = 1.0
 # --- Anthropic API key ---
 CONF_ANTHROPIC_API_KEY = "anthropic_api_key"
 
+# ---- OpenAI-compatible endpoints (shared by the STT and TTS provider flows) ----
+# Settings key under which a local server's normalized base URL is stored. The
+# STT and TTS provider subentries use the same key and the same shared flow
+# helper (flows/openai_compatible_endpoint.py).
+CONF_OPENAI_COMPATIBLE_ENDPOINT_BASE_URL = "base_url"
+# Keyless local servers get a placeholder key, NOT an empty one: openai>=2.45
+# (the version HA 2026.8+ ships) rejects an empty api_key in the constructor
+# with "Missing credentials". The placeholder never reaches the wire — the
+# runtime strips the Authorization header per request with the SDK's ``Omit``
+# sentinel, matching the flow's keyless validation request. A bogus bearer
+# would be rejected by auth proxies (e.g. LiteLLM virtual keys) even though
+# validation passed.
+LOCAL_KEYLESS_API_KEY = "sk-hga-keyless-local"
+
 # ---- Speech-to-Text (STT) ----
 CONF_STT_OPENAI_PROVIDER_ID = "openai_provider_subentry_id"
 CONF_STT_MODEL_NAME = "model_name"
@@ -425,20 +439,13 @@ RECOMMENDED_OPENAI_STT_MODEL: STT_MODEL_OPENAI_SUPPORTED = "gpt-4o-mini-transcri
 STT_RESPONSE_FORMATS = ("text", "json", "verbose_json", "srt", "vtt")
 
 # Local (OpenAI-compatible) STT provider, e.g. Speaches serving faster-whisper.
-CONF_STT_BASE_URL = "base_url"
+CONF_STT_BASE_URL = CONF_OPENAI_COMPATIBLE_ENDPOINT_BASE_URL
 # Speaches model ID; the flow accepts any custom value, this is only a default.
 # Systran's large-v3-turbo repo went private on Hugging Face (2026-09); this is
 # the public CTranslate2 conversion of the same weights, tagged so Speaches'
 # registry accepts it.
 RECOMMENDED_LOCAL_STT_MODEL = "deepdml/faster-whisper-large-v3-turbo-ct2"
-# Keyless local servers get a placeholder key, NOT an empty one: openai>=2.45
-# (the version HA 2026.8+ ships) rejects an empty api_key in the constructor
-# with "Missing credentials". The placeholder never reaches the wire — the
-# runtime strips the Authorization header per request with the SDK's ``Omit``
-# sentinel, matching the flow's keyless validation request. A bogus bearer
-# would be rejected by auth proxies (e.g. LiteLLM virtual keys) even though
-# validation passed.
-LOCAL_STT_KEYLESS_API_KEY = "sk-hga-keyless-local"
+LOCAL_STT_KEYLESS_API_KEY = LOCAL_KEYLESS_API_KEY
 
 # ---------------- Chat model ----------------
 CHAT_MODEL_TOP_P = 1.0

--- a/custom_components/home_generative_agent/const.py
+++ b/custom_components/home_generative_agent/const.py
@@ -14,6 +14,7 @@ SUBENTRY_TYPE_DATABASE = "database"
 SUBENTRY_TYPE_MODEL_PROVIDER = "model_provider"
 SUBENTRY_TYPE_FEATURE = "feature"
 SUBENTRY_TYPE_STT_PROVIDER = "stt_provider"
+SUBENTRY_TYPE_TTS_PROVIDER = "tts_provider"
 SUBENTRY_TYPE_SENTINEL = "sentinel"
 
 HTTP_STATUS_UNAUTHORIZED = 401
@@ -446,6 +447,49 @@ CONF_STT_BASE_URL = CONF_OPENAI_COMPATIBLE_ENDPOINT_BASE_URL
 # registry accepts it.
 RECOMMENDED_LOCAL_STT_MODEL = "deepdml/faster-whisper-large-v3-turbo-ct2"
 LOCAL_STT_KEYLESS_API_KEY = LOCAL_KEYLESS_API_KEY
+
+# ---- Text-to-Speech (TTS) ----
+CONF_TTS_OPENAI_PROVIDER_ID = "openai_provider_subentry_id"
+CONF_TTS_MODEL_NAME = "model_name"
+CONF_TTS_VOICE = "voice"
+CONF_TTS_SPEED = "speed"
+CONF_TTS_INSTRUCTIONS = "instructions"
+CONF_TTS_BASE_URL = CONF_OPENAI_COMPATIBLE_ENDPOINT_BASE_URL
+
+TTS_MODEL_OPENAI_SUPPORTED = Literal["gpt-4o-mini-tts", "tts-1", "tts-1-hd"]
+RECOMMENDED_OPENAI_TTS_MODEL: TTS_MODEL_OPENAI_SUPPORTED = "gpt-4o-mini-tts"
+# Only the gpt-4o-mini-tts family accepts the `instructions` parameter; the API
+# rejects it for tts-1 / tts-1-hd, so the runtime gates on this prefix.
+TTS_INSTRUCTIONS_MODEL_PREFIX = "gpt-4o-mini-tts"
+# Built-in OpenAI voices, display-cased; voice ids are the lowercase form.
+OPENAI_TTS_VOICES = (
+    "Alloy",
+    "Ash",
+    "Ballad",
+    "Cedar",
+    "Coral",
+    "Echo",
+    "Fable",
+    "Marin",
+    "Nova",
+    "Onyx",
+    "Sage",
+    "Shimmer",
+    "Verse",
+)
+RECOMMENDED_OPENAI_TTS_VOICE = "alloy"
+# Local (OpenAI-compatible) TTS provider, e.g. Speaches serving Kokoro.
+RECOMMENDED_LOCAL_TTS_MODEL = "speaches-ai/Kokoro-82M-v1.0-ONNX"
+RECOMMENDED_LOCAL_TTS_VOICE = "af_heart"
+TTS_SPEED_MIN = 0.25
+TTS_SPEED_MAX = 4.0
+TTS_SPEED_DEFAULT = 1.0
+# Audio containers each backend can produce. Home Assistant converts anything
+# else with ffmpeg, so the entity only has to pick something the backend
+# accepts; Speaches (faster-whisper/Kokoro) rejects opus and aac.
+TTS_OPENAI_RESPONSE_FORMATS = frozenset({"mp3", "opus", "aac", "flac", "wav", "pcm"})
+TTS_LOCAL_RESPONSE_FORMATS = frozenset({"mp3", "flac", "wav", "pcm"})
+TTS_DEFAULT_RESPONSE_FORMAT = "mp3"
 
 # ---------------- Chat model ----------------
 CHAT_MODEL_TOP_P = 1.0

--- a/custom_components/home_generative_agent/const.py
+++ b/custom_components/home_generative_agent/const.py
@@ -440,13 +440,11 @@ RECOMMENDED_OPENAI_STT_MODEL: STT_MODEL_OPENAI_SUPPORTED = "gpt-4o-mini-transcri
 STT_RESPONSE_FORMATS = ("text", "json", "verbose_json", "srt", "vtt")
 
 # Local (OpenAI-compatible) STT provider, e.g. Speaches serving faster-whisper.
-CONF_STT_BASE_URL = CONF_OPENAI_COMPATIBLE_ENDPOINT_BASE_URL
 # Speaches model ID; the flow accepts any custom value, this is only a default.
 # Systran's large-v3-turbo repo went private on Hugging Face (2026-09); this is
 # the public CTranslate2 conversion of the same weights, tagged so Speaches'
 # registry accepts it.
 RECOMMENDED_LOCAL_STT_MODEL = "deepdml/faster-whisper-large-v3-turbo-ct2"
-LOCAL_STT_KEYLESS_API_KEY = LOCAL_KEYLESS_API_KEY
 
 # ---- Text-to-Speech (TTS) ----
 CONF_TTS_OPENAI_PROVIDER_ID = "openai_provider_subentry_id"
@@ -454,7 +452,6 @@ CONF_TTS_MODEL_NAME = "model_name"
 CONF_TTS_VOICE = "voice"
 CONF_TTS_SPEED = "speed"
 CONF_TTS_INSTRUCTIONS = "instructions"
-CONF_TTS_BASE_URL = CONF_OPENAI_COMPATIBLE_ENDPOINT_BASE_URL
 
 TTS_MODEL_OPENAI_SUPPORTED = Literal["gpt-4o-mini-tts", "tts-1", "tts-1-hd"]
 RECOMMENDED_OPENAI_TTS_MODEL: TTS_MODEL_OPENAI_SUPPORTED = "gpt-4o-mini-tts"

--- a/custom_components/home_generative_agent/core/openai_endpoint.py
+++ b/custom_components/home_generative_agent/core/openai_endpoint.py
@@ -1,0 +1,204 @@
+"""
+Shared runtime for the OpenAI-backed audio platforms (STT and TTS).
+
+Both platforms read the same subentry credential shape, written by the shared
+flow helper (``flows/openai_compatible_endpoint.py``)::
+
+    openai -> {"api_key": str | None, <provider_id_key>: str | None}
+    local  -> {"base_url": "<...>/v1", "api_key": str | None, ...}
+
+and turn it into one OpenAI SDK client. This module is the single owner of the
+rules for that: a linked OpenAI model provider is authoritative for the key, a
+keyless local server gets a placeholder key plus a stripped Authorization
+header, and the client is built on Home Assistant's shared httpx client with a
+pinned timeout, no retries, and a cache keyed on the two configurable inputs.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import httpx
+from homeassistant.helpers.httpx_client import get_async_client
+from openai import AsyncOpenAI, Omit
+
+from ..const import (  # noqa: TID252
+    CONF_OPENAI_COMPATIBLE_ENDPOINT_BASE_URL,
+    LOCAL_KEYLESS_API_KEY,
+    SUBENTRY_TYPE_MODEL_PROVIDER,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+
+# Connect timeout shared by both platforms; the read timeout is per platform.
+CONNECT_TIMEOUT_S = 5.0
+
+
+class OpenAIConnectionError(Exception):
+    """The subentry cannot produce a usable connection (message says why)."""
+
+
+_MISSING_BASE_URL = "base URL missing"
+_MISSING_API_KEY = "API key missing"
+
+
+@dataclass(frozen=True, slots=True)
+class OpenAIConnection:
+    """Resolved credentials for one request."""
+
+    api_key: str
+    base_url: str | None
+    keyless: bool
+
+    def apply_to_request(self, request: dict[str, Any]) -> None:
+        """
+        Strip the Authorization header for a keyless local server.
+
+        The placeholder key exists only because the SDK constructor refuses an
+        empty one (openai>=2.45); the SDK's ``Omit`` sentinel drops the header
+        the client would otherwise add from it, so the wire shape matches the
+        flow's keyless validation request.
+        """
+        if self.keyless:
+            request["extra_headers"] = {"Authorization": Omit()}
+
+
+def load_model_settings(data: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the subentry's ``model`` mapping as a plain dict."""
+    model_data = data.get("model", {})
+    return dict(model_data) if isinstance(model_data, Mapping) else {}
+
+
+def _settings(data: Mapping[str, Any]) -> dict[str, Any]:
+    settings = data.get("settings", {})
+    return dict(settings) if isinstance(settings, Mapping) else {}
+
+
+def resolve_openai_api_key(
+    entry: ConfigEntry, data: Mapping[str, Any], *, provider_id_key: str
+) -> str | None:
+    """
+    Return the API key for an OpenAI provider subentry, or ``None``.
+
+    A linked OpenAI model-provider subentry is authoritative: its key is used
+    and there is never a fallback to the platform-level key, which the flow
+    blanks out when linking. Without a link, the platform-level key is used.
+    """
+    settings = _settings(data)
+    provider_id = settings.get(provider_id_key)
+    if provider_id:
+        provider = entry.subentries.get(provider_id)
+        if provider and provider.subentry_type == SUBENTRY_TYPE_MODEL_PROVIDER:
+            provider_settings = provider.data.get("settings", {})
+            if isinstance(provider_settings, Mapping):
+                provider_key = dict(provider_settings).get("api_key")
+                if isinstance(provider_key, str) and provider_key:
+                    return provider_key
+                return None
+    api_key = settings.get("api_key")
+    return api_key if isinstance(api_key, str) and api_key else None
+
+
+def resolve_openai_connection(
+    entry: ConfigEntry,
+    provider_type: str,
+    data: Mapping[str, Any],
+    *,
+    provider_id_key: str,
+) -> OpenAIConnection:
+    """
+    Return the connection for a provider subentry.
+
+    ``local`` requires the stored base URL and substitutes the keyless
+    placeholder when no key is configured; ``openai`` requires a key (own or
+    linked) and uses the SDK's default endpoint. Raises
+    ``OpenAIConnectionError`` with a short reason when the subentry is unusable.
+    """
+    if provider_type == "local":
+        settings = _settings(data)
+        base_url = settings.get(CONF_OPENAI_COMPATIBLE_ENDPOINT_BASE_URL)
+        if not isinstance(base_url, str) or not base_url:
+            raise OpenAIConnectionError(_MISSING_BASE_URL)
+        configured_key = settings.get("api_key")
+        if isinstance(configured_key, str) and configured_key:
+            return OpenAIConnection(configured_key, base_url, keyless=False)
+        return OpenAIConnection(LOCAL_KEYLESS_API_KEY, base_url, keyless=True)
+    api_key = resolve_openai_api_key(entry, data, provider_id_key=provider_id_key)
+    if not api_key:
+        raise OpenAIConnectionError(_MISSING_API_KEY)
+    return OpenAIConnection(api_key, None, keyless=False)
+
+
+class OpenAIClientCache:
+    """
+    One cached ``AsyncOpenAI`` per entity, rebuilt when its inputs change.
+
+    The client is built on Home Assistant's shared httpx client so the SDK
+    never creates its own SSL context — a blocking read of the certifi bundle —
+    on the event loop, and so back-to-back requests can reuse a pooled
+    connection instead of repeating the TLS handshake.
+
+    The httpx client belongs to Home Assistant. Do not close it from here. HA
+    also blocks that mistake — it swaps in a warn-only ``aclose`` and only its
+    own shutdown listener holds the real one — so a stray close would warn
+    rather than tear down the shared pool. Dropping a superseded cached client
+    is safe for the same reason: the SDK installs its close-on-GC finalizer only
+    on a client it built itself, never on one we supply.
+
+    The timeout is pinned rather than inherited. The SDK adopts a supplied
+    client's timeout only when it differs from the httpx default, so leaving it
+    off would silently retime every request if a future Home Assistant release
+    set one on the shared client. Two other SDK defaults are deliberately given
+    up with the swap and left as HA has them: ``follow_redirects`` (httpx's
+    ``False``, so a 3xx from a proxy surfaces as an error) and the SDK's
+    connection limits (HA's pool keeps connections alive for 15s, which bounds
+    the reuse win to back-to-back requests).
+
+    Retries are off. The SDK default of two would make a wedged server cost
+    three timeouts of silence before the pipeline hears an error; a voice turn
+    should fail fast instead, so the timeout means one attempt.
+
+    The cache is keyed on ``(api_key, base_url)`` — the two configurable inputs.
+    ``base_url`` is ``None`` for the OpenAI provider (SDK default endpoint) and
+    the configured endpoint for ``local`` providers, so switching a subentry
+    between provider types, repointing a local server, or rotating a key
+    rebuilds the client on the next request.
+    """
+
+    def __init__(self, timeout_s: float) -> None:
+        """Remember the platform's read timeout."""
+        self._timeout_s = timeout_s
+        self._client: AsyncOpenAI | None = None
+        self._cache_key: tuple[str, str | None] | None = None
+
+    @property
+    def client(self) -> AsyncOpenAI | None:
+        """The currently cached client, if one has been built."""
+        return self._client
+
+    @property
+    def cache_key(self) -> tuple[str, str | None] | None:
+        """The ``(api_key, base_url)`` the cached client was built for."""
+        return self._cache_key
+
+    def get(
+        self, hass: HomeAssistant, api_key: str, base_url: str | None
+    ) -> AsyncOpenAI:
+        """Return the cached client for these inputs, building it if needed."""
+        cache_key = (api_key, base_url)
+        if self._client is not None and self._cache_key == cache_key:
+            return self._client
+        client = AsyncOpenAI(
+            api_key=api_key,
+            base_url=base_url,
+            http_client=get_async_client(hass),
+            timeout=httpx.Timeout(self._timeout_s, connect=CONNECT_TIMEOUT_S),
+            max_retries=0,
+        )
+        self._client = client
+        self._cache_key = cache_key
+        return client

--- a/custom_components/home_generative_agent/flows/openai_compatible_endpoint.py
+++ b/custom_components/home_generative_agent/flows/openai_compatible_endpoint.py
@@ -1,0 +1,278 @@
+"""
+Shared credential helpers for the OpenAI-backed provider subentry flows.
+
+The STT and TTS provider flows configure the same two kinds of backend: the
+OpenAI API (a key, or a link to an OpenAI model-provider subentry) and a local
+OpenAI-compatible server (a URL plus an optional key). This module holds the
+one copy of how those credentials are collected, validated, and stored so the
+two flows cannot drift apart. The stored shape is::
+
+    openai -> {"api_key": str | None, <provider_id_key>: str | None}
+    local  -> {"base_url": "<...>/v1", "api_key": str | None,
+               <provider_id_key>: None}
+
+Local URLs are normalized (scheme, no trailing slash, ``/v1`` suffix) at write
+time, so runtime readers use the stored value verbatim. A keyless local server
+stores ``api_key: None``; the runtime substitutes a placeholder the SDK
+accepts and strips the Authorization header per request.
+
+The model-provider flow's ``openai_compatible`` type stores the same concept in
+an older shape (raw URL, literal ``"none"`` key sentinel); migrating it onto
+this helper is tracked in TODOS.md.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+from homeassistant.config_entries import SOURCE_RECONFIGURE, ConfigSubentryFlow
+from homeassistant.const import CONF_API_KEY
+from homeassistant.helpers.selector import (
+    SelectOptionDict,
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+    TextSelector,
+    TextSelectorConfig,
+    TextSelectorType,
+)
+
+from ..const import (  # noqa: TID252
+    CONF_OPENAI_COMPATIBLE_ENDPOINT_BASE_URL,
+    SUBENTRY_TYPE_MODEL_PROVIDER,
+)
+from ..core.utils import (  # noqa: TID252
+    CannotConnectError,
+    InvalidAuthError,
+    normalize_openai_compatible_base_url,
+    validate_openai_compatible_url,
+    validate_openai_key,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from homeassistant.config_entries import ConfigSubentry
+
+LOGGER = logging.getLogger(__name__)
+
+# Value of the "reuse an OpenAI model provider" selector meaning "no, use a
+# separate key typed below".
+SEPARATE_KEY_OPTION = "none"
+
+
+def get_entry_from_flow(flow: ConfigSubentryFlow) -> Any:
+    """Return the parent config entry of a subentry flow."""
+    return flow._get_entry()  # noqa: SLF001
+
+
+def current_subentry(
+    flow: ConfigSubentryFlow, subentry_type: str
+) -> ConfigSubentry | None:
+    """
+    Return the subentry a flow is reconfiguring, if any.
+
+    Prefers the flow's own subentry id, then the context, and finally — on a
+    reconfigure with neither — the single subentry of ``subentry_type`` when
+    exactly one exists.
+    """
+    entry = get_entry_from_flow(flow)
+    subentry_id = getattr(flow, "_subentry_id", None) or flow.context.get("subentry_id")
+    if subentry_id:
+        return entry.subentries.get(subentry_id)
+    if flow.source == SOURCE_RECONFIGURE:
+        matching = [
+            sub
+            for sub in entry.subentries.values()
+            if sub.subentry_type == subentry_type
+        ]
+        if len(matching) == 1:
+            return matching[0]
+    return None
+
+
+def openai_provider_options(flow: ConfigSubentryFlow) -> list[SelectOptionDict]:
+    """Return selector options for every OpenAI model-provider subentry."""
+    entry = get_entry_from_flow(flow)
+    options: list[SelectOptionDict] = []
+    for sub in entry.subentries.values():
+        if sub.subentry_type != SUBENTRY_TYPE_MODEL_PROVIDER:
+            continue
+        if sub.data.get("provider_type") != "openai":
+            continue
+        options.append(
+            SelectOptionDict(label=sub.title or sub.subentry_id, value=sub.subentry_id)
+        )
+    return options
+
+
+def resolve_provider_name(
+    submitted_name: str | None,
+    provider_type: str,
+    *,
+    provider_names: Mapping[str, str],
+    stale_name: str | None,
+    fallback: str,
+) -> str:
+    """
+    Return the provider name to store after the provider step is submitted.
+
+    Two kinds of untouched pre-fill are replaced with the selected type's own
+    default. ``stale_name`` is the previously stored name when the provider
+    type just changed (``None`` otherwise): a submission equal to it is the
+    form's pre-fill and would mislabel the new provider in the Assist pipeline
+    dropdown. On an add, the form renders before the dropdown is touched, so it
+    pre-fills the default type's name; a submitted name that is another type's
+    default is that stale pre-fill, not a choice. Any other name survives.
+    """
+    name = submitted_name
+    if stale_name is not None and name == stale_name:
+        name = None
+    own_default = provider_names.get(provider_type)
+    if name and name in provider_names.values() and name != own_default:
+        name = None
+    return name or own_default or fallback
+
+
+async def build_openai_key_settings(
+    hass: Any,
+    openai_opts: list[SelectOptionDict],
+    user_input: dict[str, Any],
+    *,
+    provider_id_key: str,
+) -> tuple[dict[str, Any], str | None]:
+    """
+    Build the settings for an OpenAI provider and return an error key if any.
+
+    Linking to an OpenAI model-provider subentry stores its id and blanks the
+    key so the linked provider stays authoritative; a separate key is validated
+    against the OpenAI API before it is stored.
+    """
+    api_key = user_input.get(CONF_API_KEY)
+    provider_id = user_input.get(provider_id_key)
+
+    if openai_opts and provider_id and provider_id != SEPARATE_KEY_OPTION:
+        return {provider_id_key: provider_id, CONF_API_KEY: None}, None
+
+    if not api_key:
+        return {}, "invalid_auth"
+
+    try:
+        await validate_openai_key(hass, api_key)
+    except InvalidAuthError:
+        return {}, "invalid_auth"
+    except CannotConnectError:
+        return {}, "cannot_connect"
+    except Exception:
+        LOGGER.exception("Unexpected exception validating OpenAI key")
+        return {}, "unknown"
+
+    return {CONF_API_KEY: api_key, provider_id_key: None}, None
+
+
+async def build_local_endpoint_settings(
+    hass: Any,
+    user_input: dict[str, Any],
+    *,
+    provider_id_key: str,
+) -> tuple[dict[str, Any], str | None]:
+    """
+    Build the settings for a local OpenAI-compatible server.
+
+    The URL is normalized before validation so what is stored is exactly what
+    was proven reachable. A blank key is stored as ``None`` (keyless server).
+    """
+    base_url = user_input.get(CONF_OPENAI_COMPATIBLE_ENDPOINT_BASE_URL)
+    if not isinstance(base_url, str) or not base_url.strip():
+        return {}, "cannot_connect"
+    base_url = normalize_openai_compatible_base_url(base_url)
+    api_key = user_input.get(CONF_API_KEY) or None
+
+    try:
+        await validate_openai_compatible_url(hass, base_url, api_key)
+    except InvalidAuthError:
+        return {}, "invalid_auth"
+    except CannotConnectError:
+        return {}, "cannot_connect"
+    except Exception:
+        LOGGER.exception("Unexpected exception validating local endpoint")
+        return {}, "unknown"
+
+    return {
+        CONF_OPENAI_COMPATIBLE_ENDPOINT_BASE_URL: base_url,
+        CONF_API_KEY: api_key,
+        provider_id_key: None,
+    }, None
+
+
+def local_endpoint_schema(prefill: Mapping[str, Any]) -> vol.Schema:
+    """
+    Return the credentials form for a local OpenAI-compatible server.
+
+    ``prefill`` is what the form redisplays: the stored settings normally, or
+    the just-typed input after a validation error, so a retry against a booting
+    server does not demand retyping the URL and a corrected typo does not
+    silently revert to the saved value.
+    """
+    base_url = prefill.get(CONF_OPENAI_COMPATIBLE_ENDPOINT_BASE_URL)
+    api_key = prefill.get(CONF_API_KEY)
+    return vol.Schema(
+        {
+            vol.Required(
+                CONF_OPENAI_COMPATIBLE_ENDPOINT_BASE_URL,
+                description={"suggested_value": base_url},
+                default=base_url or "",
+            ): TextSelector(TextSelectorConfig(type=TextSelectorType.URL)),
+            vol.Optional(
+                CONF_API_KEY,
+                description={"suggested_value": api_key},
+                default=api_key or "",
+            ): TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD)),
+        }
+    )
+
+
+def openai_key_schema(
+    openai_opts: list[SelectOptionDict],
+    stored: Mapping[str, Any],
+    *,
+    provider_id_key: str,
+) -> vol.Schema:
+    """
+    Return the credentials form for the OpenAI provider.
+
+    When OpenAI model-provider subentries exist, a selector offers to reuse one
+    (defaulting to the stored link, or to "separate key" when a standalone key
+    is stored). The key field is always present.
+    """
+    schema_dict: dict[Any, Any] = {}
+    if openai_opts:
+        reuse_opts = [
+            SelectOptionDict(label="Use a separate key", value=SEPARATE_KEY_OPTION),
+            *openai_opts,
+        ]
+        stored_provider_id = stored.get(provider_id_key)
+        stored_api_key = stored.get(CONF_API_KEY)
+        if stored_provider_id is None and stored_api_key:
+            default_id = SEPARATE_KEY_OPTION
+        else:
+            default_id = stored_provider_id or reuse_opts[1]["value"]
+        schema_dict[vol.Required(provider_id_key, default=default_id)] = SelectSelector(
+            SelectSelectorConfig(
+                options=reuse_opts,
+                mode=SelectSelectorMode.DROPDOWN,
+                sort=False,
+                custom_value=False,
+            )
+        )
+
+    schema_dict[
+        vol.Optional(
+            CONF_API_KEY,
+            description={"suggested_value": stored.get(CONF_API_KEY)},
+            default=stored.get(CONF_API_KEY) or "",
+        )
+    ] = TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD))
+    return vol.Schema(schema_dict)

--- a/custom_components/home_generative_agent/flows/openai_compatible_endpoint.py
+++ b/custom_components/home_generative_agent/flows/openai_compatible_endpoint.py
@@ -112,28 +112,37 @@ def resolve_provider_name(
     submitted_name: str | None,
     provider_type: str,
     *,
+    previous_type: str | None,
+    current_name: str | None,
     provider_names: Mapping[str, str],
-    stale_name: str | None,
-    fallback: str,
-) -> str:
+) -> str | None:
     """
-    Return the provider name to store after the provider step is submitted.
+    Return the provider name to store after the provider step, or ``None``.
 
-    Two kinds of untouched pre-fill are replaced with the selected type's own
-    default. ``stale_name`` is the previously stored name when the provider
-    type just changed (``None`` otherwise): a submission equal to it is the
-    form's pre-fill and would mislabel the new provider in the Assist pipeline
-    dropdown. On an add, the form renders before the dropdown is touched, so it
-    pre-fills the default type's name; a submitted name that is another type's
-    default is that stale pre-fill, not a choice. Any other name survives.
+    Two kinds of untouched pre-fill are dropped (the caller then applies the
+    selected type's default). On a type switch (``previous_type`` set and
+    different), a submission equal to ``current_name`` is the form's pre-fill
+    and would mislabel the new provider in the Assist pipeline dropdown. On an
+    add (``previous_type`` is ``None``), the form renders before the dropdown
+    is touched and pre-fills the default type's name, so a submission that is
+    another type's default is that stale pre-fill, not a choice. A same-type
+    reconfigure keeps whatever name is stored or typed, even another type's
+    default — renaming an existing entry behind the user's back is worse than
+    a label they can fix themselves.
     """
     name = submitted_name
-    if stale_name is not None and name == stale_name:
-        name = None
+    type_changed = previous_type is not None and previous_type != provider_type
+    if type_changed and name == current_name:
+        return None
     own_default = provider_names.get(provider_type)
-    if name and name in provider_names.values() and name != own_default:
-        name = None
-    return name or own_default or fallback
+    if (
+        previous_type is None
+        and name
+        and name in provider_names.values()
+        and name != own_default
+    ):
+        return None
+    return name or None
 
 
 async def build_openai_key_settings(

--- a/custom_components/home_generative_agent/flows/stt_provider_subentry_flow.py
+++ b/custom_components/home_generative_agent/flows/stt_provider_subentry_flow.py
@@ -9,11 +9,9 @@ import voluptuous as vol
 from homeassistant.config_entries import (
     SOURCE_RECONFIGURE,
     SOURCE_USER,
-    ConfigSubentry,
     ConfigSubentryFlow,
     SubentryFlowResult,
 )
-from homeassistant.const import CONF_API_KEY
 from homeassistant.helpers.selector import (
     BooleanSelector,
     NumberSelector,
@@ -28,7 +26,6 @@ from homeassistant.helpers.selector import (
 )
 
 from ..const import (  # noqa: TID252
-    CONF_STT_BASE_URL,
     CONF_STT_LANGUAGE,
     CONF_STT_MODEL_NAME,
     CONF_STT_OPENAI_PROVIDER_ID,
@@ -40,15 +37,16 @@ from ..const import (  # noqa: TID252
     RECOMMENDED_OPENAI_STT_MODEL,
     STT_MODEL_OPENAI_SUPPORTED,
     STT_RESPONSE_FORMATS,
-    SUBENTRY_TYPE_MODEL_PROVIDER,
     SUBENTRY_TYPE_STT_PROVIDER,
 )
-from ..core.utils import (  # noqa: TID252
-    CannotConnectError,
-    InvalidAuthError,
-    normalize_openai_compatible_base_url,
-    validate_openai_compatible_url,
-    validate_openai_key,
+from .openai_compatible_endpoint import (
+    build_local_endpoint_settings,
+    build_openai_key_settings,
+    current_subentry,
+    local_endpoint_schema,
+    openai_key_schema,
+    openai_provider_options,
+    resolve_provider_name,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -57,106 +55,7 @@ ProviderNames = {
     "openai": "STT - OpenAI",
     "local": "STT - Local",
 }
-
-
-def _get_entry_from_flow(flow: ConfigSubentryFlow) -> Any:
-    """Return the config entry for a subentry flow."""
-    return flow._get_entry()  # type: ignore[attr-defined]  # noqa: SLF001
-
-
-def _current_subentry(flow: ConfigSubentryFlow) -> ConfigSubentry | None:
-    """Return the subentry currently being edited, if any."""
-    entry = _get_entry_from_flow(flow)
-    subentry_id = getattr(flow, "_subentry_id", None)
-    if not subentry_id:
-        subentry_id = flow.context.get("subentry_id")
-    if subentry_id:
-        return entry.subentries.get(subentry_id)
-    if flow.source == SOURCE_RECONFIGURE:
-        matches = [
-            subentry
-            for subentry in entry.subentries.values()
-            if subentry.subentry_type == SUBENTRY_TYPE_STT_PROVIDER
-        ]
-        if len(matches) == 1:
-            return matches[0]
-    return None
-
-
-def _openai_provider_options(flow: ConfigSubentryFlow) -> list[SelectOptionDict]:
-    """Return OpenAI model provider subentries for reuse."""
-    entry = _get_entry_from_flow(flow)
-    options: list[SelectOptionDict] = []
-    for subentry in entry.subentries.values():
-        if subentry.subentry_type != SUBENTRY_TYPE_MODEL_PROVIDER:
-            continue
-        if subentry.data.get("provider_type") != "openai":
-            continue
-        options.append(
-            SelectOptionDict(
-                label=subentry.title or subentry.subentry_id,
-                value=subentry.subentry_id,
-            )
-        )
-    return options
-
-
-async def _build_openai_settings(
-    hass: Any, openai_opts: list[SelectOptionDict], user_input: dict[str, Any]
-) -> tuple[dict[str, Any], str | None]:
-    """Build OpenAI settings and return error key if any."""
-    settings: dict[str, Any] = {}
-    api_key = user_input.get(CONF_API_KEY)
-    provider_id = user_input.get(CONF_STT_OPENAI_PROVIDER_ID)
-
-    if openai_opts and provider_id and provider_id != "none":
-        settings[CONF_STT_OPENAI_PROVIDER_ID] = provider_id
-        settings[CONF_API_KEY] = None
-        return settings, None
-
-    if not api_key:
-        return {}, "invalid_auth"
-
-    try:
-        await validate_openai_key(hass, api_key)
-    except InvalidAuthError:
-        return {}, "invalid_auth"
-    except CannotConnectError:
-        return {}, "cannot_connect"
-    except Exception:
-        LOGGER.exception("Unexpected exception validating OpenAI key")
-        return {}, "unknown"
-
-    settings[CONF_API_KEY] = api_key
-    settings[CONF_STT_OPENAI_PROVIDER_ID] = None
-    return settings, None
-
-
-async def _build_local_settings(
-    hass: Any, user_input: dict[str, Any]
-) -> tuple[dict[str, Any], str | None]:
-    """Build local (OpenAI-compatible) settings and return error key if any."""
-    base_url = user_input.get(CONF_STT_BASE_URL)
-    if not isinstance(base_url, str) or not base_url.strip():
-        return {}, "cannot_connect"
-    base_url = normalize_openai_compatible_base_url(base_url)
-    api_key = user_input.get(CONF_API_KEY) or None
-
-    try:
-        await validate_openai_compatible_url(hass, base_url, api_key)
-    except InvalidAuthError:
-        return {}, "invalid_auth"
-    except CannotConnectError:
-        return {}, "cannot_connect"
-    except Exception:
-        LOGGER.exception("Unexpected exception validating local STT endpoint")
-        return {}, "unknown"
-
-    return {
-        CONF_STT_BASE_URL: base_url,
-        CONF_API_KEY: api_key,
-        CONF_STT_OPENAI_PROVIDER_ID: None,
-    }, None
+_FALLBACK_NAME = "STT Provider"
 
 
 class SttProviderSubentryFlow(ConfigSubentryFlow):
@@ -179,11 +78,11 @@ class SttProviderSubentryFlow(ConfigSubentryFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> SubentryFlowResult:
         """Entry point for STT provider setup or reconfigure."""
-        current = _current_subentry(self)
+        current = current_subentry(self, SUBENTRY_TYPE_STT_PROVIDER)
         if current:
             self._provider_type = current.data.get("provider_type")
             self._name = current.data.get("name") or ProviderNames.get(
-                self._provider_type or "openai", "STT Provider"
+                self._provider_type or "openai", _FALLBACK_NAME
             )
             self._settings = dict(current.data.get("settings") or {})
             self._model = dict(current.data.get("model") or {})
@@ -201,28 +100,27 @@ class SttProviderSubentryFlow(ConfigSubentryFlow):
             type_changed = (
                 self._provider_type is not None and provider_type != self._provider_type
             )
-            submitted_name = user_input.get("name")
             if type_changed:
                 # Switching provider types must not carry state across.
                 # Settings: the stored OpenAI key would otherwise prefill the
                 # local server's optional key field and be sent to a plaintext
                 # LAN endpoint (the model-provider flow guards the same leak).
                 # Model: the other type's model ID is invalid or a silent 404
-                # for the new one. Name: the pre-filled old default ("STT -
-                # OpenAI") would mislabel the new provider in the Assist
-                # pipeline dropdown; only a deliberately edited name survives.
+                # for the new one.
                 self._settings = {}
                 self._model = {}
-                if submitted_name == self._name:
-                    submitted_name = None
-            self._provider_type = provider_type
-            self._name = submitted_name or ProviderNames.get(
-                provider_type, "STT Provider"
+            self._name = resolve_provider_name(
+                user_input.get("name"),
+                provider_type,
+                provider_names=ProviderNames,
+                stale_name=self._name if type_changed else None,
+                fallback=_FALLBACK_NAME,
             )
+            self._provider_type = provider_type
             return await self.async_step_credentials()
 
         provider_type = self._provider_type or "openai"
-        default_name = self._name or ProviderNames.get(provider_type, "STT Provider")
+        default_name = self._name or ProviderNames.get(provider_type, _FALLBACK_NAME)
         schema = vol.Schema(
             {
                 vol.Required(
@@ -258,14 +156,19 @@ class SttProviderSubentryFlow(ConfigSubentryFlow):
         """Configure provider credentials."""
         errors: dict[str, str] = {}
         provider_type = self._provider_type or "openai"
-        openai_opts = _openai_provider_options(self)
+        openai_opts = openai_provider_options(self)
 
         if user_input is not None:
             if provider_type == "local":
-                settings, error = await _build_local_settings(self.hass, user_input)
+                settings, error = await build_local_endpoint_settings(
+                    self.hass, user_input, provider_id_key=CONF_STT_OPENAI_PROVIDER_ID
+                )
             elif provider_type == "openai":
-                settings, error = await _build_openai_settings(
-                    self.hass, openai_opts, user_input
+                settings, error = await build_openai_key_settings(
+                    self.hass,
+                    openai_opts,
+                    user_input,
+                    provider_id_key=CONF_STT_OPENAI_PROVIDER_ID,
                 )
             else:
                 # Unreachable today (the provider select admits only the two
@@ -287,60 +190,20 @@ class SttProviderSubentryFlow(ConfigSubentryFlow):
             prefill = (
                 user_input if user_input is not None and errors else self._settings
             )
-            local_schema = vol.Schema(
-                {
-                    vol.Required(
-                        CONF_STT_BASE_URL,
-                        description={"suggested_value": prefill.get(CONF_STT_BASE_URL)},
-                        default=prefill.get(CONF_STT_BASE_URL) or "",
-                    ): TextSelector(TextSelectorConfig(type=TextSelectorType.URL)),
-                    vol.Optional(
-                        CONF_API_KEY,
-                        description={"suggested_value": prefill.get(CONF_API_KEY)},
-                        default=prefill.get(CONF_API_KEY) or "",
-                    ): TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD)),
-                }
-            )
             return self.async_show_form(
-                step_id="credentials", data_schema=local_schema, errors=errors
+                step_id="credentials",
+                data_schema=local_endpoint_schema(prefill),
+                errors=errors,
             )
-
-        schema_dict: dict[Any, Any] = {}
-        if openai_opts:
-            reuse_opts = [
-                SelectOptionDict(label="Use a separate key", value="none"),
-                *openai_opts,
-            ]
-            stored_provider_id = self._settings.get(CONF_STT_OPENAI_PROVIDER_ID)
-            stored_api_key = self._settings.get(CONF_API_KEY)
-            if stored_provider_id is None and stored_api_key:
-                default_id = "none"
-            else:
-                default_id = stored_provider_id or reuse_opts[1]["value"]
-            schema_dict[
-                vol.Required(
-                    CONF_STT_OPENAI_PROVIDER_ID,
-                    default=default_id,
-                )
-            ] = SelectSelector(
-                SelectSelectorConfig(
-                    options=reuse_opts,
-                    mode=SelectSelectorMode.DROPDOWN,
-                    sort=False,
-                    custom_value=False,
-                )
-            )
-
-        schema_dict[
-            vol.Optional(
-                CONF_API_KEY,
-                description={"suggested_value": self._settings.get(CONF_API_KEY)},
-                default=self._settings.get(CONF_API_KEY) or "",
-            )
-        ] = TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD))
 
         return self.async_show_form(
-            step_id="credentials", data_schema=vol.Schema(schema_dict), errors=errors
+            step_id="credentials",
+            data_schema=openai_key_schema(
+                openai_opts,
+                self._settings,
+                provider_id_key=CONF_STT_OPENAI_PROVIDER_ID,
+            ),
+            errors=errors,
         )
 
     async def async_step_model(
@@ -348,7 +211,7 @@ class SttProviderSubentryFlow(ConfigSubentryFlow):
     ) -> SubentryFlowResult:
         """Configure model and advanced STT options."""
         errors: dict[str, str] = {}
-        current = _current_subentry(self)
+        current = current_subentry(self, SUBENTRY_TYPE_STT_PROVIDER)
         model_data = dict(self._model)
 
         if user_input is not None:
@@ -374,7 +237,7 @@ class SttProviderSubentryFlow(ConfigSubentryFlow):
                     "provider_type": self._provider_type or "openai",
                     "name": self._name
                     or ProviderNames.get(
-                        self._provider_type or "openai", "STT Provider"
+                        self._provider_type or "openai", _FALLBACK_NAME
                     ),
                     "settings": self._settings,
                     "model": model_data,

--- a/custom_components/home_generative_agent/flows/stt_provider_subentry_flow.py
+++ b/custom_components/home_generative_agent/flows/stt_provider_subentry_flow.py
@@ -112,10 +112,10 @@ class SttProviderSubentryFlow(ConfigSubentryFlow):
             self._name = resolve_provider_name(
                 user_input.get("name"),
                 provider_type,
+                previous_type=self._provider_type,
+                current_name=self._name,
                 provider_names=ProviderNames,
-                stale_name=self._name if type_changed else None,
-                fallback=_FALLBACK_NAME,
-            )
+            ) or ProviderNames.get(provider_type, _FALLBACK_NAME)
             self._provider_type = provider_type
             return await self.async_step_credentials()
 

--- a/custom_components/home_generative_agent/flows/tts_provider_subentry_flow.py
+++ b/custom_components/home_generative_agent/flows/tts_provider_subentry_flow.py
@@ -120,10 +120,10 @@ class TtsProviderSubentryFlow(ConfigSubentryFlow):
             self._name = resolve_provider_name(
                 user_input.get("name"),
                 provider_type,
+                previous_type=self._provider_type,
+                current_name=self._name,
                 provider_names=ProviderNames,
-                stale_name=self._name if type_changed else None,
-                fallback=_FALLBACK_NAME,
-            )
+            ) or ProviderNames.get(provider_type, _FALLBACK_NAME)
             self._provider_type = provider_type
             return await self.async_step_credentials()
 
@@ -233,10 +233,12 @@ class TtsProviderSubentryFlow(ConfigSubentryFlow):
                 errors["base"] = "invalid_model"
             else:
                 model_data[CONF_TTS_MODEL_NAME] = model_name
-                model_data[CONF_TTS_VOICE] = (
-                    str(user_input.get(CONF_TTS_VOICE) or "").strip()
-                    or recommended_voice
-                )
+                voice = str(user_input.get(CONF_TTS_VOICE) or "").strip()
+                if provider_type == "openai":
+                    # The API's voice enum is lowercase while the advertised
+                    # labels are display-cased ("Nova"); accept either.
+                    voice = voice.lower()
+                model_data[CONF_TTS_VOICE] = voice or recommended_voice
                 model_data[CONF_TTS_SPEED] = _coerce_speed(
                     user_input.get(CONF_TTS_SPEED)
                 )

--- a/custom_components/home_generative_agent/flows/tts_provider_subentry_flow.py
+++ b/custom_components/home_generative_agent/flows/tts_provider_subentry_flow.py
@@ -1,0 +1,327 @@
+"""Text-to-speech provider config subentry flow."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, get_args
+
+import voluptuous as vol
+from homeassistant.config_entries import (
+    SOURCE_RECONFIGURE,
+    SOURCE_USER,
+    ConfigSubentryFlow,
+    SubentryFlowResult,
+)
+from homeassistant.helpers.selector import (
+    NumberSelector,
+    NumberSelectorConfig,
+    SelectOptionDict,
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+    TextSelector,
+    TextSelectorConfig,
+    TextSelectorType,
+)
+
+from ..const import (  # noqa: TID252
+    CONF_TTS_INSTRUCTIONS,
+    CONF_TTS_MODEL_NAME,
+    CONF_TTS_OPENAI_PROVIDER_ID,
+    CONF_TTS_SPEED,
+    CONF_TTS_VOICE,
+    RECOMMENDED_LOCAL_TTS_MODEL,
+    RECOMMENDED_LOCAL_TTS_VOICE,
+    RECOMMENDED_OPENAI_TTS_MODEL,
+    RECOMMENDED_OPENAI_TTS_VOICE,
+    SUBENTRY_TYPE_TTS_PROVIDER,
+    TTS_MODEL_OPENAI_SUPPORTED,
+    TTS_SPEED_DEFAULT,
+    TTS_SPEED_MAX,
+    TTS_SPEED_MIN,
+)
+from .openai_compatible_endpoint import (
+    build_local_endpoint_settings,
+    build_openai_key_settings,
+    current_subentry,
+    local_endpoint_schema,
+    openai_key_schema,
+    openai_provider_options,
+    resolve_provider_name,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+ProviderNames = {
+    "openai": "TTS - OpenAI",
+    "local": "TTS - Local",
+}
+_FALLBACK_NAME = "TTS Provider"
+
+
+def _coerce_speed(value: Any) -> float:
+    """Clamp a submitted speed into the API's range; blank means the default."""
+    try:
+        speed = float(value)
+    except (TypeError, ValueError):
+        return TTS_SPEED_DEFAULT
+    return min(max(speed, TTS_SPEED_MIN), TTS_SPEED_MAX)
+
+
+class TtsProviderSubentryFlow(ConfigSubentryFlow):
+    """Config flow handler for TTS provider subentries."""
+
+    def __init__(self) -> None:
+        """Initialize the TTS provider flow."""
+        self._provider_type: str | None = None
+        self._name: str | None = None
+        self._settings: dict[str, Any] = {}
+        self._model: dict[str, Any] = {}
+
+    def _schedule_reload(self) -> None:
+        entry = self._get_entry()
+        self.hass.async_create_task(
+            self.hass.config_entries.async_reload(entry.entry_id)
+        )
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> SubentryFlowResult:
+        """Entry point for TTS provider setup or reconfigure."""
+        current = current_subentry(self, SUBENTRY_TYPE_TTS_PROVIDER)
+        if current:
+            self._provider_type = current.data.get("provider_type")
+            self._name = current.data.get("name") or ProviderNames.get(
+                self._provider_type or "openai", _FALLBACK_NAME
+            )
+            self._settings = dict(current.data.get("settings") or {})
+            self._model = dict(current.data.get("model") or {})
+        return await self.async_step_provider(user_input)
+
+    async_step_reconfigure = async_step_user
+
+    async def async_step_provider(
+        self, user_input: dict[str, Any] | None = None
+    ) -> SubentryFlowResult:
+        """Select provider type and name."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            provider_type = user_input.get("provider_type") or "openai"
+            type_changed = (
+                self._provider_type is not None and provider_type != self._provider_type
+            )
+            if type_changed:
+                # Switching provider types must not carry state across: the
+                # stored OpenAI key would otherwise prefill the local server's
+                # optional key field, and the other type's model and voice ids
+                # are invalid for the new one.
+                self._settings = {}
+                self._model = {}
+            self._name = resolve_provider_name(
+                user_input.get("name"),
+                provider_type,
+                provider_names=ProviderNames,
+                stale_name=self._name if type_changed else None,
+                fallback=_FALLBACK_NAME,
+            )
+            self._provider_type = provider_type
+            return await self.async_step_credentials()
+
+        provider_type = self._provider_type or "openai"
+        default_name = self._name or ProviderNames.get(provider_type, _FALLBACK_NAME)
+        schema = vol.Schema(
+            {
+                vol.Required(
+                    "provider_type",
+                    default=provider_type,
+                ): SelectSelector(
+                    SelectSelectorConfig(
+                        options=[
+                            SelectOptionDict(label="OpenAI", value="openai"),
+                            SelectOptionDict(
+                                label="Local (OpenAI-compatible)", value="local"
+                            ),
+                        ],
+                        mode=SelectSelectorMode.DROPDOWN,
+                        sort=False,
+                        custom_value=False,
+                    )
+                ),
+                vol.Optional(
+                    "name",
+                    description={"suggested_value": default_name},
+                    default=default_name,
+                ): TextSelector(TextSelectorConfig(type=TextSelectorType.TEXT)),
+            }
+        )
+        return self.async_show_form(
+            step_id="provider", data_schema=schema, errors=errors
+        )
+
+    async def async_step_credentials(
+        self, user_input: dict[str, Any] | None = None
+    ) -> SubentryFlowResult:
+        """Configure provider credentials."""
+        errors: dict[str, str] = {}
+        provider_type = self._provider_type or "openai"
+        openai_opts = openai_provider_options(self)
+
+        if user_input is not None:
+            if provider_type == "local":
+                settings, error = await build_local_endpoint_settings(
+                    self.hass, user_input, provider_id_key=CONF_TTS_OPENAI_PROVIDER_ID
+                )
+            elif provider_type == "openai":
+                settings, error = await build_openai_key_settings(
+                    self.hass,
+                    openai_opts,
+                    user_input,
+                    provider_id_key=CONF_TTS_OPENAI_PROVIDER_ID,
+                )
+            else:
+                # Unreachable today (the provider select admits only the two
+                # types above, custom_value=False) — kept so a future type
+                # added to the select but not wired here fails visibly.
+                settings, error = {}, "not_supported"
+            if error:
+                errors["base"] = error
+            else:
+                self._settings = settings
+                return await self.async_step_model()
+
+        if provider_type == "local":
+            # On a validation error, redisplay what was just typed — not the
+            # stored settings — so a retry against a booting server does not
+            # demand retyping the URL.
+            prefill = (
+                user_input if user_input is not None and errors else self._settings
+            )
+            return self.async_show_form(
+                step_id="credentials",
+                data_schema=local_endpoint_schema(prefill),
+                errors=errors,
+            )
+
+        return self.async_show_form(
+            step_id="credentials",
+            data_schema=openai_key_schema(
+                openai_opts,
+                self._settings,
+                provider_id_key=CONF_TTS_OPENAI_PROVIDER_ID,
+            ),
+            errors=errors,
+        )
+
+    async def async_step_model(
+        self, user_input: dict[str, Any] | None = None
+    ) -> SubentryFlowResult:
+        """Configure model, voice, and advanced TTS options."""
+        errors: dict[str, str] = {}
+        current = current_subentry(self, SUBENTRY_TYPE_TTS_PROVIDER)
+        model_data = dict(self._model)
+        provider_type = self._provider_type or "openai"
+        if provider_type == "local":
+            recommended_model = RECOMMENDED_LOCAL_TTS_MODEL
+            recommended_voice = RECOMMENDED_LOCAL_TTS_VOICE
+        else:
+            recommended_model = RECOMMENDED_OPENAI_TTS_MODEL
+            recommended_voice = RECOMMENDED_OPENAI_TTS_VOICE
+
+        if user_input is not None:
+            model_name = user_input.get(CONF_TTS_MODEL_NAME)
+            if not model_name:
+                errors["base"] = "invalid_model"
+            else:
+                model_data[CONF_TTS_MODEL_NAME] = model_name
+                model_data[CONF_TTS_VOICE] = (
+                    str(user_input.get(CONF_TTS_VOICE) or "").strip()
+                    or recommended_voice
+                )
+                model_data[CONF_TTS_SPEED] = _coerce_speed(
+                    user_input.get(CONF_TTS_SPEED)
+                )
+                model_data[CONF_TTS_INSTRUCTIONS] = (
+                    user_input.get(CONF_TTS_INSTRUCTIONS) or None
+                )
+
+            if not errors:
+                payload = {
+                    "provider_type": provider_type,
+                    "name": self._name
+                    or ProviderNames.get(provider_type, _FALLBACK_NAME),
+                    "settings": self._settings,
+                    "model": model_data,
+                }
+                if current is None:
+                    if self.source not in (SOURCE_USER, SOURCE_RECONFIGURE):
+                        return self.async_abort(reason="no_existing_subentry")
+                    if self.source == SOURCE_RECONFIGURE:
+                        self._source = SOURCE_USER
+                        self.context["source"] = SOURCE_USER
+                    self._schedule_reload()
+                    return self.async_create_entry(title=payload["name"], data=payload)
+                self._schedule_reload()
+                return self.async_update_and_abort(
+                    self._get_entry(),
+                    current,
+                    data=payload,
+                    title=payload["name"],
+                )
+
+        if provider_type == "local":
+            model_options = [
+                SelectOptionDict(label=recommended_model, value=recommended_model)
+            ]
+            allow_custom_model = True
+        else:
+            model_options = [
+                SelectOptionDict(label=model, value=model)
+                for model in get_args(TTS_MODEL_OPENAI_SUPPORTED)
+            ]
+            allow_custom_model = False
+
+        schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_TTS_MODEL_NAME,
+                    default=model_data.get(CONF_TTS_MODEL_NAME, recommended_model),
+                ): SelectSelector(
+                    SelectSelectorConfig(
+                        options=model_options,
+                        mode=SelectSelectorMode.DROPDOWN,
+                        sort=False,
+                        custom_value=allow_custom_model,
+                    )
+                ),
+                vol.Optional(
+                    CONF_TTS_VOICE,
+                    description={
+                        "suggested_value": model_data.get(CONF_TTS_VOICE)
+                        or recommended_voice
+                    },
+                    default=model_data.get(CONF_TTS_VOICE) or recommended_voice,
+                ): TextSelector(TextSelectorConfig(type=TextSelectorType.TEXT)),
+                vol.Optional(
+                    CONF_TTS_SPEED,
+                    description={
+                        "suggested_value": model_data.get(
+                            CONF_TTS_SPEED, TTS_SPEED_DEFAULT
+                        )
+                    },
+                    default=model_data.get(CONF_TTS_SPEED, TTS_SPEED_DEFAULT),
+                ): NumberSelector(
+                    NumberSelectorConfig(
+                        min=TTS_SPEED_MIN, max=TTS_SPEED_MAX, step=0.05
+                    )
+                ),
+                vol.Optional(
+                    CONF_TTS_INSTRUCTIONS,
+                    description={
+                        "suggested_value": model_data.get(CONF_TTS_INSTRUCTIONS)
+                    },
+                    default=model_data.get(CONF_TTS_INSTRUCTIONS) or "",
+                ): TextSelector(TextSelectorConfig(type=TextSelectorType.TEXT)),
+            }
+        )
+
+        return self.async_show_form(step_id="model", data_schema=schema, errors=errors)

--- a/custom_components/home_generative_agent/strings.json
+++ b/custom_components/home_generative_agent/strings.json
@@ -152,6 +152,61 @@
         "unknown": "Unexpected error."
       }
     },
+    "tts_provider": {
+      "entry_type": "service",
+      "abort": {
+        "reconfigure_successful": "TTS provider updated."
+      },
+      "initiate_flow": {
+        "reconfigure": "Reconfigure TTS Provider",
+        "user": "Add TTS Provider"
+      },
+      "step": {
+        "provider": {
+          "title": "Text-to-Speech Provider",
+          "description": "Select a provider type and name.",
+          "data": {
+            "provider_type": "Provider",
+            "name": "Provider name"
+          }
+        },
+        "credentials": {
+          "title": "Credentials",
+          "description": "Choose how to authenticate the TTS provider. Local providers connect to an OpenAI-compatible server URL instead.",
+          "data": {
+            "openai_provider_subentry_id": "Reuse OpenAI model provider",
+            "api_key": "API key",
+            "base_url": "Server URL"
+          },
+          "data_description": {
+            "api_key": "Required for OpenAI. Optional for local servers that need no authentication.",
+            "base_url": "OpenAI-compatible endpoint of the local TTS server, e.g. a Speaches instance. A missing /v1 suffix is added automatically."
+          }
+        },
+        "model": {
+          "title": "Model, voice & advanced options",
+          "description": "Select a model and voice, and optional advanced settings.",
+          "data": {
+            "model_name": "Model",
+            "voice": "Voice",
+            "speed": "Speed",
+            "instructions": "Voice instructions (optional)"
+          },
+          "data_description": {
+            "voice": "OpenAI: alloy, ash, ballad, cedar, coral, echo, fable, marin, nova, onyx, sage, shimmer, or verse. Local: a voice id the server's model provides, e.g. af_heart for Kokoro.",
+            "speed": "Playback speed multiplier, 0.25 to 4.0. 1.0 is normal speed.",
+            "instructions": "How the voice should sound, e.g. tone or pacing. Used only by OpenAI gpt-4o-mini-tts models; ignored elsewhere."
+          }
+        }
+      },
+      "error": {
+        "cannot_connect": "Can't reach the provider.",
+        "invalid_auth": "Invalid credentials.",
+        "invalid_model": "Select a valid model.",
+        "not_supported": "Provider not supported yet.",
+        "unknown": "Unexpected error."
+      }
+    },
     "sentinel": {
       "entry_type": "service",
       "abort": {

--- a/custom_components/home_generative_agent/stt.py
+++ b/custom_components/home_generative_agent/stt.py
@@ -10,18 +10,15 @@ import wave
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
-import httpx
 from homeassistant.components import stt
 from homeassistant.components.stt import (
     SpeechMetadata,
     SpeechResult,
     SpeechToTextEntity,
 )
-from homeassistant.helpers.httpx_client import get_async_client
-from openai import AsyncOpenAI, AuthenticationError, Omit, OpenAIError
+from openai import AuthenticationError, OpenAIError
 
 from .const import (
-    CONF_OPENAI_COMPATIBLE_ENDPOINT_BASE_URL,
     CONF_STT_LANGUAGE,
     CONF_STT_MODEL_NAME,
     CONF_STT_OPENAI_PROVIDER_ID,
@@ -29,11 +26,16 @@ from .const import (
     CONF_STT_RESPONSE_FORMAT,
     CONF_STT_TEMPERATURE,
     CONF_STT_TRANSLATE,
-    LOCAL_KEYLESS_API_KEY,
     RECOMMENDED_LOCAL_STT_MODEL,
     RECOMMENDED_OPENAI_STT_MODEL,
-    SUBENTRY_TYPE_MODEL_PROVIDER,
     SUBENTRY_TYPE_STT_PROVIDER,
+)
+from .core.openai_endpoint import (
+    OpenAIClientCache,
+    OpenAIConnection,
+    OpenAIConnectionError,
+    load_model_settings,
+    resolve_openai_connection,
 )
 
 if TYPE_CHECKING:
@@ -106,14 +108,6 @@ def _normalize_int(value: Any, default: int) -> int:
         except ValueError:
             return default
     return default
-
-
-def _load_model_settings(data: dict[str, Any]) -> dict[str, Any]:
-    """Normalize model settings payload."""
-    model_data = data.get("model", {})
-    if not isinstance(model_data, Mapping):
-        model_data = {}
-    return dict(model_data)
 
 
 def _build_openai_request(  # noqa: PLR0913
@@ -200,8 +194,7 @@ class HGASttEntity(SpeechToTextEntity):
         self._subentry = entry.subentries[subentry_id]
         self._attr_unique_id = f"{entry.entry_id}_{subentry_id}"
         self._attr_name = self._subentry.title or "STT"
-        self._openai_client: AsyncOpenAI | None = None
-        self._openai_client_cache_key: tuple[str, str | None] | None = None
+        self._clients = OpenAIClientCache(STT_REQUEST_TIMEOUT_S)
 
     @property
     def supported_languages(self) -> list[str]:
@@ -247,109 +240,24 @@ class HGASttEntity(SpeechToTextEntity):
         """Return supported audio channels."""
         return _all_enum_values(stt.AudioChannels)
 
-    def _resolve_api_key(self, data: dict[str, Any]) -> str | None:
-        settings = data.get("settings", {})
-        settings = dict(settings) if isinstance(settings, Mapping) else {}
-        provider_id = settings.get(CONF_STT_OPENAI_PROVIDER_ID)
-        if provider_id:
-            provider = self.entry.subentries.get(provider_id)
-            if provider and provider.subentry_type == SUBENTRY_TYPE_MODEL_PROVIDER:
-                provider_settings = provider.data.get("settings", {})
-                if isinstance(provider_settings, Mapping):
-                    # A linked provider is authoritative: never fall back to the
-                    # STT-level key, which the flow blanks out when linking.
-                    provider_key = dict(provider_settings).get("api_key")
-                    if isinstance(provider_key, str) and provider_key:
-                        return provider_key
-                    return None
-        api_key = settings.get("api_key")
-        return api_key if isinstance(api_key, str) and api_key else None
-
-    def _get_client(self, api_key: str, base_url: str | None) -> AsyncOpenAI:
-        """
-        Return a cached OpenAI client for the resolved API key and base URL.
-
-        The client is built on Home Assistant's shared httpx client so the SDK
-        never creates its own SSL context — a blocking read of the certifi
-        bundle — on the event loop, and so back-to-back utterances can reuse a
-        pooled connection instead of repeating the TLS handshake. The cache is
-        keyed on the API key and base URL so reconfiguring the STT subentry or
-        its linked model provider takes effect on the next stream.
-
-        The httpx client belongs to Home Assistant. Do not close it from here.
-        HA also blocks that mistake — it swaps in a warn-only ``aclose`` and only
-        its own shutdown listener holds the real one — so a stray close would
-        warn rather than tear down the shared pool. Dropping a superseded cached
-        client is safe for the same reason the fix works: the SDK installs its
-        close-on-GC finalizer only on a client it built itself, never on one we
-        supply. The old per-stream client did carry that finalizer.
-
-        The timeout is pinned rather than inherited. The SDK adopts a supplied
-        client's timeout only when it differs from the httpx default, so leaving
-        it off would silently retime every transcription if a future Home
-        Assistant release ever set one on the shared client. Two other SDK
-        defaults are deliberately given up with the swap and left as HA has
-        them: ``follow_redirects`` (HA leaves httpx's ``False``, so a 3xx from a
-        proxy surfaces as an error rather than being followed) and the SDK's
-        connection limits (HA's pool keeps connections alive for 15s, which is
-        what bounds the reuse win above to back-to-back utterances).
-
-        The cache is keyed on ``(api_key, base_url)`` — the two configurable
-        inputs to the client. ``base_url`` is ``None`` for the OpenAI provider
-        (SDK default endpoint) and the configured endpoint for ``local``
-        providers, so switching a subentry between provider types or repointing
-        a local server rebuilds the client on the next stream.
-        """
-        cache_key = (api_key, base_url)
-        if (
-            self._openai_client is not None
-            and self._openai_client_cache_key == cache_key
-        ):
-            return self._openai_client
-        client = AsyncOpenAI(
-            api_key=api_key,
-            base_url=base_url,
-            http_client=get_async_client(self.hass),
-            timeout=httpx.Timeout(STT_REQUEST_TIMEOUT_S, connect=5.0),
-            # The SDK default of 2 retries would make a wedged server cost three
-            # timeouts of silence before the pipeline hears an error; a voice
-            # turn should fail fast instead, so the timeout means one attempt.
-            max_retries=0,
-        )
-        self._openai_client = client
-        self._openai_client_cache_key = cache_key
-        return client
+    def _get_client(self, api_key: str, base_url: str | None) -> Any:
+        """Return the cached OpenAI client for these credentials."""
+        return self._clients.get(self.hass, api_key, base_url)
 
     def _resolve_connection(
         self, provider_type: str, data: dict[str, Any]
-    ) -> tuple[str, str | None] | None:
-        """
-        Return (api_key, base_url) for the provider, or None if unconfigured.
-
-        Local providers require a base URL and fall back to the keyless
-        placeholder when the server needs none. The placeholder only satisfies
-        the SDK constructor; the stream strips the Authorization header per
-        request so the wire shape matches the flow's validation request.
-        """
-        if provider_type == "local":
-            settings = data.get("settings", {})
-            settings = dict(settings) if isinstance(settings, Mapping) else {}
-            base_url = settings.get(CONF_OPENAI_COMPATIBLE_ENDPOINT_BASE_URL)
-            if not isinstance(base_url, str) or not base_url:
-                LOGGER.warning("Local STT base URL missing for %s", self.entity_id)
-                return None
-            configured_key = settings.get("api_key")
-            api_key = (
-                configured_key
-                if isinstance(configured_key, str) and configured_key
-                else LOCAL_KEYLESS_API_KEY
+    ) -> OpenAIConnection | None:
+        """Return the connection for this subentry, or None (logged) if unusable."""
+        try:
+            return resolve_openai_connection(
+                self.entry,
+                provider_type,
+                data,
+                provider_id_key=CONF_STT_OPENAI_PROVIDER_ID,
             )
-            return api_key, base_url
-        api_key = self._resolve_api_key(data)
-        if not api_key:
-            LOGGER.warning("OpenAI STT API key missing for %s", self.entity_id)
+        except OpenAIConnectionError as err:
+            LOGGER.warning("STT %s for %s", err, self.entity_id)
             return None
-        return api_key, None
 
     async def async_process_audio_stream(  # noqa: PLR0912
         self, metadata: SpeechMetadata, stream: Any
@@ -365,9 +273,8 @@ class HGASttEntity(SpeechToTextEntity):
         connection = self._resolve_connection(provider_type, data)
         if connection is None:
             return SpeechResult(result=result_state, text=None)
-        api_key, base_url = connection
 
-        model_data = _load_model_settings(data)
+        model_data = load_model_settings(data)
         default_model = (
             RECOMMENDED_LOCAL_STT_MODEL
             if provider_type == "local"
@@ -398,18 +305,13 @@ class HGASttEntity(SpeechToTextEntity):
             temperature,
             response_format,
         )
-        if api_key == LOCAL_KEYLESS_API_KEY:
-            # Keyless local server: send no Authorization header at all. The
-            # placeholder exists only because the SDK constructor refuses an
-            # empty key; ``Omit`` drops the header the client would otherwise
-            # add from it.
-            request["extra_headers"] = {"Authorization": Omit()}
+        connection.apply_to_request(request)
 
         # Building the client is inside the try: it now touches hass.data and
         # the SDK constructor, and a failure there should fail this utterance,
         # not raise out into the assist pipeline.
         try:
-            client = self._get_client(api_key, base_url)
+            client = self._get_client(connection.api_key, connection.base_url)
             # Local servers (faster-whisper) serve /audio/translations for any
             # whisper model; OpenAI only does for whisper-1. A local non-whisper
             # model degrades to transcription like the OpenAI path does, rather

--- a/custom_components/home_generative_agent/stt.py
+++ b/custom_components/home_generative_agent/stt.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.httpx_client import get_async_client
 from openai import AsyncOpenAI, AuthenticationError, Omit, OpenAIError
 
 from .const import (
-    CONF_STT_BASE_URL,
+    CONF_OPENAI_COMPATIBLE_ENDPOINT_BASE_URL,
     CONF_STT_LANGUAGE,
     CONF_STT_MODEL_NAME,
     CONF_STT_OPENAI_PROVIDER_ID,
@@ -29,7 +29,7 @@ from .const import (
     CONF_STT_RESPONSE_FORMAT,
     CONF_STT_TEMPERATURE,
     CONF_STT_TRANSLATE,
-    LOCAL_STT_KEYLESS_API_KEY,
+    LOCAL_KEYLESS_API_KEY,
     RECOMMENDED_LOCAL_STT_MODEL,
     RECOMMENDED_OPENAI_STT_MODEL,
     SUBENTRY_TYPE_MODEL_PROVIDER,
@@ -311,6 +311,10 @@ class HGASttEntity(SpeechToTextEntity):
             base_url=base_url,
             http_client=get_async_client(self.hass),
             timeout=httpx.Timeout(STT_REQUEST_TIMEOUT_S, connect=5.0),
+            # The SDK default of 2 retries would make a wedged server cost three
+            # timeouts of silence before the pipeline hears an error; a voice
+            # turn should fail fast instead, so the timeout means one attempt.
+            max_retries=0,
         )
         self._openai_client = client
         self._openai_client_cache_key = cache_key
@@ -330,7 +334,7 @@ class HGASttEntity(SpeechToTextEntity):
         if provider_type == "local":
             settings = data.get("settings", {})
             settings = dict(settings) if isinstance(settings, Mapping) else {}
-            base_url = settings.get(CONF_STT_BASE_URL)
+            base_url = settings.get(CONF_OPENAI_COMPATIBLE_ENDPOINT_BASE_URL)
             if not isinstance(base_url, str) or not base_url:
                 LOGGER.warning("Local STT base URL missing for %s", self.entity_id)
                 return None
@@ -338,7 +342,7 @@ class HGASttEntity(SpeechToTextEntity):
             api_key = (
                 configured_key
                 if isinstance(configured_key, str) and configured_key
-                else LOCAL_STT_KEYLESS_API_KEY
+                else LOCAL_KEYLESS_API_KEY
             )
             return api_key, base_url
         api_key = self._resolve_api_key(data)
@@ -394,7 +398,7 @@ class HGASttEntity(SpeechToTextEntity):
             temperature,
             response_format,
         )
-        if api_key == LOCAL_STT_KEYLESS_API_KEY:
+        if api_key == LOCAL_KEYLESS_API_KEY:
             # Keyless local server: send no Authorization header at all. The
             # placeholder exists only because the SDK constructor refuses an
             # empty key; ``Omit`` drops the header the client would otherwise

--- a/custom_components/home_generative_agent/translations/cs.json
+++ b/custom_components/home_generative_agent/translations/cs.json
@@ -152,6 +152,61 @@
         "unknown": "Neočekávaná chyba."
       }
     },
+    "tts_provider": {
+      "entry_type": "service",
+      "abort": {
+        "reconfigure_successful": "Poskytovatel TTS byl aktualizován."
+      },
+      "initiate_flow": {
+        "reconfigure": "Přenastavit poskytovatele TTS",
+        "user": "Přidat poskytovatele TTS"
+      },
+      "step": {
+        "provider": {
+          "title": "Poskytovatel převodu textu na řeč (TTS)",
+          "description": "Vyberte typ a název poskytovatele.",
+          "data": {
+            "provider_type": "Poskytovatel",
+            "name": "Název poskytovatele"
+          }
+        },
+        "credentials": {
+          "title": "Přihlašovací údaje",
+          "description": "Vyberte způsob autentizace poskytovatele TTS. Lokální poskytovatelé se místo toho připojují přes URL serveru kompatibilního s OpenAI.",
+          "data": {
+            "openai_provider_subentry_id": "Znovu použít poskytovatele OpenAI",
+            "api_key": "API klíč",
+            "base_url": "URL serveru"
+          },
+          "data_description": {
+            "api_key": "Vyžadováno pro OpenAI. Volitelné pro lokální servery bez autentizace.",
+            "base_url": "OpenAI-kompatibilní koncový bod lokálního TTS serveru, např. instance Speaches. Chybějící přípona /v1 se doplní automaticky."
+          }
+        },
+        "model": {
+          "title": "Model, hlas a pokročilé možnosti",
+          "description": "Vyberte model a hlas a volitelná pokročilá nastavení.",
+          "data": {
+            "model_name": "Model",
+            "voice": "Hlas",
+            "speed": "Rychlost",
+            "instructions": "Pokyny pro hlas (volitelné)"
+          },
+          "data_description": {
+            "voice": "OpenAI: alloy, ash, ballad, cedar, coral, echo, fable, marin, nova, onyx, sage, shimmer nebo verse. Lokální: identifikátor hlasu, který poskytuje model serveru, např. af_heart pro Kokoro.",
+            "speed": "Násobek rychlosti přehrávání, 0,25 až 4,0. 1,0 je normální rychlost.",
+            "instructions": "Jak má hlas znít, např. tón nebo tempo. Používají pouze modely OpenAI gpt-4o-mini-tts; jinde se ignoruje."
+          }
+        }
+      },
+      "error": {
+        "cannot_connect": "K poskytovateli se nelze připojit.",
+        "invalid_auth": "Neplatné přihlašovací údaje.",
+        "invalid_model": "Vyberte platný model.",
+        "not_supported": "Poskytovatel zatím není podporován.",
+        "unknown": "Neočekávaná chyba."
+      }
+    },
     "sentinel": {
       "entry_type": "service",
       "abort": {

--- a/custom_components/home_generative_agent/translations/en.json
+++ b/custom_components/home_generative_agent/translations/en.json
@@ -152,6 +152,61 @@
         "unknown": "Unexpected error."
       }
     },
+    "tts_provider": {
+      "entry_type": "service",
+      "abort": {
+        "reconfigure_successful": "TTS provider updated."
+      },
+      "initiate_flow": {
+        "reconfigure": "Reconfigure TTS Provider",
+        "user": "Add TTS Provider"
+      },
+      "step": {
+        "provider": {
+          "title": "Text-to-Speech Provider",
+          "description": "Select a provider type and name.",
+          "data": {
+            "provider_type": "Provider",
+            "name": "Provider name"
+          }
+        },
+        "credentials": {
+          "title": "Credentials",
+          "description": "Choose how to authenticate the TTS provider. Local providers connect to an OpenAI-compatible server URL instead.",
+          "data": {
+            "openai_provider_subentry_id": "Reuse OpenAI model provider",
+            "api_key": "API key",
+            "base_url": "Server URL"
+          },
+          "data_description": {
+            "api_key": "Required for OpenAI. Optional for local servers that need no authentication.",
+            "base_url": "OpenAI-compatible endpoint of the local TTS server, e.g. a Speaches instance. A missing /v1 suffix is added automatically."
+          }
+        },
+        "model": {
+          "title": "Model, voice & advanced options",
+          "description": "Select a model and voice, and optional advanced settings.",
+          "data": {
+            "model_name": "Model",
+            "voice": "Voice",
+            "speed": "Speed",
+            "instructions": "Voice instructions (optional)"
+          },
+          "data_description": {
+            "voice": "OpenAI: alloy, ash, ballad, cedar, coral, echo, fable, marin, nova, onyx, sage, shimmer, or verse. Local: a voice id the server's model provides, e.g. af_heart for Kokoro.",
+            "speed": "Playback speed multiplier, 0.25 to 4.0. 1.0 is normal speed.",
+            "instructions": "How the voice should sound, e.g. tone or pacing. Used only by OpenAI gpt-4o-mini-tts models; ignored elsewhere."
+          }
+        }
+      },
+      "error": {
+        "cannot_connect": "Can't reach the provider.",
+        "invalid_auth": "Invalid credentials.",
+        "invalid_model": "Select a valid model.",
+        "not_supported": "Provider not supported yet.",
+        "unknown": "Unexpected error."
+      }
+    },
     "sentinel": {
       "entry_type": "service",
       "abort": {

--- a/custom_components/home_generative_agent/translations/ru.json
+++ b/custom_components/home_generative_agent/translations/ru.json
@@ -142,6 +142,61 @@
         "unknown": "Unexpected error."
       }
     },
+    "tts_provider": {
+      "entry_type": "service",
+      "abort": {
+        "reconfigure_successful": "TTS provider updated."
+      },
+      "initiate_flow": {
+        "reconfigure": "Reconfigure TTS Provider",
+        "user": "Add TTS Provider"
+      },
+      "step": {
+        "provider": {
+          "title": "Text-to-Speech Provider",
+          "description": "Select a provider type and name.",
+          "data": {
+            "provider_type": "Provider",
+            "name": "Provider name"
+          }
+        },
+        "credentials": {
+          "title": "Credentials",
+          "description": "Choose how to authenticate the TTS provider. Local providers connect to an OpenAI-compatible server URL instead.",
+          "data": {
+            "openai_provider_subentry_id": "Reuse OpenAI model provider",
+            "api_key": "API key",
+            "base_url": "Server URL"
+          },
+          "data_description": {
+            "api_key": "Required for OpenAI. Optional for local servers that need no authentication.",
+            "base_url": "OpenAI-compatible endpoint of the local TTS server, e.g. a Speaches instance. A missing /v1 suffix is added automatically."
+          }
+        },
+        "model": {
+          "title": "Model, voice & advanced options",
+          "description": "Select a model and voice, and optional advanced settings.",
+          "data": {
+            "model_name": "Model",
+            "voice": "Voice",
+            "speed": "Speed",
+            "instructions": "Voice instructions (optional)"
+          },
+          "data_description": {
+            "voice": "OpenAI: alloy, ash, ballad, cedar, coral, echo, fable, marin, nova, onyx, sage, shimmer, or verse. Local: a voice id the server's model provides, e.g. af_heart for Kokoro.",
+            "speed": "Playback speed multiplier, 0.25 to 4.0. 1.0 is normal speed.",
+            "instructions": "How the voice should sound, e.g. tone or pacing. Used only by OpenAI gpt-4o-mini-tts models; ignored elsewhere."
+          }
+        }
+      },
+      "error": {
+        "cannot_connect": "Can't reach the provider.",
+        "invalid_auth": "Invalid credentials.",
+        "invalid_model": "Select a valid model.",
+        "not_supported": "Provider not supported yet.",
+        "unknown": "Unexpected error."
+      }
+    },
     "sentinel": {
       "entry_type": "service",
       "abort": {

--- a/custom_components/home_generative_agent/translations/tr.json
+++ b/custom_components/home_generative_agent/translations/tr.json
@@ -142,6 +142,61 @@
         "unknown": "Beklenmeyen hata."
       }
     },
+    "tts_provider": {
+      "entry_type": "service",
+      "abort": {
+        "reconfigure_successful": "TTS sağlayıcı güncellendi."
+      },
+      "initiate_flow": {
+        "reconfigure": "TTS sağlayıcıyı yeniden yapılandır",
+        "user": "TTS sağlayıcı ekle"
+      },
+      "step": {
+        "provider": {
+          "title": "Metinden Konuşmaya Sağlayıcı",
+          "description": "Sağlayıcı türünü ve adını seçin.",
+          "data": {
+            "provider_type": "Sağlayıcı",
+            "name": "Sağlayıcı adı"
+          }
+        },
+        "credentials": {
+          "title": "Kimlik bilgileri",
+          "description": "TTS sağlayıcısı için kimlik doğrulama seçin. Yerel sağlayıcılar bunun yerine OpenAI uyumlu bir sunucu URL'sine bağlanır.",
+          "data": {
+            "openai_provider_subentry_id": "OpenAI model sağlayıcıyı yeniden kullan",
+            "api_key": "API anahtarı",
+            "base_url": "Sunucu URL'si"
+          },
+          "data_description": {
+            "api_key": "OpenAI için zorunludur. Kimlik doğrulaması gerektirmeyen yerel sunucular için isteğe bağlıdır.",
+            "base_url": "Yerel TTS sunucusunun OpenAI uyumlu uç noktası, örn. bir Speaches örneği. Eksik /v1 eki otomatik olarak eklenir."
+          }
+        },
+        "model": {
+          "title": "Model, ses ve gelişmiş seçenekler",
+          "description": "Bir model ve ses seçin, isteğe bağlı gelişmiş ayarları yapılandırın.",
+          "data": {
+            "model_name": "Model",
+            "voice": "Ses",
+            "speed": "Hız",
+            "instructions": "Ses yönergeleri (isteğe bağlı)"
+          },
+          "data_description": {
+            "voice": "OpenAI: alloy, ash, ballad, cedar, coral, echo, fable, marin, nova, onyx, sage, shimmer veya verse. Yerel: sunucunun modelinin sağladığı bir ses kimliği, örn. Kokoro için af_heart.",
+            "speed": "Oynatma hızı çarpanı, 0,25 ile 4,0 arası. 1,0 normal hızdır.",
+            "instructions": "Sesin nasıl olması gerektiği, örn. ton veya tempo. Yalnızca OpenAI gpt-4o-mini-tts modelleri kullanır; diğerlerinde yok sayılır."
+          }
+        }
+      },
+      "error": {
+        "cannot_connect": "Sağlayıcıya erişilemiyor.",
+        "invalid_auth": "Geçersiz kimlik bilgileri.",
+        "invalid_model": "Geçerli bir model seçin.",
+        "not_supported": "Sağlayıcı henüz desteklenmiyor.",
+        "unknown": "Beklenmeyen hata."
+      }
+    },
     "sentinel": {
       "entry_type": "service",
       "abort": {

--- a/custom_components/home_generative_agent/tts.py
+++ b/custom_components/home_generative_agent/tts.py
@@ -21,7 +21,7 @@ from openai import AsyncOpenAI, AuthenticationError, Omit, OpenAIError
 from propcache.api import cached_property
 
 from .const import (
-    CONF_TTS_BASE_URL,
+    CONF_OPENAI_COMPATIBLE_ENDPOINT_BASE_URL,
     CONF_TTS_INSTRUCTIONS,
     CONF_TTS_MODEL_NAME,
     CONF_TTS_OPENAI_PROVIDER_ID,
@@ -137,10 +137,15 @@ def _negotiate_format(preferred: Any, supported: frozenset[str]) -> tuple[str, s
     Voice PE's 16 kHz mono wav request is always converted by HA as well.
     """
     fmt = str(preferred or TTS_DEFAULT_RESPONSE_FORMAT).lower()
+    # HA compares the returned extension to the literal preference and only
+    # skips ffmpeg on an exact match, so the caller's own spelling is reported
+    # even where the backend calls the codec something else (ogg/oga carry
+    # opus; raw is pcm). Reporting the backend's name would re-mux every
+    # reply, and ``-f pcm`` is not an ffmpeg demuxer at all.
     if fmt in ("ogg", "oga"):
-        return ("ogg", "opus") if "opus" in supported else ("mp3", "mp3")
+        return (fmt, "opus") if "opus" in supported else ("mp3", "mp3")
     if fmt == "raw":
-        fmt = "pcm"
+        return ("raw", "pcm") if "pcm" in supported else ("mp3", "mp3")
     if fmt in supported:
         return fmt, fmt
     return TTS_DEFAULT_RESPONSE_FORMAT, TTS_DEFAULT_RESPONSE_FORMAT
@@ -173,7 +178,6 @@ class HGATtsEntity(TextToSpeechEntity):
     """Text-to-speech entity backed by the OpenAI speech API or a local server."""
 
     _attr_has_entity_name = True
-    _attr_supported_languages = SUPPORTED_LANGUAGES
     _attr_default_language = DEFAULT_LANGUAGE
 
     def __init__(self, entry: ConfigEntry, subentry_id: str) -> None:
@@ -192,6 +196,28 @@ class HGATtsEntity(TextToSpeechEntity):
         self._openai_client_cache_key: tuple[str, str | None] | None = None
 
     # ------------------------------------------------------------------ config
+
+    @cached_property
+    def supported_languages(self) -> list[str]:
+        """
+        Return the accepted language tags.
+
+        The Assist pipeline matches loosely, but ``tts.speak`` and the media
+        source check exact membership, so the bare primary subtags (``en``) and
+        Home Assistant's own configured language are accepted alongside the
+        region-qualified tags the models document. The models detect the
+        language from the text; the tag only has to get past that check.
+        Cached like the base class declares; it is first read after the entity
+        is added, when ``hass`` is set.
+        """
+        languages = set(SUPPORTED_LANGUAGES)
+        languages.update(tag.split("-", 1)[0] for tag in SUPPORTED_LANGUAGES)
+        hass = getattr(self, "hass", None)
+        hass_lang = getattr(getattr(hass, "config", None), "language", None)
+        if isinstance(hass_lang, str) and hass_lang:
+            languages.add(hass_lang)
+            languages.add(hass_lang.split("-", 1)[0])
+        return sorted(languages)
 
     @property
     def _provider_type(self) -> str:
@@ -286,7 +312,7 @@ class HGATtsEntity(TextToSpeechEntity):
         if provider_type == "local":
             settings = data.get("settings", {})
             settings = dict(settings) if isinstance(settings, Mapping) else {}
-            base_url = settings.get(CONF_TTS_BASE_URL)
+            base_url = settings.get(CONF_OPENAI_COMPATIBLE_ENDPOINT_BASE_URL)
             if not isinstance(base_url, str) or not base_url:
                 msg = f"Local TTS base URL missing for {self.entity_id}"
                 raise HomeAssistantError(msg)
@@ -326,6 +352,10 @@ class HGATtsEntity(TextToSpeechEntity):
             base_url=base_url,
             http_client=get_async_client(self.hass),
             timeout=httpx.Timeout(TTS_REQUEST_TIMEOUT_S, connect=5.0),
+            # The SDK default of 2 retries would make a wedged local server cost
+            # three timeouts (~3 minutes) of silence on the satellite before an
+            # error surfaces; a spoken reply should fail fast instead.
+            max_retries=0,
         )
         self._openai_client = client
         self._openai_client_cache_key = cache_key

--- a/custom_components/home_generative_agent/tts.py
+++ b/custom_components/home_generative_agent/tts.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
-import httpx
 from homeassistant.components.tts import (
     ATTR_PREFERRED_FORMAT,
     ATTR_VOICE,
@@ -16,24 +14,20 @@ from homeassistant.components.tts import (
 )
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.httpx_client import get_async_client
-from openai import AsyncOpenAI, AuthenticationError, Omit, OpenAIError
+from openai import AuthenticationError, OpenAIError
 from propcache.api import cached_property
 
 from .const import (
-    CONF_OPENAI_COMPATIBLE_ENDPOINT_BASE_URL,
     CONF_TTS_INSTRUCTIONS,
     CONF_TTS_MODEL_NAME,
     CONF_TTS_OPENAI_PROVIDER_ID,
     CONF_TTS_SPEED,
     CONF_TTS_VOICE,
-    LOCAL_KEYLESS_API_KEY,
     OPENAI_TTS_VOICES,
     RECOMMENDED_LOCAL_TTS_MODEL,
     RECOMMENDED_LOCAL_TTS_VOICE,
     RECOMMENDED_OPENAI_TTS_MODEL,
     RECOMMENDED_OPENAI_TTS_VOICE,
-    SUBENTRY_TYPE_MODEL_PROVIDER,
     SUBENTRY_TYPE_TTS_PROVIDER,
     TTS_DEFAULT_RESPONSE_FORMAT,
     TTS_INSTRUCTIONS_MODEL_PREFIX,
@@ -41,8 +35,16 @@ from .const import (
     TTS_OPENAI_RESPONSE_FORMATS,
     TTS_SPEED_DEFAULT,
 )
+from .core.openai_endpoint import (
+    OpenAIClientCache,
+    OpenAIConnectionError,
+    load_model_settings,
+    resolve_openai_connection,
+)
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -121,11 +123,6 @@ SUPPORTED_LANGUAGES = [
 DEFAULT_LANGUAGE = "en-US"
 
 
-def _load_model_settings(data: Mapping[str, Any]) -> dict[str, Any]:
-    model_data = data.get("model", {})
-    return dict(model_data) if isinstance(model_data, Mapping) else {}
-
-
 def _negotiate_format(preferred: Any, supported: frozenset[str]) -> tuple[str, str]:
     """
     Return ``(extension, request_format)`` for a preferred output format.
@@ -192,8 +189,7 @@ class HGATtsEntity(TextToSpeechEntity):
         self._subentry = entry.subentries[subentry_id]
         self._attr_unique_id = f"{entry.entry_id}_{subentry_id}"
         self._attr_name = self._subentry.title or "TTS"
-        self._openai_client: AsyncOpenAI | None = None
-        self._openai_client_cache_key: tuple[str, str | None] | None = None
+        self._clients = OpenAIClientCache(TTS_REQUEST_TIMEOUT_S)
 
     # ------------------------------------------------------------------ config
 
@@ -224,7 +220,7 @@ class HGATtsEntity(TextToSpeechEntity):
         return str(self._subentry.data.get("provider_type") or "openai")
 
     def _model_settings(self) -> dict[str, Any]:
-        return _load_model_settings(self._subentry.data)
+        return load_model_settings(self._subentry.data)
 
     def _configured_model(self) -> str:
         model = self._model_settings().get(CONF_TTS_MODEL_NAME)
@@ -280,86 +276,9 @@ class HGATtsEntity(TextToSpeechEntity):
 
     # ------------------------------------------------------------ connection
 
-    def _resolve_api_key(self, data: Mapping[str, Any]) -> str | None:
-        settings = data.get("settings", {})
-        settings = dict(settings) if isinstance(settings, Mapping) else {}
-        provider_id = settings.get(CONF_TTS_OPENAI_PROVIDER_ID)
-        if provider_id:
-            provider = self.entry.subentries.get(provider_id)
-            if provider and provider.subentry_type == SUBENTRY_TYPE_MODEL_PROVIDER:
-                provider_settings = provider.data.get("settings", {})
-                if isinstance(provider_settings, Mapping):
-                    # A linked provider is authoritative: never fall back to the
-                    # TTS-level key, which the flow blanks out when linking.
-                    provider_key = dict(provider_settings).get("api_key")
-                    if isinstance(provider_key, str) and provider_key:
-                        return provider_key
-                    return None
-        api_key = settings.get("api_key")
-        return api_key if isinstance(api_key, str) and api_key else None
-
-    def _resolve_connection(
-        self, provider_type: str, data: Mapping[str, Any]
-    ) -> tuple[str, str | None]:
-        """
-        Return (api_key, base_url) for the provider.
-
-        Local providers require a base URL and fall back to the keyless
-        placeholder when the server needs none; the request strips the
-        Authorization header so the wire shape matches the flow's validation.
-        Raises HomeAssistantError when the subentry cannot be used.
-        """
-        if provider_type == "local":
-            settings = data.get("settings", {})
-            settings = dict(settings) if isinstance(settings, Mapping) else {}
-            base_url = settings.get(CONF_OPENAI_COMPATIBLE_ENDPOINT_BASE_URL)
-            if not isinstance(base_url, str) or not base_url:
-                msg = f"Local TTS base URL missing for {self.entity_id}"
-                raise HomeAssistantError(msg)
-            configured_key = settings.get("api_key")
-            api_key = (
-                configured_key
-                if isinstance(configured_key, str) and configured_key
-                else LOCAL_KEYLESS_API_KEY
-            )
-            return api_key, base_url
-        api_key = self._resolve_api_key(data)
-        if not api_key:
-            msg = f"OpenAI TTS API key missing for {self.entity_id}"
-            raise HomeAssistantError(msg)
-        return api_key, None
-
-    def _get_client(self, api_key: str, base_url: str | None) -> AsyncOpenAI:
-        """
-        Return a cached OpenAI client for the resolved API key and base URL.
-
-        Built on Home Assistant's shared httpx client so the SDK never creates
-        its own SSL context (a blocking read of the certifi bundle) on the event
-        loop, and so consecutive replies reuse a pooled connection. The client
-        belongs to HA and is never closed here. The timeout is pinned on the
-        SDK client rather than inherited from the shared one. The cache is keyed
-        on ``(api_key, base_url)`` so reconfiguring the subentry or its linked
-        model provider takes effect on the next reply.
-        """
-        cache_key = (api_key, base_url)
-        if (
-            self._openai_client is not None
-            and self._openai_client_cache_key == cache_key
-        ):
-            return self._openai_client
-        client = AsyncOpenAI(
-            api_key=api_key,
-            base_url=base_url,
-            http_client=get_async_client(self.hass),
-            timeout=httpx.Timeout(TTS_REQUEST_TIMEOUT_S, connect=5.0),
-            # The SDK default of 2 retries would make a wedged local server cost
-            # three timeouts (~3 minutes) of silence on the satellite before an
-            # error surfaces; a spoken reply should fail fast instead.
-            max_retries=0,
-        )
-        self._openai_client = client
-        self._openai_client_cache_key = cache_key
-        return client
+    def _get_client(self, api_key: str, base_url: str | None) -> Any:
+        """Return the cached OpenAI client for these credentials."""
+        return self._clients.get(self.hass, api_key, base_url)
 
     # ------------------------------------------------------------- synthesis
 
@@ -409,17 +328,21 @@ class HGATtsEntity(TextToSpeechEntity):
             msg = f"Unsupported TTS provider type {provider_type!r}"
             raise HomeAssistantError(msg)
 
-        api_key, base_url = self._resolve_connection(provider_type, self._subentry.data)
+        try:
+            connection = resolve_openai_connection(
+                self.entry,
+                provider_type,
+                self._subentry.data,
+                provider_id_key=CONF_TTS_OPENAI_PROVIDER_ID,
+            )
+        except OpenAIConnectionError as err:
+            msg = f"TTS {err} for {self.entity_id}"
+            raise HomeAssistantError(msg) from err
         extension, request = self._build_request(message, options)
-        if api_key == LOCAL_KEYLESS_API_KEY:
-            # Keyless local server: send no Authorization header at all. The
-            # placeholder exists only because the SDK constructor refuses an
-            # empty key; ``Omit`` drops the header the client would otherwise
-            # add from it.
-            request["extra_headers"] = {"Authorization": Omit()}
+        connection.apply_to_request(request)
 
         try:
-            client = self._get_client(api_key, base_url)
+            client = self._get_client(connection.api_key, connection.base_url)
             response = await client.audio.speech.create(**request)
             audio = response.content
         except AuthenticationError as err:

--- a/custom_components/home_generative_agent/tts.py
+++ b/custom_components/home_generative_agent/tts.py
@@ -1,0 +1,407 @@
+"""Text-to-speech platform for Home Generative Agent (OpenAI or a local server)."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
+
+import httpx
+from homeassistant.components.tts import (
+    ATTR_PREFERRED_FORMAT,
+    ATTR_VOICE,
+    TextToSpeechEntity,
+    TtsAudioType,
+    Voice,
+)
+from homeassistant.core import callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.httpx_client import get_async_client
+from openai import AsyncOpenAI, AuthenticationError, Omit, OpenAIError
+from propcache.api import cached_property
+
+from .const import (
+    CONF_TTS_BASE_URL,
+    CONF_TTS_INSTRUCTIONS,
+    CONF_TTS_MODEL_NAME,
+    CONF_TTS_OPENAI_PROVIDER_ID,
+    CONF_TTS_SPEED,
+    CONF_TTS_VOICE,
+    LOCAL_KEYLESS_API_KEY,
+    OPENAI_TTS_VOICES,
+    RECOMMENDED_LOCAL_TTS_MODEL,
+    RECOMMENDED_LOCAL_TTS_VOICE,
+    RECOMMENDED_OPENAI_TTS_MODEL,
+    RECOMMENDED_OPENAI_TTS_VOICE,
+    SUBENTRY_TYPE_MODEL_PROVIDER,
+    SUBENTRY_TYPE_TTS_PROVIDER,
+    TTS_DEFAULT_RESPONSE_FORMAT,
+    TTS_INSTRUCTIONS_MODEL_PREFIX,
+    TTS_LOCAL_RESPONSE_FORMATS,
+    TTS_OPENAI_RESPONSE_FORMATS,
+    TTS_SPEED_DEFAULT,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+    from .core.runtime import HGAConfigEntry
+
+LOGGER = logging.getLogger(__name__)
+
+# Pinned so the effective timeout never depends on what HA's shared httpx
+# client happens to carry. A spoken reply is a few sentences; a minute covers a
+# cold model load on a local server with room to spare.
+TTS_REQUEST_TIMEOUT_S = 60.0
+
+# Language tags the OpenAI speech models document. The models detect the input
+# language themselves, so this list only has to satisfy the Assist pipeline's
+# language matching; a local model (e.g. Kokoro) may cover fewer of them.
+SUPPORTED_LANGUAGES = [
+    "af-ZA",
+    "ar-SA",
+    "hy-AM",
+    "az-AZ",
+    "be-BY",
+    "bs-BA",
+    "bg-BG",
+    "ca-ES",
+    "zh-CN",
+    "hr-HR",
+    "cs-CZ",
+    "da-DK",
+    "nl-NL",
+    "en-US",
+    "et-EE",
+    "fi-FI",
+    "fr-FR",
+    "gl-ES",
+    "de-DE",
+    "el-GR",
+    "he-IL",
+    "hi-IN",
+    "hu-HU",
+    "is-IS",
+    "id-ID",
+    "it-IT",
+    "ja-JP",
+    "kn-IN",
+    "kk-KZ",
+    "ko-KR",
+    "lv-LV",
+    "lt-LT",
+    "mk-MK",
+    "ms-MY",
+    "mr-IN",
+    "mi-NZ",
+    "ne-NP",
+    "no-NO",
+    "fa-IR",
+    "pl-PL",
+    "pt-PT",
+    "ro-RO",
+    "ru-RU",
+    "sr-RS",
+    "sk-SK",
+    "sl-SI",
+    "es-ES",
+    "sw-KE",
+    "sv-SE",
+    "fil-PH",
+    "ta-IN",
+    "th-TH",
+    "tr-TR",
+    "uk-UA",
+    "ur-PK",
+    "vi-VN",
+    "cy-GB",
+]
+DEFAULT_LANGUAGE = "en-US"
+
+
+def _load_model_settings(data: Mapping[str, Any]) -> dict[str, Any]:
+    model_data = data.get("model", {})
+    return dict(model_data) if isinstance(model_data, Mapping) else {}
+
+
+def _negotiate_format(preferred: Any, supported: frozenset[str]) -> tuple[str, str]:
+    """
+    Return ``(extension, request_format)`` for a preferred output format.
+
+    ``extension`` is what the entity reports to Home Assistant and
+    ``request_format`` is what the backend is asked for. Containers the backend
+    cannot produce fall back to mp3 and Home Assistant converts with ffmpeg;
+    the preferred_* sample options are never declared as supported, so the
+    Voice PE's 16 kHz mono wav request is always converted by HA as well.
+    """
+    fmt = str(preferred or TTS_DEFAULT_RESPONSE_FORMAT).lower()
+    if fmt in ("ogg", "oga"):
+        return ("ogg", "opus") if "opus" in supported else ("mp3", "mp3")
+    if fmt == "raw":
+        fmt = "pcm"
+    if fmt in supported:
+        return fmt, fmt
+    return TTS_DEFAULT_RESPONSE_FORMAT, TTS_DEFAULT_RESPONSE_FORMAT
+
+
+def _wants_instructions(provider_type: str, model_name: str) -> bool:
+    """Only OpenAI's gpt-4o-mini-tts family accepts the instructions parameter."""
+    return provider_type == "openai" and model_name.startswith(
+        TTS_INSTRUCTIONS_MODEL_PREFIX
+    )
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,  # noqa: ARG001
+    entry: HGAConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up TTS entities, one per TTS provider subentry."""
+    for subentry in entry.subentries.values():
+        if subentry.subentry_type != SUBENTRY_TYPE_TTS_PROVIDER:
+            continue
+        # Bound to the subentry so the entity-registry entry is removed with it.
+        async_add_entities(
+            [HGATtsEntity(entry, subentry.subentry_id)],
+            config_subentry_id=subentry.subentry_id,
+        )
+
+
+class HGATtsEntity(TextToSpeechEntity):
+    """Text-to-speech entity backed by the OpenAI speech API or a local server."""
+
+    _attr_has_entity_name = True
+    _attr_supported_languages = SUPPORTED_LANGUAGES
+    _attr_default_language = DEFAULT_LANGUAGE
+
+    def __init__(self, entry: ConfigEntry, subentry_id: str) -> None:
+        """Initialize the TTS entity."""
+        # ATTR_VOICE must be declared or the pipeline's voice option is
+        # rejected; declaring ATTR_PREFERRED_FORMAT means the entity picks the
+        # container itself, so HA only runs ffmpeg for sample-rate/channel
+        # changes.
+        self._attr_supported_options = [ATTR_VOICE, ATTR_PREFERRED_FORMAT]
+        self.entry = entry
+        self.subentry_id = subentry_id
+        self._subentry = entry.subentries[subentry_id]
+        self._attr_unique_id = f"{entry.entry_id}_{subentry_id}"
+        self._attr_name = self._subentry.title or "TTS"
+        self._openai_client: AsyncOpenAI | None = None
+        self._openai_client_cache_key: tuple[str, str | None] | None = None
+
+    # ------------------------------------------------------------------ config
+
+    @property
+    def _provider_type(self) -> str:
+        return str(self._subentry.data.get("provider_type") or "openai")
+
+    def _model_settings(self) -> dict[str, Any]:
+        return _load_model_settings(self._subentry.data)
+
+    def _configured_model(self) -> str:
+        model = self._model_settings().get(CONF_TTS_MODEL_NAME)
+        if isinstance(model, str) and model:
+            return model
+        return (
+            RECOMMENDED_LOCAL_TTS_MODEL
+            if self._provider_type == "local"
+            else RECOMMENDED_OPENAI_TTS_MODEL
+        )
+
+    def _configured_voice(self) -> str:
+        voice = self._model_settings().get(CONF_TTS_VOICE)
+        if isinstance(voice, str) and voice:
+            return voice
+        return (
+            RECOMMENDED_LOCAL_TTS_VOICE
+            if self._provider_type == "local"
+            else RECOMMENDED_OPENAI_TTS_VOICE
+        )
+
+    @cached_property
+    def default_options(self) -> Mapping[str, Any]:
+        """
+        Return the options used when the caller does not specify any.
+
+        Cached like the base class declares; a reconfigured subentry reloads the
+        config entry and rebuilds the entity, so the cache never goes stale.
+        """
+        return {
+            ATTR_VOICE: self._configured_voice(),
+            ATTR_PREFERRED_FORMAT: TTS_DEFAULT_RESPONSE_FORMAT,
+        }
+
+    @callback
+    def async_get_supported_voices(self, language: str) -> list[Voice] | None:  # noqa: ARG002
+        """
+        Return the selectable voices, configured default first.
+
+        The Assist pipeline takes index 0 as its default voice. OpenAI's voices
+        are a fixed set; a local server's cannot be listed through the OpenAI
+        API, so only the configured voice is offered there (any other voice id
+        can still be requested through the pipeline options).
+        """
+        configured = self._configured_voice()
+        if self._provider_type != "openai":
+            return [Voice(configured, configured)]
+        voices = [Voice(name.lower(), name) for name in OPENAI_TTS_VOICES]
+        voices.sort(key=lambda voice: voice.voice_id != configured)
+        if voices[0].voice_id != configured:
+            voices.insert(0, Voice(configured, configured))
+        return voices
+
+    # ------------------------------------------------------------ connection
+
+    def _resolve_api_key(self, data: Mapping[str, Any]) -> str | None:
+        settings = data.get("settings", {})
+        settings = dict(settings) if isinstance(settings, Mapping) else {}
+        provider_id = settings.get(CONF_TTS_OPENAI_PROVIDER_ID)
+        if provider_id:
+            provider = self.entry.subentries.get(provider_id)
+            if provider and provider.subentry_type == SUBENTRY_TYPE_MODEL_PROVIDER:
+                provider_settings = provider.data.get("settings", {})
+                if isinstance(provider_settings, Mapping):
+                    # A linked provider is authoritative: never fall back to the
+                    # TTS-level key, which the flow blanks out when linking.
+                    provider_key = dict(provider_settings).get("api_key")
+                    if isinstance(provider_key, str) and provider_key:
+                        return provider_key
+                    return None
+        api_key = settings.get("api_key")
+        return api_key if isinstance(api_key, str) and api_key else None
+
+    def _resolve_connection(
+        self, provider_type: str, data: Mapping[str, Any]
+    ) -> tuple[str, str | None]:
+        """
+        Return (api_key, base_url) for the provider.
+
+        Local providers require a base URL and fall back to the keyless
+        placeholder when the server needs none; the request strips the
+        Authorization header so the wire shape matches the flow's validation.
+        Raises HomeAssistantError when the subentry cannot be used.
+        """
+        if provider_type == "local":
+            settings = data.get("settings", {})
+            settings = dict(settings) if isinstance(settings, Mapping) else {}
+            base_url = settings.get(CONF_TTS_BASE_URL)
+            if not isinstance(base_url, str) or not base_url:
+                msg = f"Local TTS base URL missing for {self.entity_id}"
+                raise HomeAssistantError(msg)
+            configured_key = settings.get("api_key")
+            api_key = (
+                configured_key
+                if isinstance(configured_key, str) and configured_key
+                else LOCAL_KEYLESS_API_KEY
+            )
+            return api_key, base_url
+        api_key = self._resolve_api_key(data)
+        if not api_key:
+            msg = f"OpenAI TTS API key missing for {self.entity_id}"
+            raise HomeAssistantError(msg)
+        return api_key, None
+
+    def _get_client(self, api_key: str, base_url: str | None) -> AsyncOpenAI:
+        """
+        Return a cached OpenAI client for the resolved API key and base URL.
+
+        Built on Home Assistant's shared httpx client so the SDK never creates
+        its own SSL context (a blocking read of the certifi bundle) on the event
+        loop, and so consecutive replies reuse a pooled connection. The client
+        belongs to HA and is never closed here. The timeout is pinned on the
+        SDK client rather than inherited from the shared one. The cache is keyed
+        on ``(api_key, base_url)`` so reconfiguring the subentry or its linked
+        model provider takes effect on the next reply.
+        """
+        cache_key = (api_key, base_url)
+        if (
+            self._openai_client is not None
+            and self._openai_client_cache_key == cache_key
+        ):
+            return self._openai_client
+        client = AsyncOpenAI(
+            api_key=api_key,
+            base_url=base_url,
+            http_client=get_async_client(self.hass),
+            timeout=httpx.Timeout(TTS_REQUEST_TIMEOUT_S, connect=5.0),
+        )
+        self._openai_client = client
+        self._openai_client_cache_key = cache_key
+        return client
+
+    # ------------------------------------------------------------- synthesis
+
+    def _build_request(
+        self, message: str, options: Mapping[str, Any]
+    ) -> tuple[str, dict[str, Any]]:
+        """Return ``(extension, kwargs)`` for ``client.audio.speech.create``."""
+        provider_type = self._provider_type
+        model_settings = self._model_settings()
+        model_name = self._configured_model()
+        supported = (
+            TTS_LOCAL_RESPONSE_FORMATS
+            if provider_type == "local"
+            else TTS_OPENAI_RESPONSE_FORMATS
+        )
+        extension, response_format = _negotiate_format(
+            options.get(ATTR_PREFERRED_FORMAT), supported
+        )
+        request: dict[str, Any] = {
+            "model": model_name,
+            "voice": options.get(ATTR_VOICE) or self._configured_voice(),
+            "input": message,
+            "response_format": response_format,
+        }
+        speed = model_settings.get(CONF_TTS_SPEED)
+        if isinstance(speed, (int, float)) and float(speed) != TTS_SPEED_DEFAULT:
+            request["speed"] = float(speed)
+        instructions = model_settings.get(CONF_TTS_INSTRUCTIONS)
+        if (
+            isinstance(instructions, str)
+            and instructions
+            and _wants_instructions(provider_type, model_name)
+        ):
+            request["instructions"] = instructions
+        return extension, request
+
+    async def async_get_tts_audio(
+        self, message: str, language: str, options: dict[str, Any]
+    ) -> TtsAudioType:
+        """Synthesize ``message`` and return ``(extension, audio bytes)``."""
+        _ = language  # the models detect the language from the text itself
+        if not message.strip():
+            msg = f"No text to synthesize for {self.entity_id}"
+            raise HomeAssistantError(msg)
+        provider_type = self._provider_type
+        if provider_type not in ("openai", "local"):
+            msg = f"Unsupported TTS provider type {provider_type!r}"
+            raise HomeAssistantError(msg)
+
+        api_key, base_url = self._resolve_connection(provider_type, self._subentry.data)
+        extension, request = self._build_request(message, options)
+        if api_key == LOCAL_KEYLESS_API_KEY:
+            # Keyless local server: send no Authorization header at all. The
+            # placeholder exists only because the SDK constructor refuses an
+            # empty key; ``Omit`` drops the header the client would otherwise
+            # add from it.
+            request["extra_headers"] = {"Authorization": Omit()}
+
+        try:
+            client = self._get_client(api_key, base_url)
+            response = await client.audio.speech.create(**request)
+            audio = response.content
+        except AuthenticationError as err:
+            LOGGER.warning("TTS authentication failed for %s", self.entity_id)
+            msg = f"TTS authentication failed for {self.entity_id}"
+            raise HomeAssistantError(msg) from err
+        except OpenAIError as err:
+            LOGGER.warning("TTS request failed for %s: %s", self.entity_id, err)
+            msg = f"TTS request failed for {self.entity_id}: {err}"
+            raise HomeAssistantError(msg) from err
+
+        if not audio:
+            msg = f"TTS backend returned no audio for {self.entity_id}"
+            raise HomeAssistantError(msg)
+        return extension, audio

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,6 +10,7 @@ The configuration UI is available in English, Czech, and Turkish, with a partial
 - [Tool Retrieval (RAG)](#tool-retrieval-rag)
 - [Control Home Assistant (LLM API)](#control-home-assistant-llm-api)
 - [Speech-to-Text (STT)](#speech-to-text-stt)
+- [Text-to-Speech (TTS)](#text-to-speech-tts)
 - [Schema-first YAML Mode](#schema-first-yaml-mode)
 - [Critical Action PIN](#critical-action-pin)
 - [Global Options](#global-options)
@@ -269,7 +270,7 @@ services:
     volumes:
       - hf-hub-cache:/home/ubuntu/.cache/huggingface/hub
     environment:
-      - PRELOAD_MODELS=["deepdml/faster-whisper-large-v3-turbo-ct2"]
+      - PRELOAD_MODELS=["deepdml/faster-whisper-large-v3-turbo-ct2", "speaches-ai/Kokoro-82M-v1.0-ONNX"]
       - STT_MODEL_TTL=-1            # keep the model resident; the first utterance after a reload pays several seconds
       # - WHISPER__COMPUTE_TYPE=int8_float32   # required on Pascal GPUs (GTX 10xx): float16 is not supported there
     deploy:
@@ -284,6 +285,40 @@ volumes:
 ```
 
 > **Tip:** local whisper models occasionally hallucinate short phrases ("Thank you.") from silence or noise. The **Speech input filters** in the integration options (**Configure**) drop such phantom transcriptions before they reach the agent — add the phrases you see under **Ignored exact STT phrases**.
+
+---
+
+## Text-to-Speech (TTS)
+
+HGA also provides a built-in TTS engine for Assist pipelines, so a reply can be spoken by the OpenAI speech API or by the same local server that handles speech-to-text. Two provider types are supported: **OpenAI** and **Local** (any server exposing the OpenAI `/v1/audio/speech` endpoint, e.g. [Speaches](https://speaches.ai/) serving Kokoro or piper voices).
+
+1. Open **Settings → Devices & Services → Home Generative Agent**.
+2. Click **+ TTS Provider**.
+3. Choose **OpenAI** or **Local (OpenAI-compatible)** and give it a name. The name is what the Assist pipeline's Text-to-speech dropdown shows.
+4. On the **Credentials** step:
+   - **OpenAI:** reuse an existing OpenAI Model Provider subentry or select **Use a separate key** and enter a dedicated API key.
+   - **Local:** enter the server URL (e.g. `http://192.168.1.100:8000` — a missing `/v1` suffix is added automatically). The API key is optional; leave it blank for servers without authentication. The endpoint is validated when you submit the form.
+5. On **Model, voice & advanced options**:
+   - model: `gpt-4o-mini-tts` (recommended), `tts-1`, or `tts-1-hd` for OpenAI; `speaches-ai/Kokoro-82M-v1.0-ONNX` (recommended) or any model ID your server serves for Local
+   - voice: OpenAI offers `alloy`, `ash`, `ballad`, `cedar`, `coral`, `echo`, `fable`, `marin`, `nova`, `onyx`, `sage`, `shimmer`, and `verse`; for Local, type a voice id the model provides (Kokoro: `af_heart`, `af_bella`, `am_adam`, `bf_emma`, `bm_george`, …; piper: the voice name from the model id, e.g. `hfc_female` for `speaches-ai/piper-en_US-hfc_female-medium`)
+   - speed: 0.25–4.0, default 1.0
+   - voice instructions (optional): tone and pacing hints, used only by OpenAI's `gpt-4o-mini-tts` models and ignored elsewhere
+6. Go to **Settings → Voice assistants → Assist pipelines** and select **TTS - OpenAI** / **TTS - Local** (or your chosen name) for Text-to-speech. The configured voice is the pipeline's default; the pipeline's own voice picker lists the OpenAI voices, or the single configured voice for a local server.
+
+Audio is requested as mp3 (or wav/flac/pcm when the pipeline asks for it) and Home Assistant converts to whatever the satellite needs, so a Voice PE's 16 kHz wav request works with either provider. Credential and server changes take effect on the next reply, like STT.
+
+### Running a local TTS server
+
+The Speaches container from the [STT section](#running-a-local-stt-server) serves TTS too. Speaches only serves models that are already downloaded, so add the TTS model to `PRELOAD_MODELS` (the compose example above lists Kokoro) or download it once with `POST /v1/models/<model-id>`:
+
+```bash
+curl -X POST http://192.168.1.100:8000/v1/models/speaches-ai/Kokoro-82M-v1.0-ONNX
+```
+
+Two things to know about the local backend:
+
+- **Kokoro needs a reasonably modern machine.** On a GPU box that also runs Ollama it is fast and sounds good. On an old CPU without AVX2 it can take several times the audio duration to synthesize a sentence, and ONNX Runtime's CUDA path does not help it on Pascal-class GPUs. In that case use a piper voice instead — `speaches-ai/piper-en_US-hfc_female-medium` (voice `hfc_female`) or a `-low` variant — which synthesizes a sentence in about a second on CPU and needs no GPU. Browse the available models with `GET /v1/registry?task=text-to-speech`.
+- **Speaches does not produce opus or aac.** HGA never asks it to; a pipeline that wants those gets mp3 converted by Home Assistant.
 
 ---
 

--- a/docs/constants.md
+++ b/docs/constants.md
@@ -481,7 +481,7 @@ The same rules screen two surfaces: direct tool calls from the conversation agen
 |---|---|---|---|
 | `TTS_INSTRUCTIONS_MODEL_PREFIX` | `const.py` | `gpt-4o-mini-tts` | Only models with this prefix on the OpenAI provider receive the optional voice instructions; the API rejects the parameter for `tts-1`/`tts-1-hd`, and local servers never get it. |
 | `TTS_OPENAI_RESPONSE_FORMATS` / `TTS_LOCAL_RESPONSE_FORMATS` | `const.py` | mp3, opus, aac, flac, wav, pcm / mp3, flac, wav, pcm | Containers each backend can produce; a pipeline preference outside the set is served as mp3 and converted by Home Assistant. |
-| `TTS_REQUEST_TIMEOUT_S` | `tts.py` | `60.0` (s) | Timeout for one speech request (connect timeout 5 s), pinned on the OpenAI client rather than inherited from Home Assistant's shared httpx client. |
+| `TTS_REQUEST_TIMEOUT_S` | `tts.py` | `60.0` (s) | Timeout for one speech request (connect timeout 5 s), pinned on the OpenAI client rather than inherited from Home Assistant's shared httpx client. The client makes one attempt (`max_retries=0`), as does the STT client, so a wedged server costs one timeout of silence rather than three. |
 | `LOCAL_KEYLESS_API_KEY` | `const.py` | `sk-hga-keyless-local` | Placeholder key for keyless local STT/TTS servers; satisfies the SDK constructor and is stripped from every request with the SDK's `Omit` sentinel. |
 
 ---

--- a/docs/constants.md
+++ b/docs/constants.md
@@ -463,6 +463,29 @@ The same rules screen two surfaces: direct tool calls from the conversation agen
 
 ---
 
+## Text-to-Speech (TTS)
+
+**File:** `const.py` | **UI-configurable**
+
+| Constant | Config key | Default | Purpose |
+|---|---|---|---|
+| `RECOMMENDED_OPENAI_TTS_MODEL` | `model_name` | `gpt-4o-mini-tts` | Default OpenAI speech model for the TTS provider. Supported values: `gpt-4o-mini-tts`, `tts-1`, `tts-1-hd`. |
+| `RECOMMENDED_OPENAI_TTS_VOICE` | `voice` | `alloy` | Default OpenAI voice; any of the 13 built-in voices in `OPENAI_TTS_VOICES` can be chosen, and the configured one leads the Assist pipeline's voice list. |
+| `RECOMMENDED_LOCAL_TTS_MODEL` | `model_name` | `speaches-ai/Kokoro-82M-v1.0-ONNX` | Default model for a local OpenAI-compatible TTS server (Speaches). Any model ID the server serves can be typed in. |
+| `RECOMMENDED_LOCAL_TTS_VOICE` | `voice` | `af_heart` | Default voice for the local model. |
+| `TTS_SPEED_DEFAULT` | `speed` | `1.0` (range `TTS_SPEED_MIN`–`TTS_SPEED_MAX`, 0.25–4.0) | Playback speed multiplier; the default is not sent to the backend. |
+
+**Code-only:**
+
+| Constant | File | Value | Purpose |
+|---|---|---|---|
+| `TTS_INSTRUCTIONS_MODEL_PREFIX` | `const.py` | `gpt-4o-mini-tts` | Only models with this prefix on the OpenAI provider receive the optional voice instructions; the API rejects the parameter for `tts-1`/`tts-1-hd`, and local servers never get it. |
+| `TTS_OPENAI_RESPONSE_FORMATS` / `TTS_LOCAL_RESPONSE_FORMATS` | `const.py` | mp3, opus, aac, flac, wav, pcm / mp3, flac, wav, pcm | Containers each backend can produce; a pipeline preference outside the set is served as mp3 and converted by Home Assistant. |
+| `TTS_REQUEST_TIMEOUT_S` | `tts.py` | `60.0` (s) | Timeout for one speech request (connect timeout 5 s), pinned on the OpenAI client rather than inherited from Home Assistant's shared httpx client. |
+| `LOCAL_KEYLESS_API_KEY` | `const.py` | `sk-hga-keyless-local` | Placeholder key for keyless local STT/TTS servers; satisfies the SDK constructor and is stripped from every request with the SDK's `Omit` sentinel. |
+
+---
+
 ## HTTP Endpoint
 
 **File:** `http.py` | **Code-only**
@@ -508,6 +531,12 @@ These constants live outside `const.py` in individual modules. They affect runti
 | Constant | Value | Purpose |
 |---|---|---|
 | `STT_REQUEST_TIMEOUT_S` | `120.0` (s) | Transcription/translation request timeout (connect timeout 5 s). Each STT entity caches one OpenAI client built on Home Assistant's shared httpx client, so this timeout is pinned on the SDK client instead of inherited from the shared one. |
+
+### `tts.py`
+
+| Constant | Value | Purpose |
+|---|---|---|
+| `TTS_REQUEST_TIMEOUT_S` | `60.0` (s) | Speech request timeout (connect timeout 5 s). Each TTS entity caches one OpenAI client built on Home Assistant's shared httpx client, so this timeout is pinned on the SDK client instead of inherited from the shared one. |
 
 ### `core/person_gallery.py`
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,6 +5,10 @@ pytest-homeassistant-custom-component==0.13.357
 # Match HA core's openai_conversation pin for this HA version: the STT platform
 # runs against core's SDK, and its constructor rules change between releases.
 openai==2.45.0
+# HA's tts component imports mutagen at module import; pin to core's tts manifest.
+mutagen==1.48.1
+# ...and HA's ffmpeg component (imported by tts); pin to core's ffmpeg manifest.
+ha-ffmpeg==3.2.2
 
 pytest==9.*
 pytest-asyncio==1.*

--- a/tests/custom_components/home_generative_agent/test_stt.py
+++ b/tests/custom_components/home_generative_agent/test_stt.py
@@ -24,7 +24,7 @@ from custom_components.home_generative_agent.const import (
     CONF_STT_RESPONSE_FORMAT,
     CONF_STT_TEMPERATURE,
     CONF_STT_TRANSLATE,
-    LOCAL_STT_KEYLESS_API_KEY,
+    LOCAL_KEYLESS_API_KEY,
     RECOMMENDED_LOCAL_STT_MODEL,
     SUBENTRY_TYPE_MODEL_PROVIDER,
     SUBENTRY_TYPE_STT_PROVIDER,
@@ -261,6 +261,13 @@ async def test_no_ssl_context_is_built_on_the_event_loop(
     assert result.result == ha_stt.SpeechResultState.SUCCESS
     assert calls == []
     assert len(patched_client["constructed"]) == 1
+
+
+async def test_client_does_not_retry(patched_client: Any) -> None:
+    """One attempt per utterance: SDK retries would triple a timeout's silence."""
+    entity, _ = _make_entity()
+    await _run(entity, [SimpleNamespace(text="hello")])
+    assert patched_client["kwargs"][0]["max_retries"] == 0
 
 
 async def test_request_timeout_is_pinned_not_inherited(patched_client: Any) -> None:
@@ -747,8 +754,8 @@ async def test_local_provider_builds_client_with_base_url(
     assert kwargs["base_url"] == LOCAL_BASE_URL
     # openai>=2.45 (HA 2026.8+) raises "Missing credentials" on an empty
     # api_key, so the constructor must always get a non-empty placeholder.
-    assert kwargs["api_key"] == LOCAL_STT_KEYLESS_API_KEY
-    assert LOCAL_STT_KEYLESS_API_KEY
+    assert kwargs["api_key"] == LOCAL_KEYLESS_API_KEY
+    assert LOCAL_KEYLESS_API_KEY
     assert len(seen["transcriptions"]) == 1
     # The flow validated the endpoint without an Authorization header; runtime
     # must match, or servers that reject unknown bearer tokens 401 every

--- a/tests/custom_components/home_generative_agent/test_stt.py
+++ b/tests/custom_components/home_generative_agent/test_stt.py
@@ -29,6 +29,7 @@ from custom_components.home_generative_agent.const import (
     SUBENTRY_TYPE_MODEL_PROVIDER,
     SUBENTRY_TYPE_STT_PROVIDER,
 )
+from custom_components.home_generative_agent.core import openai_endpoint
 from custom_components.home_generative_agent.stt import HGASttEntity
 
 if TYPE_CHECKING:
@@ -155,7 +156,7 @@ def patched_client(monkeypatch: pytest.MonkeyPatch, shared_httpx_client: Any) ->
         calls["http_clients"].append(hass)
         return shared_httpx_client
 
-    real_async_openai = hga_stt.AsyncOpenAI
+    real_async_openai = openai_endpoint.AsyncOpenAI
 
     def _counting_async_openai(**kwargs: Any) -> Any:
         client = real_async_openai(**kwargs)
@@ -163,8 +164,8 @@ def patched_client(monkeypatch: pytest.MonkeyPatch, shared_httpx_client: Any) ->
         calls["kwargs"].append(kwargs)
         return client
 
-    monkeypatch.setattr(hga_stt, "get_async_client", _fake_get_async_client)
-    monkeypatch.setattr(hga_stt, "AsyncOpenAI", _counting_async_openai)
+    monkeypatch.setattr(openai_endpoint, "get_async_client", _fake_get_async_client)
+    monkeypatch.setattr(openai_endpoint, "AsyncOpenAI", _counting_async_openai)
     return calls
 
 
@@ -231,7 +232,7 @@ async def test_client_uses_shared_httpx_client(
     assert patched_client["http_clients"] == [entity.hass]
     # Our contract: HA's client is handed to the SDK constructor.
     assert patched_client["kwargs"][0]["http_client"] is shared_httpx_client
-    client = entity._openai_client
+    client = entity._clients.client
     assert client is not None
     # And the SDK honors it, so it never builds an SSL context of its own.
     assert client._client is shared_httpx_client
@@ -283,7 +284,7 @@ async def test_request_timeout_is_pinned_not_inherited(patched_client: Any) -> N
     timeout = patched_client["kwargs"][0]["timeout"]
     assert timeout.read == hga_stt.STT_REQUEST_TIMEOUT_S
     assert timeout.connect == 5.0
-    client = entity._openai_client
+    client = entity._clients.client
     assert client is not None
     assert client.timeout == timeout
 
@@ -358,12 +359,12 @@ async def test_client_construction_failure_returns_error_result(
         msg = "shared client unavailable"
         raise RuntimeError(msg)
 
-    monkeypatch.setattr(hga_stt, "get_async_client", _boom)
+    monkeypatch.setattr(openai_endpoint, "get_async_client", _boom)
     entity, _ = _make_entity()
     result = await entity.async_process_audio_stream(_metadata(), await _stream())
     assert result.result == ha_stt.SpeechResultState.ERROR
     assert result.text is None
-    assert entity._openai_client is None
+    assert entity._clients.client is None
 
 
 async def test_concurrent_streams_build_one_client(patched_client: Any) -> None:
@@ -388,10 +389,10 @@ async def test_client_reused_across_streams(patched_client: Any) -> None:
     """Repeated utterances reuse one client and one connection pool."""
     entity, _ = _make_entity()
     await _run(entity, [SimpleNamespace(text="one")])
-    first = entity._openai_client
+    first = entity._clients.client
     assert first is not None
     await _run(entity, [SimpleNamespace(text="two")])
-    assert entity._openai_client is first
+    assert entity._clients.client is first
     assert len(patched_client["constructed"]) == 1
     assert len(patched_client["http_clients"]) == 1
 
@@ -400,14 +401,14 @@ async def test_client_rebuilt_when_api_key_changes(patched_client: Any) -> None:
     """Reconfiguring the STT subentry key takes effect on the next stream."""
     entity, entry = _make_entity(settings={"api_key": "key-1"})
     await _run(entity, [SimpleNamespace(text="one")])
-    first = entity._openai_client
+    first = entity._clients.client
     entry.subentries["stt_1"].reconfigure(
         {**entry.subentries["stt_1"].data, "settings": {"api_key": "key-2"}}
     )
     await _run(entity, [SimpleNamespace(text="two")])
-    assert entity._openai_client is not first
-    assert entity._openai_client is not None
-    assert entity._openai_client.api_key == "key-2"
+    assert entity._clients.client is not first
+    assert entity._clients.client is not None
+    assert entity._clients.client.api_key == "key-2"
     assert len(patched_client["constructed"]) == 2
 
 
@@ -419,14 +420,14 @@ async def test_client_rebuilt_when_linked_provider_key_changes() -> None:
         provider_settings={"api_key": "prov-key-1"},
     )
     await _run(entity, [SimpleNamespace(text="one")])
-    assert entity._openai_client is not None
-    assert entity._openai_client.api_key == "prov-key-1"
-    first = entity._openai_client
+    assert entity._clients.client is not None
+    assert entity._clients.client.api_key == "prov-key-1"
+    first = entity._clients.client
     entry.subentries["prov_1"].reconfigure({"settings": {"api_key": "prov-key-2"}})
     await _run(entity, [SimpleNamespace(text="two")])
-    assert entity._openai_client is not first
-    assert entity._openai_client is not None
-    assert entity._openai_client.api_key == "prov-key-2"
+    assert entity._clients.client is not first
+    assert entity._clients.client is not None
+    assert entity._clients.client.api_key == "prov-key-2"
 
 
 @pytest.mark.usefixtures("patched_client")
@@ -535,7 +536,7 @@ async def test_empty_audio_builds_no_client(patched_client: Any) -> None:
 
     result = await entity.async_process_audio_stream(_metadata(), _empty())
     assert result.result == ha_stt.SpeechResultState.ERROR
-    assert entity._openai_client is None
+    assert entity._clients.client is None
     assert not patched_client["constructed"]
     assert not patched_client["http_clients"]
 
@@ -545,7 +546,7 @@ async def test_missing_api_key_builds_no_client(patched_client: Any) -> None:
     entity, _ = _make_entity(settings={})
     result = await entity.async_process_audio_stream(_metadata(), await _stream())
     assert result.result == ha_stt.SpeechResultState.ERROR
-    assert entity._openai_client is None
+    assert entity._clients.client is None
     assert not patched_client["constructed"]
     assert not patched_client["http_clients"]
 
@@ -555,7 +556,7 @@ async def test_non_openai_provider_builds_no_client(patched_client: Any) -> None
     entity, _ = _make_entity(provider_type="whisper")
     result = await entity.async_process_audio_stream(_metadata(), await _stream())
     assert result.result == ha_stt.SpeechResultState.ERROR
-    assert entity._openai_client is None
+    assert entity._clients.client is None
     assert not patched_client["constructed"]
     assert not patched_client["http_clients"]
 
@@ -614,8 +615,8 @@ async def test_missing_provider_subentry_falls_back_to_settings_key() -> None:
     )
     result, _ = await _run(entity, [SimpleNamespace(text="ok")])
     assert result.result == ha_stt.SpeechResultState.SUCCESS
-    assert entity._openai_client is not None
-    assert entity._openai_client.api_key == "fallback-key"
+    assert entity._clients.client is not None
+    assert entity._clients.client.api_key == "fallback-key"
 
 
 @pytest.mark.usefixtures("patched_client")
@@ -628,8 +629,8 @@ async def test_wrong_provider_subentry_type_falls_back_to_settings_key() -> None
     entry.subentries["prov_1"].subentry_type = SUBENTRY_TYPE_STT_PROVIDER
     result, _ = await _run(entity, [SimpleNamespace(text="ok")])
     assert result.result == ha_stt.SpeechResultState.SUCCESS
-    assert entity._openai_client is not None
-    assert entity._openai_client.api_key == "fallback-key"
+    assert entity._clients.client is not None
+    assert entity._clients.client.api_key == "fallback-key"
 
 
 async def test_linked_provider_without_key_builds_no_client(
@@ -642,7 +643,7 @@ async def test_linked_provider_without_key_builds_no_client(
     )
     result = await entity.async_process_audio_stream(_metadata(), await _stream())
     assert result.result == ha_stt.SpeechResultState.ERROR
-    assert entity._openai_client is None
+    assert entity._clients.client is None
     assert not patched_client["constructed"]
     assert not patched_client["http_clients"]
 
@@ -659,19 +660,19 @@ async def test_client_reused_when_key_value_unchanged(patched_client: Any) -> No
     """
     entity, entry = _make_entity(settings={"api_key": "key-1"})
     await _run(entity, [SimpleNamespace(text="one")])
-    first = entity._openai_client
+    first = entity._clients.client
     assert first is not None
     # A literal here would be interned and defeat the point of this test.
     reloaded = "".join(["key", "-", "1"])  # noqa: FLY002
     assert reloaded == "key-1"
-    cache_key = entity._openai_client_cache_key
+    cache_key = entity._clients.cache_key
     assert cache_key is not None
     assert reloaded is not cache_key[0]
     entry.subentries["stt_1"].reconfigure(
         {**entry.subentries["stt_1"].data, "settings": {"api_key": reloaded}}
     )
     await _run(entity, [SimpleNamespace(text="two")])
-    assert entity._openai_client is first
+    assert entity._clients.client is first
     assert len(patched_client["constructed"]) == 1
 
 
@@ -801,7 +802,7 @@ async def test_client_rebuilt_when_base_url_changes(patched_client: Any) -> None
     """Repointing a local subentry at a new server takes effect on the next stream."""
     entity, entry = _make_local_entity()
     await _run(entity, [SimpleNamespace(text="one")])
-    first = entity._openai_client
+    first = entity._clients.client
     assert first is not None
     entry.subentries["stt_1"].reconfigure(
         {
@@ -810,7 +811,7 @@ async def test_client_rebuilt_when_base_url_changes(patched_client: Any) -> None
         }
     )
     await _run(entity, [SimpleNamespace(text="two")])
-    assert entity._openai_client is not first
+    assert entity._clients.client is not first
     assert len(patched_client["constructed"]) == 2
     assert patched_client["kwargs"][1]["base_url"] == "http://other-box:8000/v1"
 

--- a/tests/custom_components/home_generative_agent/test_subentries.py
+++ b/tests/custom_components/home_generative_agent/test_subentries.py
@@ -444,6 +444,51 @@ async def test_stt_provider_flow_add_local_replaces_stale_default_name(
     assert result.get("title") == "Garage Whisper"
 
 
+async def test_stt_provider_flow_same_type_reconfigure_keeps_stored_name(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Changing only the URL of an existing local entry never renames it.
+
+    An entry stored as "STT - OpenAI" by the old add-flow pre-fill wart keeps
+    that label on a same-type reconfigure; the stale-default rule applies to
+    adds and type switches only, so an entity name and pipeline label never
+    change behind the user's back.
+    """
+    entry = DummyEntry()
+    entry.subentries["stt1"] = DummySubentry(
+        "stt1",
+        SUBENTRY_TYPE_STT_PROVIDER,
+        "STT - OpenAI",
+        {
+            "provider_type": "local",
+            "name": "STT - OpenAI",
+            "settings": {
+                "base_url": "http://old:8000/v1",
+                "api_key": None,
+                "openai_provider_subentry_id": None,
+            },
+            "model": {"model_name": "some/whisper"},
+        },
+    )
+    flow = _make_stt_flow(hass, entry)
+    cast("Any", flow)._subentry_id = "stt1"
+
+    async def _noop_validate(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(
+        "custom_components.home_generative_agent.flows.openai_compatible_endpoint.validate_openai_compatible_url",
+        _noop_validate,
+    )
+    await flow.async_step_user()
+    await flow.async_step_provider({"provider_type": "local", "name": "STT - OpenAI"})
+    await flow.async_step_credentials({"base_url": "http://new:8000"})
+    result = await flow.async_step_model({"model_name": "some/whisper"})
+    assert result.get("type") == "update_entry"
+    assert result.get("title") == "STT - OpenAI"
+
+
 async def test_stt_provider_flow_switch_to_local_resets_openai_state(
     hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -541,8 +586,9 @@ async def test_tts_provider_flow_reuses_openai_provider(hass: HomeAssistant) -> 
     assert _schema_marker(third, "model_name").default() == "gpt-4o-mini-tts"
     assert _schema_marker(third, "voice").default() == "alloy"
 
+    # Display-cased voice (as the entity itself advertises it) is normalized.
     result = await flow.async_step_model(
-        {"model_name": "gpt-4o-mini-tts", "voice": "nova", "speed": 1.1}
+        {"model_name": "gpt-4o-mini-tts", "voice": "Nova", "speed": 1.1}
     )
     assert result.get("type") == "create_entry"
     assert result.get("title") == "TTS - OpenAI"

--- a/tests/custom_components/home_generative_agent/test_subentries.py
+++ b/tests/custom_components/home_generative_agent/test_subentries.py
@@ -88,6 +88,7 @@ from custom_components.home_generative_agent.const import (
     SUBENTRY_TYPE_MODEL_PROVIDER,
     SUBENTRY_TYPE_SENTINEL,
     SUBENTRY_TYPE_STT_PROVIDER,
+    SUBENTRY_TYPE_TTS_PROVIDER,
 )
 from custom_components.home_generative_agent.core.subentry_resolver import (
     build_model_deployments,
@@ -123,6 +124,9 @@ from custom_components.home_generative_agent.flows.sentinel_subentry_flow import
 )
 from custom_components.home_generative_agent.flows.stt_provider_subentry_flow import (
     SttProviderSubentryFlow,
+)
+from custom_components.home_generative_agent.flows.tts_provider_subentry_flow import (
+    TtsProviderSubentryFlow,
 )
 
 if TYPE_CHECKING:
@@ -186,6 +190,7 @@ def test_supported_subentry_types() -> None:
         SUBENTRY_TYPE_MODEL_PROVIDER,
         SUBENTRY_TYPE_FEATURE,
         SUBENTRY_TYPE_STT_PROVIDER,
+        SUBENTRY_TYPE_TTS_PROVIDER,
         SUBENTRY_TYPE_SENTINEL,
     }
 
@@ -193,6 +198,34 @@ def test_supported_subentry_types() -> None:
 def _make_stt_flow(hass: HomeAssistant, entry: DummyEntry) -> SttProviderSubentryFlow:
     """Build an STT subentry flow with the usual test doubles attached."""
     flow = SttProviderSubentryFlow()
+    flow.hass = hass
+    flow.async_show_form = lambda **kwargs: {  # type: ignore[assignment]
+        "type": "form",
+        "data_schema": kwargs["data_schema"],
+        "errors": kwargs.get("errors"),
+    }
+    flow.async_create_entry = lambda **kwargs: {  # type: ignore[assignment]
+        "type": "create_entry",
+        "title": kwargs.get("title"),
+        "data": kwargs.get("data"),
+    }
+    flow.async_abort = lambda **kwargs: {  # type: ignore[assignment]
+        "type": "abort",
+        "reason": kwargs.get("reason"),
+    }
+    flow.async_update_and_abort = lambda *_args, **kwargs: {  # type: ignore[assignment]
+        "type": "update_entry",
+        "title": kwargs.get("title"),
+        "data": kwargs.get("data"),
+    }
+    flow._schedule_reload = lambda: None  # type: ignore[assignment]
+    _patch_entry(flow, entry)
+    return flow
+
+
+def _make_tts_flow(hass: HomeAssistant, entry: DummyEntry) -> TtsProviderSubentryFlow:
+    """Build a TTS subentry flow with the usual test doubles attached."""
+    flow = TtsProviderSubentryFlow()
     flow.hass = hass
     flow.async_show_form = lambda **kwargs: {  # type: ignore[assignment]
         "type": "form",
@@ -475,6 +508,259 @@ async def test_stt_provider_flow_switch_to_local_resets_openai_state(
     assert result_data["provider_type"] == "local"
     assert result_data["name"] == "STT - Local"
     assert result_data["settings"] == {
+        "base_url": "http://box:8000/v1",
+        "api_key": None,
+        "openai_provider_subentry_id": None,
+    }
+
+
+_ENDPOINT_MODULE = (
+    "custom_components.home_generative_agent.flows.openai_compatible_endpoint"
+)
+
+
+async def test_tts_provider_flow_reuses_openai_provider(hass: HomeAssistant) -> None:
+    """Linking an OpenAI model provider stores its id and blanks the key."""
+    entry = DummyEntry()
+    entry.subentries["openai1"] = DummySubentry(
+        "openai1",
+        SUBENTRY_TYPE_MODEL_PROVIDER,
+        "OpenAI",
+        {"provider_type": "openai", "settings": {"api_key": "sk-shared"}},
+    )
+    flow = _make_tts_flow(hass, entry)
+
+    second = await flow.async_step_provider({"provider_type": "openai"})
+    assert second.get("type") == "form"
+    assert _schema_marker(second, "openai_provider_subentry_id").default() == "openai1"
+
+    third = await flow.async_step_credentials(
+        {"openai_provider_subentry_id": "openai1", "api_key": "ignored"}
+    )
+    assert third.get("type") == "form"
+    assert _schema_marker(third, "model_name").default() == "gpt-4o-mini-tts"
+    assert _schema_marker(third, "voice").default() == "alloy"
+
+    result = await flow.async_step_model(
+        {"model_name": "gpt-4o-mini-tts", "voice": "nova", "speed": 1.1}
+    )
+    assert result.get("type") == "create_entry"
+    assert result.get("title") == "TTS - OpenAI"
+    data = result.get("data")
+    assert data is not None
+    assert data["provider_type"] == "openai"
+    assert data["settings"] == {
+        "openai_provider_subentry_id": "openai1",
+        "api_key": None,
+    }
+    assert data["model"] == {
+        "model_name": "gpt-4o-mini-tts",
+        "voice": "nova",
+        "speed": 1.1,
+        "instructions": None,
+    }
+
+
+async def test_tts_provider_flow_uses_separate_key(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A separate OpenAI key is validated and stored without a provider link."""
+    flow = _make_tts_flow(hass, DummyEntry())
+    validated: list[str] = []
+
+    async def _validate(_hass: Any, api_key: str, *_a: Any, **_k: Any) -> None:
+        validated.append(api_key)
+
+    monkeypatch.setattr(f"{_ENDPOINT_MODULE}.validate_openai_key", _validate)
+
+    await flow.async_step_provider({"provider_type": "openai", "name": "Speaker"})
+    third = await flow.async_step_credentials({"api_key": "sk-separate"})
+    assert third.get("type") == "form"
+    assert validated == ["sk-separate"]
+
+    result = await flow.async_step_model(
+        {"model_name": "tts-1", "voice": "", "instructions": "Warm and slow."}
+    )
+    assert result.get("type") == "create_entry"
+    assert result.get("title") == "Speaker"
+    data = result.get("data")
+    assert data is not None
+    assert data["settings"] == {
+        "api_key": "sk-separate",
+        "openai_provider_subentry_id": None,
+    }
+    # A blank voice falls back to the provider's recommended voice; a blank
+    # speed to the default; instructions are stored even for tts-1 (the
+    # runtime, not the flow, decides whether the model accepts them).
+    assert data["model"] == {
+        "model_name": "tts-1",
+        "voice": "alloy",
+        "speed": 1.0,
+        "instructions": "Warm and slow.",
+    }
+
+
+async def test_tts_provider_flow_openai_invalid_key(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A rejected key redisplays the credentials form with invalid_auth."""
+    flow = _make_tts_flow(hass, DummyEntry())
+
+    async def _reject(*_args: Any, **_kwargs: Any) -> None:
+        raise InvalidAuthError
+
+    monkeypatch.setattr(f"{_ENDPOINT_MODULE}.validate_openai_key", _reject)
+    await flow.async_step_provider({"provider_type": "openai"})
+    result = await flow.async_step_credentials({"api_key": "sk-bad"})
+    assert result.get("type") == "form"
+    assert (result.get("errors") or {}).get("base") == "invalid_auth"
+
+
+async def test_tts_provider_flow_local_keyless(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Local TTS flow stores a normalized base URL and no key or linked provider."""
+    flow = _make_tts_flow(hass, DummyEntry())
+    validated: list[tuple[str, str | None]] = []
+
+    async def _validate(_hass: Any, base_url: str, api_key: str | None = None) -> None:
+        validated.append((base_url, api_key))
+
+    monkeypatch.setattr(f"{_ENDPOINT_MODULE}.validate_openai_compatible_url", _validate)
+
+    await flow.async_step_provider({"provider_type": "local", "name": "TTS - Local"})
+    # Entered without /v1 on purpose: normalization must add it before validation.
+    third = await flow.async_step_credentials({"base_url": "speaches-box:8000"})
+    assert third.get("type") == "form"
+    assert validated == [("http://speaches-box:8000/v1", None)]
+    assert _schema_marker(third, "model_name").default() == (
+        "speaches-ai/Kokoro-82M-v1.0-ONNX"
+    )
+    assert _schema_marker(third, "voice").default() == "af_heart"
+
+    result = await flow.async_step_model(
+        {
+            "model_name": "speaches-ai/piper-en_US-hfc_female-medium",
+            "voice": "hfc_female",
+        }
+    )
+    assert result.get("type") == "create_entry"
+    data = result.get("data")
+    assert data is not None
+    assert data["provider_type"] == "local"
+    assert data["settings"] == {
+        "base_url": "http://speaches-box:8000/v1",
+        "api_key": None,
+        "openai_provider_subentry_id": None,
+    }
+    assert data["model"]["model_name"] == "speaches-ai/piper-en_US-hfc_female-medium"
+    assert data["model"]["voice"] == "hfc_female"
+    assert data["model"]["speed"] == 1.0
+
+
+async def test_tts_provider_flow_local_unreachable_server_keeps_input(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed connection test redisplays the typed URL, not an empty form."""
+    flow = _make_tts_flow(hass, DummyEntry())
+
+    async def _fail(*_args: Any, **_kwargs: Any) -> None:
+        raise CannotConnectError
+
+    monkeypatch.setattr(f"{_ENDPOINT_MODULE}.validate_openai_compatible_url", _fail)
+    await flow.async_step_provider({"provider_type": "local"})
+    result = await flow.async_step_credentials({"base_url": "http://down-box:8000"})
+    assert result.get("type") == "form"
+    assert (result.get("errors") or {}).get("base") == "cannot_connect"
+    assert _schema_marker(result, "base_url").default() == "http://down-box:8000"
+
+
+async def test_tts_provider_flow_speed_is_clamped(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Out-of-range or garbage speeds are clamped to the API's range or defaulted."""
+
+    async def _noop(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(f"{_ENDPOINT_MODULE}.validate_openai_compatible_url", _noop)
+    for submitted, stored in ((9.0, 4.0), (0.1, 0.25), ("fast", 1.0), (None, 1.0)):
+        flow = _make_tts_flow(hass, DummyEntry())
+        await flow.async_step_provider({"provider_type": "local"})
+        await flow.async_step_credentials({"base_url": "http://box:8000"})
+        result = await flow.async_step_model({"model_name": "m", "speed": submitted})
+        data = result.get("data")
+        assert data is not None
+        assert data["model"]["speed"] == stored, submitted
+
+
+async def test_tts_provider_flow_add_local_replaces_stale_default_name(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Submitting the pre-filled OpenAI name for a local provider yields the local name."""
+
+    async def _noop(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(f"{_ENDPOINT_MODULE}.validate_openai_compatible_url", _noop)
+    flow = _make_tts_flow(hass, DummyEntry())
+    await flow.async_step_provider({"provider_type": "local", "name": "TTS - OpenAI"})
+    await flow.async_step_credentials({"base_url": "http://box:8000"})
+    result = await flow.async_step_model({"model_name": "m"})
+    assert result.get("title") == "TTS - Local"
+
+
+async def test_tts_provider_flow_switch_to_local_resets_openai_state(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reconfiguring openai -> local carries no key, model, voice, or stale title."""
+    entry = DummyEntry()
+    entry.subentries["tts1"] = DummySubentry(
+        "tts1",
+        SUBENTRY_TYPE_TTS_PROVIDER,
+        "TTS - OpenAI",
+        {
+            "provider_type": "openai",
+            "name": "TTS - OpenAI",
+            "settings": {
+                "api_key": "sk-proj-real",
+                "openai_provider_subentry_id": None,
+            },
+            "model": {"model_name": "gpt-4o-mini-tts", "voice": "nova", "speed": 1.0},
+        },
+    )
+    flow = _make_tts_flow(hass, entry)
+    cast("Any", flow)._subentry_id = "tts1"
+
+    async def _noop(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(f"{_ENDPOINT_MODULE}.validate_openai_compatible_url", _noop)
+
+    first = await flow.async_step_user()
+    assert first.get("type") == "form"
+    second = await flow.async_step_provider(
+        {"provider_type": "local", "name": "TTS - OpenAI"}
+    )
+    key_marker = _schema_marker(second, "api_key")
+    assert key_marker.default() == ""
+    assert (key_marker.description or {}).get("suggested_value") is None
+
+    third = await flow.async_step_credentials({"base_url": "http://box:8000"})
+    assert _schema_marker(third, "model_name").default() == (
+        "speaches-ai/Kokoro-82M-v1.0-ONNX"
+    )
+    assert _schema_marker(third, "voice").default() == "af_heart"
+
+    result = await flow.async_step_model(
+        {"model_name": "speaches-ai/Kokoro-82M-v1.0-ONNX", "voice": "af_heart"}
+    )
+    assert result.get("type") == "update_entry"
+    data = result.get("data")
+    assert data is not None
+    assert data["provider_type"] == "local"
+    assert data["name"] == "TTS - Local"
+    assert data["settings"] == {
         "base_url": "http://box:8000/v1",
         "api_key": None,
         "openai_provider_subentry_id": None,

--- a/tests/custom_components/home_generative_agent/test_subentries.py
+++ b/tests/custom_components/home_generative_agent/test_subentries.py
@@ -247,7 +247,7 @@ async def test_stt_provider_flow_reuses_openai_provider(
         return None
 
     monkeypatch.setattr(
-        "custom_components.home_generative_agent.flows.stt_provider_subentry_flow.validate_openai_key",
+        "custom_components.home_generative_agent.flows.openai_compatible_endpoint.validate_openai_key",
         _noop_validate,
     )
 
@@ -285,7 +285,7 @@ async def test_stt_provider_flow_uses_separate_key(
         return None
 
     monkeypatch.setattr(
-        "custom_components.home_generative_agent.flows.stt_provider_subentry_flow.validate_openai_key",
+        "custom_components.home_generative_agent.flows.openai_compatible_endpoint.validate_openai_key",
         _noop_validate,
     )
 
@@ -319,7 +319,7 @@ async def test_stt_provider_flow_local_keyless(
         return None
 
     monkeypatch.setattr(
-        "custom_components.home_generative_agent.flows.stt_provider_subentry_flow.validate_openai_compatible_url",
+        "custom_components.home_generative_agent.flows.openai_compatible_endpoint.validate_openai_compatible_url",
         _noop_validate,
     )
 
@@ -359,7 +359,7 @@ async def test_stt_provider_flow_local_unreachable_server(
         raise CannotConnectError
 
     monkeypatch.setattr(
-        "custom_components.home_generative_agent.flows.stt_provider_subentry_flow.validate_openai_compatible_url",
+        "custom_components.home_generative_agent.flows.openai_compatible_endpoint.validate_openai_compatible_url",
         _fail_validate,
     )
 
@@ -373,6 +373,44 @@ async def test_stt_provider_flow_local_unreachable_server(
 
 
 @pytest.mark.asyncio
+async def test_stt_provider_flow_add_local_replaces_stale_default_name(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Adding a local provider without editing the pre-filled name gets the local name.
+
+    The provider form renders before the dropdown is touched, so it pre-fills
+    the default type's name ("STT - OpenAI"); submitting that unchanged for a
+    local provider must not label the local backend as OpenAI in the Assist
+    pipeline dropdown. A name the user actually typed still survives.
+    """
+    flow = _make_stt_flow(hass, DummyEntry())
+
+    async def _noop_validate(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(
+        "custom_components.home_generative_agent.flows.openai_compatible_endpoint.validate_openai_compatible_url",
+        _noop_validate,
+    )
+
+    await flow.async_step_provider({"provider_type": "local", "name": "STT - OpenAI"})
+    await flow.async_step_credentials({"base_url": "http://box:8000"})
+    result = await flow.async_step_model({"model_name": "some/whisper"})
+    assert result.get("type") == "create_entry"
+    assert result.get("title") == "STT - Local"
+    result_data = result.get("data")
+    assert result_data is not None
+    assert result_data["name"] == "STT - Local"
+
+    # A deliberately typed name is kept verbatim.
+    flow = _make_stt_flow(hass, DummyEntry())
+    await flow.async_step_provider({"provider_type": "local", "name": "Garage Whisper"})
+    await flow.async_step_credentials({"base_url": "http://box:8000"})
+    result = await flow.async_step_model({"model_name": "some/whisper"})
+    assert result.get("title") == "Garage Whisper"
+
+
 async def test_stt_provider_flow_switch_to_local_resets_openai_state(
     hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -406,7 +444,7 @@ async def test_stt_provider_flow_switch_to_local_resets_openai_state(
         return None
 
     monkeypatch.setattr(
-        "custom_components.home_generative_agent.flows.stt_provider_subentry_flow.validate_openai_compatible_url",
+        "custom_components.home_generative_agent.flows.openai_compatible_endpoint.validate_openai_compatible_url",
         _noop_validate,
     )
 

--- a/tests/custom_components/home_generative_agent/test_tts.py
+++ b/tests/custom_components/home_generative_agent/test_tts.py
@@ -1,0 +1,537 @@
+# ruff: noqa: S101
+"""Tests for the text-to-speech platform (OpenAI and local OpenAI-compatible)."""
+
+from __future__ import annotations
+
+import contextlib
+from types import MappingProxyType, SimpleNamespace
+from typing import TYPE_CHECKING, Any, cast
+
+import httpx
+import pytest
+from homeassistant.components.tts import ATTR_PREFERRED_FORMAT, ATTR_VOICE
+from homeassistant.exceptions import HomeAssistantError
+from openai import AuthenticationError, Omit, OpenAIError
+from openai._models import FinalRequestOptions
+
+from custom_components.home_generative_agent import tts as hga_tts
+from custom_components.home_generative_agent.const import (
+    CONF_TTS_INSTRUCTIONS,
+    CONF_TTS_MODEL_NAME,
+    CONF_TTS_OPENAI_PROVIDER_ID,
+    CONF_TTS_SPEED,
+    CONF_TTS_VOICE,
+    LOCAL_KEYLESS_API_KEY,
+    OPENAI_TTS_VOICES,
+    RECOMMENDED_LOCAL_TTS_MODEL,
+    RECOMMENDED_LOCAL_TTS_VOICE,
+    RECOMMENDED_OPENAI_TTS_MODEL,
+    RECOMMENDED_OPENAI_TTS_VOICE,
+    SUBENTRY_TYPE_MODEL_PROVIDER,
+    SUBENTRY_TYPE_TTS_PROVIDER,
+)
+from custom_components.home_generative_agent.tts import HGATtsEntity
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+AUDIO = b"ID3\x00fake-mp3-bytes"
+LOCAL_BASE_URL = "http://speaches-box:8000/v1"
+
+
+class _FakeSubentry:
+    """Minimal stand-in for a Home Assistant config subentry."""
+
+    def __init__(
+        self, subentry_type: str, data: dict[str, Any], title: str = "TTS - Test"
+    ) -> None:
+        self.subentry_type = subentry_type
+        self.subentry_id = "tts_1"
+        self.data: Mapping[str, Any] = MappingProxyType(dict(data))
+        self.title = title
+
+    def reconfigure(self, data: dict[str, Any]) -> None:
+        """Replace the whole data mapping, as ``async_update_subentry`` does."""
+        self.data = MappingProxyType(dict(data))
+
+
+class _FakeEntry:
+    """Minimal stand-in for a Home Assistant config entry."""
+
+    def __init__(self, subentries: dict[str, _FakeSubentry]) -> None:
+        self.entry_id = "entry_1"
+        self.subentries = subentries
+
+
+def _make_entity(
+    settings: dict[str, Any] | None = None,
+    model: dict[str, Any] | None = None,
+    provider_settings: dict[str, Any] | None = None,
+    provider_type: str = "openai",
+) -> tuple[HGATtsEntity, _FakeEntry]:
+    """Build a TTS entity backed by fake subentries."""
+    subentries: dict[str, _FakeSubentry] = {
+        "tts_1": _FakeSubentry(
+            SUBENTRY_TYPE_TTS_PROVIDER,
+            {
+                "provider_type": provider_type,
+                "settings": settings if settings is not None else {"api_key": "key-1"},
+                "model": model or {},
+            },
+        )
+    }
+    if provider_settings is not None:
+        subentries["prov_1"] = _FakeSubentry(
+            SUBENTRY_TYPE_MODEL_PROVIDER,
+            {"settings": provider_settings},
+            title="OpenAI",
+        )
+    entry = _FakeEntry(subentries)
+    entity = HGATtsEntity(cast("Any", entry), "tts_1")
+    entity.hass = cast("Any", SimpleNamespace(config=SimpleNamespace(language="en")))
+    entity.entity_id = "tts.hga_test"
+    return entity, entry
+
+
+def _make_local_entity(
+    settings: dict[str, Any] | None = None,
+    model: dict[str, Any] | None = None,
+) -> tuple[HGATtsEntity, _FakeEntry]:
+    """Build a local-provider TTS entity with a keyless server by default."""
+    return _make_entity(
+        settings=settings if settings is not None else {"base_url": LOCAL_BASE_URL},
+        model=model,
+        provider_type="local",
+    )
+
+
+def _no_network(request: httpx.Request) -> httpx.Response:
+    """Fail loudly instead of letting a test reach the real API."""
+    msg = f"test attempted a real network request: {request.method} {request.url}"
+    raise AssertionError(msg)
+
+
+@pytest.fixture
+async def shared_httpx_client() -> Any:
+    """Stand in for Home Assistant's shared httpx client."""
+    client = httpx.AsyncClient(transport=httpx.MockTransport(_no_network))
+    yield client
+    await client.aclose()
+
+
+@pytest.fixture
+def patched_client(monkeypatch: pytest.MonkeyPatch, shared_httpx_client: Any) -> Any:
+    """Patch get_async_client and count AsyncOpenAI constructions."""
+    calls: dict[str, Any] = {"http_clients": [], "constructed": [], "kwargs": []}
+
+    def _fake_get_async_client(hass: Any) -> httpx.AsyncClient:
+        calls["http_clients"].append(hass)
+        return shared_httpx_client
+
+    real_async_openai = hga_tts.AsyncOpenAI
+
+    def _counting_async_openai(**kwargs: Any) -> Any:
+        client = real_async_openai(**kwargs)
+        calls["constructed"].append(client)
+        calls["kwargs"].append(kwargs)
+        return client
+
+    monkeypatch.setattr(hga_tts, "get_async_client", _fake_get_async_client)
+    monkeypatch.setattr(hga_tts, "AsyncOpenAI", _counting_async_openai)
+    return calls
+
+
+async def _speak(
+    entity: HGATtsEntity,
+    responses: list[Any] | None = None,
+    message: str = "Hello there",
+    options: dict[str, Any] | None = None,
+) -> tuple[Any, list[dict[str, Any]]]:
+    """Synthesize once, stubbing the client's network call once it exists."""
+    seen: list[dict[str, Any]] = []
+    original = entity._get_client
+
+    def _wrapped(api_key: str, base_url: str | None = None) -> Any:
+        client = original(api_key, base_url)
+        _install_stub(client, responses or [], seen)
+        return client
+
+    entity._get_client = _wrapped  # type: ignore[method-assign]
+    try:
+        merged = {**entity.default_options, **(options or {})}
+        result = await entity.async_get_tts_audio(message, "en-US", merged)
+    finally:
+        # Delete rather than rebind, so the class method is not permanently
+        # shadowed by an instance attribute holding a self-reference.
+        with contextlib.suppress(AttributeError):
+            object.__delattr__(entity, "_get_client")
+    return result, seen
+
+
+def _install_stub(
+    client: Any, responses: list[Any], seen: list[dict[str, Any]]
+) -> None:
+    """Stub ``audio.speech.create`` on a real OpenAI client, recording kwargs."""
+    queue = list(responses)
+
+    async def _create(**kwargs: Any) -> Any:
+        seen.append(kwargs)
+        result = queue.pop(0) if queue else SimpleNamespace(content=AUDIO)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    client.audio.speech.create = _create
+
+
+def _openai_error() -> OpenAIError:
+    return OpenAIError("boom")
+
+
+def _auth_error() -> AuthenticationError:
+    request = httpx.Request("POST", "https://api.openai.com/v1/audio/speech")
+    response = httpx.Response(401, request=request)
+    return AuthenticationError("bad key", response=response, body=None)
+
+
+# ------------------------------------------------------------------ client
+
+
+async def test_client_uses_shared_httpx_client(
+    patched_client: Any, shared_httpx_client: Any
+) -> None:
+    """The SDK client is built on HA's shared httpx client, not its own."""
+    entity, _ = _make_entity()
+    (extension, audio), _ = await _speak(entity)
+    assert extension == "mp3"
+    assert audio == AUDIO
+    assert patched_client["http_clients"] == [entity.hass]
+    assert patched_client["kwargs"][0]["http_client"] is shared_httpx_client
+
+
+async def test_request_timeout_is_pinned(patched_client: Any) -> None:
+    """The request timeout is set on the SDK client, not inherited."""
+    entity, _ = _make_entity()
+    await _speak(entity)
+    timeout = patched_client["kwargs"][0]["timeout"]
+    assert isinstance(timeout, httpx.Timeout)
+    assert timeout.read == hga_tts.TTS_REQUEST_TIMEOUT_S
+    assert timeout.connect == 5.0
+
+
+async def test_client_reused_across_replies(patched_client: Any) -> None:
+    """Consecutive replies with unchanged credentials reuse one client."""
+    entity, _ = _make_entity()
+    await _speak(entity)
+    await _speak(entity)
+    assert len(patched_client["constructed"]) == 1
+
+
+async def test_client_rebuilt_when_api_key_changes(patched_client: Any) -> None:
+    """A reconfigured key takes effect on the next reply."""
+    entity, entry = _make_entity()
+    await _speak(entity)
+    entry.subentries["tts_1"].reconfigure(
+        {"provider_type": "openai", "settings": {"api_key": "key-2"}, "model": {}}
+    )
+    await _speak(entity)
+    assert [k["api_key"] for k in patched_client["kwargs"]] == ["key-1", "key-2"]
+
+
+async def test_linked_provider_key_is_authoritative(patched_client: Any) -> None:
+    """A linked OpenAI model provider's key wins over the TTS-level key."""
+    entity, _ = _make_entity(
+        settings={"api_key": "stale", CONF_TTS_OPENAI_PROVIDER_ID: "prov_1"},
+        provider_settings={"api_key": "provider-key"},
+    )
+    await _speak(entity)
+    assert patched_client["kwargs"][0]["api_key"] == "provider-key"
+
+
+async def test_linked_provider_without_key_fails(patched_client: Any) -> None:
+    """A linked provider with no key fails the reply instead of using a stale key."""
+    entity, _ = _make_entity(
+        settings={"api_key": "stale", CONF_TTS_OPENAI_PROVIDER_ID: "prov_1"},
+        provider_settings={},
+    )
+    with pytest.raises(HomeAssistantError, match="API key missing"):
+        await _speak(entity)
+    assert patched_client["constructed"] == []
+
+
+async def test_missing_api_key_fails(patched_client: Any) -> None:
+    """No key anywhere fails the reply before any client is built."""
+    entity, _ = _make_entity(settings={})
+    with pytest.raises(HomeAssistantError, match="API key missing"):
+        await _speak(entity)
+    assert patched_client["constructed"] == []
+
+
+# ------------------------------------------------------------------- local
+
+
+async def test_local_keyless_sends_no_authorization_header(
+    patched_client: Any,
+) -> None:
+    """A keyless local server gets the placeholder key and no bearer on the wire."""
+    entity, _ = _make_local_entity()
+    (extension, audio), seen = await _speak(entity)
+    assert extension == "mp3"
+    assert audio == AUDIO
+    kwargs = patched_client["kwargs"][0]
+    assert kwargs["base_url"] == LOCAL_BASE_URL
+    assert kwargs["api_key"] == LOCAL_KEYLESS_API_KEY
+    assert LOCAL_KEYLESS_API_KEY
+    extra_headers = seen[0]["extra_headers"]
+    assert isinstance(extra_headers["Authorization"], Omit)
+    built = patched_client["constructed"][0]._build_request(
+        FinalRequestOptions(method="post", url="/audio/speech", headers=extra_headers)
+    )
+    assert "authorization" not in built.headers
+
+
+async def test_local_configured_key_is_sent(patched_client: Any) -> None:
+    """A configured local key reaches the wire as a bearer token."""
+    entity, _ = _make_local_entity(
+        settings={"base_url": LOCAL_BASE_URL, "api_key": "local-key"}
+    )
+    _, seen = await _speak(entity)
+    assert patched_client["kwargs"][0]["api_key"] == "local-key"
+    assert "extra_headers" not in seen[0]
+    assert patched_client["constructed"][0].auth_headers == {
+        "Authorization": "Bearer local-key"
+    }
+
+
+async def test_local_missing_base_url_fails(patched_client: Any) -> None:
+    """A local provider without a URL fails the reply, not the pipeline."""
+    entity, _ = _make_local_entity(settings={})
+    with pytest.raises(HomeAssistantError, match="base URL missing"):
+        await _speak(entity)
+    assert patched_client["constructed"] == []
+
+
+@pytest.mark.usefixtures("patched_client")
+async def test_local_defaults_to_recommended_model_and_voice() -> None:
+    """A local provider with no model settings uses the Kokoro defaults."""
+    entity, _ = _make_local_entity()
+    _, seen = await _speak(entity)
+    assert seen[0]["model"] == RECOMMENDED_LOCAL_TTS_MODEL
+    assert seen[0]["voice"] == RECOMMENDED_LOCAL_TTS_VOICE
+    assert entity.async_get_supported_voices("en-US") == [
+        hga_tts.Voice(RECOMMENDED_LOCAL_TTS_VOICE, RECOMMENDED_LOCAL_TTS_VOICE)
+    ]
+
+
+@pytest.mark.usefixtures("patched_client")
+async def test_local_opus_request_falls_back_to_mp3() -> None:
+    """Speaches cannot produce opus, so an ogg request is served as mp3."""
+    entity, _ = _make_local_entity()
+    (extension, _), seen = await _speak(entity, options={ATTR_PREFERRED_FORMAT: "ogg"})
+    assert extension == "mp3"
+    assert seen[0]["response_format"] == "mp3"
+
+
+# ------------------------------------------------------------------ request
+
+
+@pytest.mark.usefixtures("patched_client")
+async def test_request_uses_configured_model_voice_speed() -> None:
+    """Configured model, voice, and a non-default speed reach the request."""
+    entity, _ = _make_entity(
+        model={
+            CONF_TTS_MODEL_NAME: "tts-1-hd",
+            CONF_TTS_VOICE: "nova",
+            CONF_TTS_SPEED: 1.25,
+        }
+    )
+    _, seen = await _speak(entity, message="Doors locked.")
+    request = seen[0]
+    assert request["model"] == "tts-1-hd"
+    assert request["voice"] == "nova"
+    assert request["input"] == "Doors locked."
+    assert request["speed"] == 1.25
+    assert request["response_format"] == "mp3"
+
+
+@pytest.mark.usefixtures("patched_client")
+async def test_default_speed_is_omitted() -> None:
+    """Speed 1.0 is the API default and is not sent."""
+    entity, _ = _make_entity(model={CONF_TTS_SPEED: 1.0})
+    _, seen = await _speak(entity)
+    assert "speed" not in seen[0]
+
+
+@pytest.mark.usefixtures("patched_client")
+async def test_pipeline_voice_option_overrides_configured_voice() -> None:
+    """A voice chosen in the Assist pipeline wins over the subentry default."""
+    entity, _ = _make_entity(model={CONF_TTS_VOICE: "nova"})
+    _, seen = await _speak(entity, options={ATTR_VOICE: "onyx"})
+    assert seen[0]["voice"] == "onyx"
+
+
+@pytest.mark.usefixtures("patched_client")
+async def test_instructions_sent_only_for_gpt4o_mini_tts() -> None:
+    """Instructions go to gpt-4o-mini-tts models only; tts-1 would reject them."""
+    entity, _ = _make_entity(
+        model={CONF_TTS_MODEL_NAME: "gpt-4o-mini-tts", CONF_TTS_INSTRUCTIONS: "Calm."}
+    )
+    _, seen = await _speak(entity)
+    assert seen[0]["instructions"] == "Calm."
+
+    entity, _ = _make_entity(
+        model={CONF_TTS_MODEL_NAME: "tts-1", CONF_TTS_INSTRUCTIONS: "Calm."}
+    )
+    _, seen = await _speak(entity)
+    assert "instructions" not in seen[0]
+
+
+@pytest.mark.usefixtures("patched_client")
+async def test_instructions_never_sent_to_local() -> None:
+    """A local server never receives instructions, whatever its model is named."""
+    entity, _ = _make_local_entity(
+        model={CONF_TTS_MODEL_NAME: "gpt-4o-mini-tts", CONF_TTS_INSTRUCTIONS: "Calm."}
+    )
+    _, seen = await _speak(entity)
+    assert "instructions" not in seen[0]
+
+
+@pytest.mark.parametrize(
+    ("preferred", "extension", "requested"),
+    [
+        (None, "mp3", "mp3"),
+        ("mp3", "mp3", "mp3"),
+        ("wav", "wav", "wav"),
+        ("flac", "flac", "flac"),
+        ("ogg", "ogg", "opus"),
+        ("oga", "ogg", "opus"),
+        ("raw", "pcm", "pcm"),
+        ("m4a", "mp3", "mp3"),
+    ],
+)
+@pytest.mark.usefixtures("patched_client")
+async def test_openai_format_negotiation(
+    preferred: str | None, extension: str, requested: str
+) -> None:
+    """The reported extension and requested container follow HA's preference."""
+    entity, _ = _make_entity()
+    options = {ATTR_PREFERRED_FORMAT: preferred} if preferred else {}
+    (got_extension, _), seen = await _speak(entity, options=options)
+    assert got_extension == extension
+    assert seen[0]["response_format"] == requested
+
+
+async def test_empty_message_is_rejected(patched_client: Any) -> None:
+    """Whitespace-only text is refused before a request is made."""
+    entity, _ = _make_entity()
+    with pytest.raises(HomeAssistantError, match="No text"):
+        await _speak(entity, message="   ")
+    assert patched_client["constructed"] == []
+
+
+@pytest.mark.usefixtures("patched_client")
+async def test_empty_audio_is_an_error() -> None:
+    """A backend returning no bytes fails the reply instead of playing silence."""
+    entity, _ = _make_entity()
+    with pytest.raises(HomeAssistantError, match="no audio"):
+        await _speak(entity, responses=[SimpleNamespace(content=b"")])
+
+
+# ------------------------------------------------------------------- errors
+
+
+@pytest.mark.usefixtures("patched_client")
+async def test_authentication_error_raises_home_assistant_error() -> None:
+    """A rejected key surfaces as HomeAssistantError, the TTS contract."""
+    entity, _ = _make_entity()
+    with pytest.raises(HomeAssistantError, match="authentication failed"):
+        await _speak(entity, responses=[_auth_error()])
+
+
+@pytest.mark.usefixtures("patched_client")
+async def test_openai_error_raises_home_assistant_error() -> None:
+    """Any SDK error surfaces as HomeAssistantError with the cause attached."""
+    entity, _ = _make_entity()
+    with pytest.raises(HomeAssistantError, match="request failed") as excinfo:
+        await _speak(entity, responses=[_openai_error()])
+    assert isinstance(excinfo.value.__cause__, OpenAIError)
+
+
+async def test_unknown_provider_type_fails(patched_client: Any) -> None:
+    """An unsupported provider type fails clearly and builds no client."""
+    entity, _ = _make_entity(provider_type="mystery")
+    with pytest.raises(HomeAssistantError, match="Unsupported"):
+        await _speak(entity)
+    assert patched_client["constructed"] == []
+
+
+# ------------------------------------------------------------------- voices
+
+
+def test_openai_voices_put_configured_voice_first() -> None:
+    """The pipeline picks index 0, so the configured voice leads the list."""
+    entity, _ = _make_entity(model={CONF_TTS_VOICE: "shimmer"})
+    voices = entity.async_get_supported_voices("en-US")
+    assert voices is not None
+    assert voices[0].voice_id == "shimmer"
+    assert {v.voice_id for v in voices} == {v.lower() for v in OPENAI_TTS_VOICES}
+
+
+def test_openai_custom_voice_is_offered_first() -> None:
+    """A voice id outside the built-in set is still offered, and first."""
+    entity, _ = _make_entity(model={CONF_TTS_VOICE: "voice_1234"})
+    voices = entity.async_get_supported_voices("en-US")
+    assert voices is not None
+    assert voices[0].voice_id == "voice_1234"
+    assert len(voices) == len(OPENAI_TTS_VOICES) + 1
+
+
+def test_openai_defaults() -> None:
+    """Default options and model fall back to the recommended OpenAI values."""
+    entity, _ = _make_entity()
+    assert entity.default_options == {
+        ATTR_VOICE: RECOMMENDED_OPENAI_TTS_VOICE,
+        ATTR_PREFERRED_FORMAT: "mp3",
+    }
+    assert entity._configured_model() == RECOMMENDED_OPENAI_TTS_MODEL
+    assert entity.supported_options == [ATTR_VOICE, ATTR_PREFERRED_FORMAT]
+    assert entity.default_language == "en-US"
+    assert "en-US" in entity.supported_languages
+
+
+def test_entity_identity_follows_subentry() -> None:
+    """Unique id and name come from the entry and subentry."""
+    entity, _ = _make_entity()
+    assert entity.unique_id == "entry_1_tts_1"
+    assert entity.name == "TTS - Test"
+
+
+# ---------------------------------------------------------------- platform
+
+
+async def test_setup_entry_adds_one_entity_per_tts_subentry() -> None:
+    """Only TTS subentries produce entities, each bound to its subentry."""
+    entry = _FakeEntry(
+        {
+            "tts_1": _FakeSubentry(
+                SUBENTRY_TYPE_TTS_PROVIDER,
+                {"provider_type": "openai", "settings": {}, "model": {}},
+            ),
+            "prov_1": _FakeSubentry(SUBENTRY_TYPE_MODEL_PROVIDER, {"settings": {}}),
+        }
+    )
+    added: list[tuple[list[Any], str | None]] = []
+
+    def _add(
+        new_entities: Any,
+        update_before_add: bool = False,  # noqa: ARG001, FBT001, FBT002
+        *,
+        config_subentry_id: str | None = None,
+    ) -> None:
+        added.append((list(new_entities), config_subentry_id))
+
+    await hga_tts.async_setup_entry(cast("Any", None), cast("Any", entry), _add)
+    assert len(added) == 1
+    entities, subentry_id = added[0]
+    assert subentry_id == "tts_1"
+    assert isinstance(entities[0], HGATtsEntity)

--- a/tests/custom_components/home_generative_agent/test_tts.py
+++ b/tests/custom_components/home_generative_agent/test_tts.py
@@ -217,6 +217,9 @@ async def test_request_timeout_is_pinned(patched_client: Any) -> None:
     assert isinstance(timeout, httpx.Timeout)
     assert timeout.read == hga_tts.TTS_REQUEST_TIMEOUT_S
     assert timeout.connect == 5.0
+    # One attempt: the SDK's default 2 retries would triple the silence a
+    # wedged server causes before the pipeline hears an error.
+    assert patched_client["kwargs"][0]["max_retries"] == 0
 
 
 async def test_client_reused_across_replies(patched_client: Any) -> None:
@@ -404,8 +407,9 @@ async def test_instructions_never_sent_to_local() -> None:
         ("wav", "wav", "wav"),
         ("flac", "flac", "flac"),
         ("ogg", "ogg", "opus"),
-        ("oga", "ogg", "opus"),
-        ("raw", "pcm", "pcm"),
+        ("oga", "oga", "opus"),
+        ("raw", "raw", "pcm"),
+        ("pcm", "pcm", "pcm"),
         ("m4a", "mp3", "mp3"),
     ],
 )
@@ -496,7 +500,8 @@ def test_openai_defaults() -> None:
     assert entity._configured_model() == RECOMMENDED_OPENAI_TTS_MODEL
     assert entity.supported_options == [ATTR_VOICE, ATTR_PREFERRED_FORMAT]
     assert entity.default_language == "en-US"
-    assert "en-US" in entity.supported_languages
+    # tts.speak checks exact membership, so bare subtags must be accepted too.
+    assert {"en-US", "en", "cs", "pt-PT"} <= set(entity.supported_languages)
 
 
 def test_entity_identity_follows_subentry() -> None:

--- a/tests/custom_components/home_generative_agent/test_tts.py
+++ b/tests/custom_components/home_generative_agent/test_tts.py
@@ -30,6 +30,7 @@ from custom_components.home_generative_agent.const import (
     SUBENTRY_TYPE_MODEL_PROVIDER,
     SUBENTRY_TYPE_TTS_PROVIDER,
 )
+from custom_components.home_generative_agent.core import openai_endpoint
 from custom_components.home_generative_agent.tts import HGATtsEntity
 
 if TYPE_CHECKING:
@@ -128,7 +129,7 @@ def patched_client(monkeypatch: pytest.MonkeyPatch, shared_httpx_client: Any) ->
         calls["http_clients"].append(hass)
         return shared_httpx_client
 
-    real_async_openai = hga_tts.AsyncOpenAI
+    real_async_openai = openai_endpoint.AsyncOpenAI
 
     def _counting_async_openai(**kwargs: Any) -> Any:
         client = real_async_openai(**kwargs)
@@ -136,8 +137,8 @@ def patched_client(monkeypatch: pytest.MonkeyPatch, shared_httpx_client: Any) ->
         calls["kwargs"].append(kwargs)
         return client
 
-    monkeypatch.setattr(hga_tts, "get_async_client", _fake_get_async_client)
-    monkeypatch.setattr(hga_tts, "AsyncOpenAI", _counting_async_openai)
+    monkeypatch.setattr(openai_endpoint, "get_async_client", _fake_get_async_client)
+    monkeypatch.setattr(openai_endpoint, "AsyncOpenAI", _counting_async_openai)
     return calls
 
 


### PR DESCRIPTION
## Summary

PR B of the local voice pipeline (PR A was #598, local STT). Adds a `tts` platform with the same two provider types as STT — **OpenAI** (speech API) and **Local (OpenAI-compatible)** (e.g. the Speaches container already serving faster-whisper, now also serving Kokoro or piper voices) — so an Assist pipeline can run speech-to-text, the agent, and text-to-speech entirely on the LAN.

Two commits:

1. **`refactor(flows)`** — extracts the STT flow's credential machinery (OpenAI key / linked model provider, local server URL + optional key, normalize-then-validate, error mapping, the two forms, subentry lookup) into `flows/openai_compatible_endpoint.py`, shared by STT and TTS. This is the "don't add a third copy" half of the TODOS.md P2 endpoint-unification item; the model-provider flow's older convention (raw URL, literal `"none"` key sentinel fed to `SecretStr` from three write sites) is deliberately left for a follow-up and the TODO now says exactly that. Stored shapes unchanged; STT tests keep every assertion (five monkeypatch targets move). Also fixes the add-flow name pre-fill wart (TODOS P3) for both flows.
2. **`feat(tts)`** — `tts.py` (`HGATtsEntity`), `flows/tts_provider_subentry_flow.py`, constants, registration, `strings`/`en`/`cs` translations, tests, docs.

## Design notes

- Mirrors `stt.py`: HA's shared httpx client, pinned `TTS_REQUEST_TIMEOUT_S`, client cached on `(api_key, base_url)`, linked OpenAI model provider authoritative, keyless local placeholder + per-request `Omit()` Authorization strip (proven in tests on the real SDK `_build_request`).
- Entities are added with `config_subentry_id` (core's pattern) so the registry entry follows the subentry; STT's missing binding is filed in TODOS as a P3.
- Declares `ATTR_VOICE` + `ATTR_PREFERRED_FORMAT`; negotiates the container per backend (Speaches has no opus/aac → mp3) and lets HA ffmpeg the sample rate/channels for the Voice PE's wav request. `instructions` are sent only to OpenAI `gpt-4o-mini-tts*` (the API rejects them for `tts-1`/`tts-1-hd`; never to local); `speed` only when ≠ 1.0.
- Voices: the 13 OpenAI built-ins with the configured voice first (the pipeline takes index 0), or the single configured voice for a local server (Speaches cannot list voices through the OpenAI API).
- Buffered synthesis only; HA's streaming TTS API is a follow-up.
- `requirements/test.txt` pins `mutagen` and `ha-ffmpeg` (HA's `tts` component imports both at module load) to core's manifest versions.

## Field notes (dev box, GTX 1080 Ti + i5-3570K)

Kokoro is **not** viable on this box: ~15 s per sentence on CPU (no AVX2) and ORT's CUDA path is no better on Pascal. `speaches-ai/piper-en_US-hfc_female-medium` synthesizes the same sentence in 2.4 s on CPU. Kokoro stays the documented default for capable boxes; the docs now point weak-CPU boxes at piper and explain the Speaches pre-download requirement.

## Test plan

- [x] `make lint`, `make test` (3046 passed), `make typecheck` 0 errors
- [x] New `test_tts.py` (35 tests) + 8 TTS flow tests + STT add-flow name test; translation parity tests pass for `strings`/`en`/`cs`
- [ ] Field: add **+ TTS Provider** (Local → Speaches, piper voice) and (OpenAI), select in the Assist pipeline, speak on the Voice PE
- [ ] `/code-review high` before merge

No version bump or CHANGELOG entry — release commit (target v3.38.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015XTPJG3scUAWWxk1TsRdzk
