### PR TITLE
docs: voice pipeline consistency pass after the TTS platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Most AI conversation integrations are prompt passthroughs: they forward your wor
 | **Face recognition** | Identify people in camera frames and personalize alerts. |
 | **Long-term memory** | Semantic search over past conversations. The agent remembers your preferences and context. |
 | **Streaming responses** | First tokens appear word-by-word in the HA conversation UI — no waiting for the full response. |
-| **Built-in speech-to-text** | STT provider for Assist pipelines, backed by the OpenAI Whisper API or a fully local OpenAI-compatible server (e.g. [Speaches](https://speaches.ai/) running faster-whisper next to Ollama) — see [STT setup](docs/configuration.md#speech-to-text-stt). |
-| **Built-in text-to-speech** | TTS provider for Assist pipelines, backed by the OpenAI speech API or the same local OpenAI-compatible server (Speaches serving Kokoro or piper voices), so the whole voice pipeline can stay on your network — see [TTS setup](docs/configuration.md#text-to-speech-tts). |
+| **Built-in speech-to-text** | STT provider for Assist pipelines, backed by the OpenAI Whisper API or a fully local OpenAI-compatible server — e.g. [Speaches](https://speaches.ai/) running faster-whisper on any machine Home Assistant can reach; it does not have to be the box that serves your LLM — see [STT setup](docs/configuration.md#speech-to-text-stt). |
+| **Built-in text-to-speech** | TTS provider for Assist pipelines, backed by the OpenAI speech API or a local OpenAI-compatible server (one Speaches container can serve both STT and TTS, with Kokoro or piper voices), so the whole voice pipeline can stay on your network — see [TTS setup](docs/configuration.md#text-to-speech-tts). |
 | **Cloud and edge models** | Use OpenAI, Gemini, Anthropic, or run everything locally with Ollama or any OpenAI-compatible server. |
 
 ## Screenshots
@@ -67,10 +67,12 @@ Most AI conversation integrations are prompt passthroughs: they forward your wor
 | Model provider | At least one of: OpenAI, Gemini, Anthropic, Ollama, or any OpenAI-compatible server |
 | Edge GPU server *(optional)* | Ollama, vLLM, llama.cpp, or LiteLLM for local model serving |
 | face-service *(optional)* | An external service for face recognition in camera analysis. Also powers Sentinel's unknown-person rules, which never fire unless face recognition is enabled (the `face_recognition` option, off by default) with this service configured |
+| Speech-to-text *(optional)* | An OpenAI API key (Whisper API), **or** a local server exposing the OpenAI `/v1/audio/transcriptions` endpoint, such as [Speaches](https://speaches.ai/) serving faster-whisper. The server can run on any machine Home Assistant can reach — it need not be the LLM box. A GPU with about 2 GB of VRAM is recommended for `faster-whisper-large-v3-turbo`; smaller whisper models run on CPU. See [STT setup](docs/configuration.md#speech-to-text-stt) |
+| Text-to-speech *(optional)* | An OpenAI API key (speech API), **or** a local server exposing the OpenAI `/v1/audio/speech` endpoint — the same Speaches container can serve both. piper voices synthesize on any CPU; Kokoro needs a modern CPU (AVX2) or a recent GPU. Audio conversion for voice satellites uses the ffmpeg bundled with Home Assistant. See [TTS setup](docs/configuration.md#text-to-speech-tts) |
 
 ## Quick Start
 
-Get the basic conversational agent running in seven steps. See the [full installation guide](docs/installation.md) for optional apps (edge models, face recognition).
+Get the basic conversational agent running in seven steps. See the [full installation guide](docs/installation.md) for optional apps (edge models, face recognition, a local speech server).
 
 **1. Install the [PostgreSQL with pgvector](https://github.com/goruck/addon-postgres-pgvector/tree/main/postgres_pgvector) app.**
 
@@ -100,11 +102,13 @@ Click the button below to add the repository, then install and configure the app
 
 You can now open the HA Assist panel and start talking to your home.
 
+**Optional — voice in and out:** click **+ STT Provider** and **+ TTS Provider** on the integration page to add HGA's own speech-to-text and text-to-speech engines (OpenAI, or a local [Speaches](https://speaches.ai/) server on any machine), then select them in your Assist pipeline. See [STT setup](docs/configuration.md#speech-to-text-stt) and [TTS setup](docs/configuration.md#text-to-speech-tts).
+
 ## Documentation
 
 | Guide | Contents |
 | --- | --- |
-| [Installation](docs/installation.md) | HACS install, manual install, optional apps (Ollama, face recognition) |
+| [Installation](docs/installation.md) | HACS install, manual install, optional apps (Ollama, face recognition, local speech server for STT/TTS) |
 | [Configuration](docs/configuration.md) | Model providers, features, per-model thinking/reasoning & budget, Tool Retrieval (RAG), per-tool exclusions & always-included tools, LLM API, STT and TTS (OpenAI or local), YAML mode, Critical Action PIN, camera description language & extra VLM instructions, UI languages (en/cs/ru/tr) |
 | [Sentinel](docs/sentinel.md) | Anomaly detection pipeline, built-in rules, triage, baseline, blueprints, notification quiet hours, services API, health sensor |
 | [Camera Entities](docs/camera-entities.md) | Image and sensor entities, dashboards, automations, proactive video analysis, face recognition |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -104,7 +104,7 @@ Several techniques reduce latency:
 - Static prompt content is placed upfront to enable cloud provider prompt caching.
 - Multi-tool turns execute tool calls concurrently (`asyncio.gather`).
 - Streaming means perceived response time is near-instant even when total generation time is longer.
-- OpenAI speech-to-text reuses one API client per STT entity, built on Home Assistant's shared HTTP client. No SSL context is constructed on the event loop between the end of a recording and the start of transcription, and back-to-back utterances reuse a pooled connection instead of repeating the TLS handshake.
+- The STT and TTS entities each reuse one API client (OpenAI or a local OpenAI-compatible server), built on Home Assistant's shared HTTP client by the runtime they share in `core/openai_endpoint.py`. No SSL context is constructed on the event loop between the end of a recording and the start of transcription, back-to-back utterances and replies reuse a pooled connection instead of repeating the TLS handshake, and each request is a single attempt so a wedged speech server costs one timeout, not three.
 
 Typical performance on the [author's reference setup](architecture.md#hardware-reference-setup) (Raspberry Pi 5 + Nvidia 3090 edge server):
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -238,7 +238,7 @@ You can select any combination. Selecting both Assist and one or more MCP APIs m
 
 ## Speech-to-Text (STT)
 
-HGA provides a built-in STT engine — no separate STT integration required. Two provider types are supported: **OpenAI** (Whisper API) and **Local** (any OpenAI-compatible transcription server, e.g. [Speaches](https://speaches.ai/) serving faster-whisper on the same box as Ollama).
+HGA provides a built-in STT engine — no separate STT integration required. Two provider types are supported: **OpenAI** (Whisper API) and **Local** (any OpenAI-compatible transcription server, e.g. [Speaches](https://speaches.ai/) serving faster-whisper). A local server can run on any machine Home Assistant can reach; it does not have to be the box that serves your LLM.
 
 1. Open **Settings → Devices & Services → Home Generative Agent**.
 2. Click **+ STT Provider**.
@@ -254,14 +254,14 @@ HGA provides a built-in STT engine — no separate STT integration required. Two
    - `translate`: on OpenAI only `whisper-1` supports it (other models fall back to transcription); local whisper servers support it for every model
 6. Go to **Settings → Voice assistants → Assist pipelines** and select **STT - OpenAI** / **STT - Local** (or your chosen name) for Speech-to-text.
 
-**Credential changes take effect on the next utterance.** Each STT entity keeps one OpenAI client, built on Home Assistant's shared HTTP client, and rebuilds it when the resolved API key or server URL changes — no restart or integration reload needed. If the entry is linked to a Model Provider subentry, that provider's key is the only one used: linking blanks the separate STT key, so a linked provider without a usable key fails the utterance with an `OpenAI STT API key missing` warning in the log rather than falling back to a stale key.
+**Credential changes take effect on the next utterance.** Each STT entity keeps one OpenAI client, built on Home Assistant's shared HTTP client, and rebuilds it when the resolved API key or server URL changes — no restart or integration reload needed. If the entry is linked to a Model Provider subentry, that provider's key is the only one used: linking blanks the separate STT key, so a linked provider without a usable key fails the utterance with an `STT API key missing` warning in the log rather than falling back to a stale key.
 
 ### Running a local STT server
 
-Any server exposing the OpenAI `/v1/audio/transcriptions` endpoint works. Speaches is a good fit for a GPU box already running Ollama (`faster-whisper-large-v3-turbo` needs roughly 1.5–2 GB of VRAM). Speaches only serves models that have already been downloaded, so list the model in `PRELOAD_MODELS` (or `POST /v1/models/<model-id>` once) before the first utterance:
+Any server exposing the OpenAI `/v1/audio/transcriptions` endpoint works. Speaches runs on any machine Home Assistant can reach — a dedicated box, the LLM server, or a spare machine with an older GPU. `faster-whisper-large-v3-turbo` needs roughly 1.5–2 GB of VRAM and transcribes a short command in well under a second on even a Pascal-class card; without a GPU pick a smaller whisper model (`Systran/faster-whisper-small`, for example) and the CPU image (`latest-cpu`). Speaches only serves models that have already been downloaded, so list the model in `PRELOAD_MODELS` (or `POST /v1/models/<model-id>` once) before the first utterance:
 
 ```yaml
-# docker-compose.yaml on the GPU box
+# docker-compose.yaml on the speech server
 services:
   speaches:
     image: ghcr.io/speaches-ai/speaches:latest-cuda
@@ -272,6 +272,7 @@ services:
     environment:
       - PRELOAD_MODELS=["deepdml/faster-whisper-large-v3-turbo-ct2", "speaches-ai/Kokoro-82M-v1.0-ONNX"]
       - STT_MODEL_TTL=-1            # keep the model resident; the first utterance after a reload pays several seconds
+      - WHISPER__TTL=-1             # same setting under the name older Speaches images read; harmless to set both
       # - WHISPER__COMPUTE_TYPE=int8_float32   # required on Pascal GPUs (GTX 10xx): float16 is not supported there
     deploy:
       resources:
@@ -290,7 +291,7 @@ volumes:
 
 ## Text-to-Speech (TTS)
 
-HGA also provides a built-in TTS engine for Assist pipelines, so a reply can be spoken by the OpenAI speech API or by the same local server that handles speech-to-text. Two provider types are supported: **OpenAI** and **Local** (any server exposing the OpenAI `/v1/audio/speech` endpoint, e.g. [Speaches](https://speaches.ai/) serving Kokoro or piper voices).
+HGA also provides a built-in TTS engine for Assist pipelines, so a reply can be spoken by the OpenAI speech API or by a local server — the same Speaches container that handles speech-to-text can serve both, but the two providers are configured independently and can point at different machines. Two provider types are supported: **OpenAI** and **Local** (any server exposing the OpenAI `/v1/audio/speech` endpoint, e.g. [Speaches](https://speaches.ai/) serving Kokoro or piper voices).
 
 1. Open **Settings → Devices & Services → Home Generative Agent**.
 2. Click **+ TTS Provider**.
@@ -317,7 +318,7 @@ curl -X POST http://192.168.1.100:8000/v1/models/speaches-ai/Kokoro-82M-v1.0-ONN
 
 Two things to know about the local backend:
 
-- **Kokoro needs a reasonably modern machine.** On a GPU box that also runs Ollama it is fast and sounds good. On an old CPU without AVX2 it can take several times the audio duration to synthesize a sentence, and ONNX Runtime's CUDA path does not help it on Pascal-class GPUs. In that case use a piper voice instead — `speaches-ai/piper-en_US-hfc_female-medium` (voice `hfc_female`) or a `-low` variant — which synthesizes a sentence in about a second on CPU and needs no GPU. Browse the available models with `GET /v1/registry?task=text-to-speech`.
+- **Kokoro needs a reasonably modern machine.** On a modern CPU (AVX2) or a recent GPU it is fast and sounds good. On an old CPU without AVX2 it can take several times the audio duration to synthesize a sentence, and ONNX Runtime's CUDA path does not help it on Pascal-class GPUs. In that case use a piper voice instead — `speaches-ai/piper-en_US-hfc_female-medium` (voice `hfc_female`) or a `-low` variant — which synthesizes a sentence in about a second on CPU and needs no GPU. Browse the available models with `GET /v1/registry?task=text-to-speech`.
 - **Speaches does not produce opus or aac.** HGA never asks it to; a pipeline that wants those gets mp3 converted by Home Assistant.
 
 ---

--- a/docs/constants.md
+++ b/docs/constants.md
@@ -459,7 +459,7 @@ The same rules screen two surfaces: direct tool calls from the conversation agen
 
 | Constant | File | Value | Purpose |
 |---|---|---|---|
-| `STT_REQUEST_TIMEOUT_S` | `stt.py` | `120.0` (s) | Timeout for a transcription or translation request (connect timeout 5 s). Matches the chat provider timeout in `__init__.py`. Pinned on the OpenAI client rather than inherited from Home Assistant's shared httpx client, so a future HA change to that client cannot silently retime transcription. |
+| `STT_REQUEST_TIMEOUT_S` | `stt.py` | `120.0` (s) | Timeout for a transcription or translation request (connect timeout 5 s). Matches the chat provider timeout in `__init__.py`. Pinned on the OpenAI client rather than inherited from Home Assistant's shared httpx client, so a future HA change to that client cannot silently retime transcription. One attempt per utterance (`max_retries=0`), like TTS. |
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -40,15 +40,14 @@ It is available in the default HACS repository, or click the button below to ope
 
 > If you previously used the legacy single-entry flow, your settings are automatically migrated to the new subentry UI.
 
-**5. Open the integration page and click Setup.**
+**5. Add a Model Provider.**
 
-- Enable the features you want (Conversation, Camera Image Analysis, Conversation Summary are on by default).
-- Configure the database connection.
-- If no model provider exists yet, you will see a reminder to add one.
+Click **+ Model Provider** on the integration page and configure at least one provider: OpenAI, Ollama, Gemini, Anthropic, or any OpenAI-compatible endpoint. The first provider is automatically assigned to all features with default models. A provider must exist before Setup will run — Setup aborts with a reminder otherwise.
 
-**6. Add a Model Provider.**
+**6. Open the integration page and click + Setup.**
 
-Click **+ Model Provider** on the integration page and configure at least one provider: OpenAI, Ollama, Gemini, Anthropic, or any OpenAI-compatible endpoint. The first provider is automatically assigned to all features with default models.
+- **Basic** enables all features (Conversation, Camera Image Analysis, Conversation Summary) with recommended defaults and creates the database subentry automatically.
+- **Advanced** steps through each feature individually and includes a database configuration step.
 
 **7. Set HGA as your voice assistant.**
 
@@ -77,6 +76,10 @@ Run models locally for lower cost and latency.
   ollama pull gemma3:4b          # vision alternative (lighter; needs Ollama 0.6+)
   ollama pull mxbai-embed-large  # embeddings
   ```
+
+**Local speech server (STT and TTS)**
+
+HGA has its own speech-to-text and text-to-speech engines for Assist pipelines. Each can use the OpenAI API or a local OpenAI-compatible server such as [Speaches](https://speaches.ai/), which serves faster-whisper for STT and Kokoro or piper voices for TTS from one container. The server can run on any machine Home Assistant can reach — it does not have to be the box that runs Ollama or your other models, and it needs no GPU for piper voices or small whisper models. Setup, a ready-to-use `docker-compose` example, and model notes are in the [configuration guide](configuration.md#speech-to-text-stt).
 
 **Automation blueprints**
 


### PR DESCRIPTION
## Summary

Documentation-only follow-up to #603, prompted by two warts in the README: it implied the local STT server has to run on the Ollama box, and STT/TTS had no entry in the Requirements table.

- **README** — STT/TTS feature rows now say the speech server runs on any machine Home Assistant can reach (one Speaches container can serve both); new **Speech-to-text** and **Text-to-speech** rows in Requirements (OpenAI key or local OpenAI-compatible server, GPU vs CPU guidance, ffmpeg bundled with HA); Quick Start mentions the optional STT/TTS providers; docs index updated.
- **Installation** — fixes a real ordering bug: the guide had **Setup** before **Model Provider**, but Setup aborts with `no_provider_for_basic_setup` when no provider exists. Steps swapped and the Basic/Advanced modes described. New optional-app section for a local speech server.
- **Configuration** — STT/TTS intros and the "Running a local STT server" section drop the "same box as Ollama" framing, add CPU-only guidance (smaller whisper model + `latest-cpu` image), set the Speaches model TTL under both env names (`STT_MODEL_TTL` from current docs, `WHISPER__TTL` read by the `latest-cuda` image in the field), and quote the STT log message as the shared runtime now emits it.
- **Architecture / constants** — describe the shared STT/TTS client runtime and the single-attempt policy.

No code changes; no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015XTPJG3scUAWWxk1TsRdzk
