### PR TITLE
fix: resolve devices via DeviceRegistry.async_get for HA 2026.9

### DIFF
--- a/custom_components/home_generative_agent/snapshot/builder.py
+++ b/custom_components/home_generative_agent/snapshot/builder.py
@@ -67,7 +67,9 @@ def _build_area_lookup(hass: HomeAssistant) -> dict[str, str | None]:
         # area, which is how areas are most commonly assigned in HA.
         area_id = entry.area_id
         if area_id is None and entry.device_id is not None:
-            device = device_registry.devices.get(entry.device_id)
+            # async_get rather than devices.get: HA 2026.9 turned ``devices`` into
+            # a deprecated view that logs on every access and types as Collection.
+            device = device_registry.async_get(entry.device_id)
             if device is not None:
                 area_id = device.area_id
         lookup[entity_id] = area_names.get(area_id) if area_id is not None else None

--- a/tests/custom_components/home_generative_agent/test_conversation_units.py
+++ b/tests/custom_components/home_generative_agent/test_conversation_units.py
@@ -1028,7 +1028,8 @@ async def test_index_tools_poisoned_tool_does_not_starve_neighbors() -> None:
     # poison is core-specific (voluptuous-openapi raises on an object() leaf,
     # probatio renders it as a string), so the failure is raised upstream of
     # the converter to hold on both cores.
-    llm_api.apis["assist"].tools[0] = _PoisonedTool("HassStartTimer")
+    tools: Any = llm_api.apis["assist"].tools
+    tools[0] = _PoisonedTool("HassStartTimer")
 
     with (
         patch(f"{_CONV}.async_dispatcher_send"),


### PR DESCRIPTION
## Summary

HA 2026.9 turned `DeviceRegistry.devices` into a deprecated view. It now types as `Collection[DeviceEntry]` (no `.get`, so `make typecheck` fails against the 2026.9 test venv) and logs a `report_usage` deprecation on every access from a custom integration.

The snapshot builder's area lookup used `device_registry.devices.get(device_id)`. This switches it to the public `async_get(device_id)`, which exists on every supported core (min 2025.5.0) and returns the same entry.

Also types the poisoned-tool test's list slot as `Any` so pyright accepts the stand-in tool introduced in d6e5794.

## Verification

```
make lint      -> All checks passed
make typecheck -> 0 errors, 0 warnings
make test      -> 3049 passed, 1 skipped (HA 2026.9.0b4 / probatio core)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011cufDyAqfCyeBdn11PcTZa
