### PR TITLE
fix: drop hard-coded -2 num_predict sentinel for chat/VLM/summarization

### DIFF
--- a/custom_components/home_generative_agent/const.py
+++ b/custom_components/home_generative_agent/const.py
@@ -555,7 +555,13 @@ RECOMMENDED_OLLAMA_CHAT_MODEL: CHAT_MODEL_OLLAMA_SUPPORTED = "gpt-oss"
 CONF_OLLAMA_CHAT_KEEPALIVE = "ollama_chat_keepalive"
 RECOMMENDED_OLLAMA_CHAT_KEEPALIVE: KeepAliveSeconds = 300
 CONF_OLLAMA_CHAT_CONTEXT_SIZE = "ollama_chat_context_size"
-CHAT_MODEL_MAX_TOKENS = -2  # Ollama only, -2 = fill context
+# Ollama only; None = let the server apply its own default (local: fill
+# context on current servers; Cloud: the model's default). A hard-coded -2
+# sentinel is rejected by the Ollama Cloud backend with "max_tokens must be
+# positive" (issue #614); langchain-ollama and the ollama client both drop
+# None options before the request is sent, so this is a no-op on local
+# servers that still accept -2.
+CHAT_MODEL_MAX_TOKENS = None
 CHAT_MODEL_REPEAT_PENALTY = 1.05  # Ollama only
 
 CONF_OPENAI_CHAT_MODEL = "openai_chat_model"
@@ -615,9 +621,11 @@ RECOMMENDED_OLLAMA_VLM: VLM_OLLAMA_SUPPORTED = "qwen3-vl:8b"
 CONF_OLLAMA_VLM_KEEPALIVE = "ollama_vlm_keepalive"
 RECOMMENDED_OLLAMA_VLM_KEEPALIVE: KeepAliveSeconds = 300
 CONF_OLLAMA_VLM_CONTEXT_SIZE = "ollama_vlm_context_size"
-VLM_NUM_PREDICT = (
-    -2
-)  # Ollama only, -2 = fill context; do not change — governs ad-hoc agent image analysis
+# Ollama only; None = let the server apply its own default (see
+# CHAT_MODEL_MAX_TOKENS for why -2 was replaced, issue #614). Governs ad-hoc
+# agent image analysis; not the same constant as VIDEO_VLM_NUM_PREDICT below,
+# which stays a fixed positive cap by design.
+VLM_NUM_PREDICT = None
 VIDEO_VLM_NUM_PREDICT: int = (
     256  # video-role token limit (see video-sentinel-priority-plan.md)
 )
@@ -743,9 +751,11 @@ RECOMMENDED_OLLAMA_SUMMARIZATION_MODEL: SUMMARIZATION_MODEL_OLLAMA_SUPPORTED = (
 CONF_OLLAMA_SUMMARIZATION_KEEPALIVE = "ollama_summarization_keepalive"
 RECOMMENDED_OLLAMA_SUMMARIZATION_KEEPALIVE: KeepAliveSeconds = 300
 CONF_OLLAMA_SUMMARIZATION_CONTEXT_SIZE = "ollama_summarization_context_size"
-SUMMARIZATION_MODEL_PREDICT = (
-    -2
-)  # Ollama only, -2 = fill context; do not change — governs conversation summarization
+# Ollama only; None = let the server apply its own default (see
+# CHAT_MODEL_MAX_TOKENS for why -2 was replaced, issue #614). Governs
+# conversation summarization; not the same constant as
+# VIDEO_SUMMARY_NUM_PREDICT below, which stays a fixed positive cap by design.
+SUMMARIZATION_MODEL_PREDICT = None
 VIDEO_SUMMARY_NUM_PREDICT: int = (
     128  # video-role token limit (see video-sentinel-priority-plan.md)
 )

--- a/docs/constants.md
+++ b/docs/constants.md
@@ -45,7 +45,7 @@ This document covers the named constants that affect integration behaviour, orga
 |---|---|---|---|
 | `CHAT_MODEL_TOP_P` | `const.py` | `1.0` | nucleus sampling p for chat |
 | `GEMINI_3_RECOMMENDED_TEMPERATURE` | `const.py` | `1.0` | Temperature bound to Gemini 3-family models (all features) when the feature temperature is still the recommended default; `top_p` is left unset in that case. An explicitly customized temperature is honored, with a logged warning |
-| `CHAT_MODEL_MAX_TOKENS` | `const.py` | `-2` | Ollama max tokens (`-2` = fill context) |
+| `CHAT_MODEL_MAX_TOKENS` | `const.py` | `None` | Ollama max tokens. `None` is dropped by langchain-ollama/ollama, so the server applies its own default (local: fill-context; Cloud: model default). Was `-2`, rejected by Ollama Cloud (issue #614). |
 | `CHAT_MODEL_REPEAT_PENALTY` | `const.py` | `1.05` | Ollama repeat penalty |
 | `OLLAMA_GPT_EFFORT` | `const.py` | `"low"` | Effort hint for `gpt-oss` reasoning tag |
 | `LANGCHAIN_LOGGING_LEVEL` | `const.py` | `"disable"` | LangChain debug verbosity (`disable`, `verbose`, `debug`) |
@@ -83,7 +83,7 @@ This document covers the named constants that affect integration behaviour, orga
 | Constant | File | Value | Purpose |
 |---|---|---|---|
 | `VLM_TOP_P` | `const.py` | `1.0` | Nucleus sampling p for VLM |
-| `VLM_NUM_PREDICT` | `const.py` | `-2` | Ollama token budget for agent image analysis (`-2` = fill context) |
+| `VLM_NUM_PREDICT` | `const.py` | `None` | Ollama token budget for agent image analysis. `None` lets the server apply its own default. Was `-2`, rejected by Ollama Cloud (issue #614). |
 | `VIDEO_VLM_NUM_PREDICT` | `const.py` | `256` | Token budget for proactive video frame descriptions. Capped intentionally to prevent video from monopolizing context. |
 | `VLM_REPEAT_PENALTY` | `const.py` | `1.05` | Ollama repeat penalty |
 | `VLM_MIRO_STAT` | `const.py` | `0` | Ollama mirostat setting |
@@ -121,7 +121,7 @@ This document covers the named constants that affect integration behaviour, orga
 | Constant | File | Value | Purpose |
 |---|---|---|---|
 | `SUMMARIZATION_MODEL_TOP_P` | `const.py` | `1.0` | Nucleus sampling p |
-| `SUMMARIZATION_MODEL_PREDICT` | `const.py` | `-2` | Ollama token budget for conversation summaries (`-2` = fill context) |
+| `SUMMARIZATION_MODEL_PREDICT` | `const.py` | `None` | Ollama token budget for conversation summaries. `None` lets the server apply its own default. Was `-2`, rejected by Ollama Cloud (issue #614). |
 | `VIDEO_SUMMARY_NUM_PREDICT` | `const.py` | `128` | Token budget for video batch summaries. Capped to prevent video from blocking other callers. |
 | `SUMMARIZATION_MODEL_REPEAT_PENALTY` | `const.py` | `1.05` | Ollama repeat penalty |
 | `SUMMARIZATION_MIRO_STAT` | `const.py` | `0` | Ollama mirostat setting |

--- a/tests/custom_components/home_generative_agent/test_fallback_setup.py
+++ b/tests/custom_components/home_generative_agent/test_fallback_setup.py
@@ -375,7 +375,9 @@ async def test_setup_configures_fallback_models_and_embedding_chain(
     chat_fallback = cast("FakeConfiguredModel", chat_model.chain[1][0])
     assert chat_fallback.base.name == "ollama"
     assert chat_fallback.config["configurable"]["model"] == "qwen-chat-fallback"
-    assert chat_fallback.config["configurable"]["num_predict"] is not None
+    # CHAT_MODEL_MAX_TOKENS is None so the Ollama server applies its own
+    # default instead of a hard-coded -2 sentinel (issue #614).
+    assert chat_fallback.config["configurable"]["num_predict"] is None
 
     vision_model = entry.runtime_data.vision_model
     assert isinstance(vision_model, FallbackVLM)
@@ -387,7 +389,9 @@ async def test_setup_configures_fallback_models_and_embedding_chain(
     assert isinstance(summarization_model, FallbackChatModel)
     summary_fallback = cast("FakeConfiguredModel", summarization_model.chain[1][0])
     assert summary_fallback.config["configurable"]["model"] == "qwen-summary-fallback"
-    assert summary_fallback.config["configurable"]["num_predict"] is not None
+    # SUMMARIZATION_MODEL_PREDICT is None so the Ollama server applies its
+    # own default instead of a hard-coded -2 sentinel (issue #614).
+    assert summary_fallback.config["configurable"]["num_predict"] is None
 
     embedding_chain = data.captured_embedding_chain["chain"]
     assert [model.name for model, _deployment, _provider_id in embedding_chain] == [

--- a/tests/custom_components/home_generative_agent/test_fallback_setup.py
+++ b/tests/custom_components/home_generative_agent/test_fallback_setup.py
@@ -384,6 +384,9 @@ async def test_setup_configures_fallback_models_and_embedding_chain(
     vlm_fallback = cast("FakeConfiguredModel", vision_model.chain[1][0])
     assert vlm_fallback.config["configurable"]["model"] == "llava-fallback"
     assert vlm_fallback.config["configurable"]["mirostat"] is not None
+    # VLM_NUM_PREDICT is None so the Ollama server applies its own default
+    # instead of a hard-coded -2 sentinel (issue #614).
+    assert vlm_fallback.config["configurable"]["num_predict"] is None
 
     summarization_model = entry.runtime_data.summarization_model
     assert isinstance(summarization_model, FallbackChatModel)

--- a/tests/custom_components/home_generative_agent/test_ollama_num_predict_wire.py
+++ b/tests/custom_components/home_generative_agent/test_ollama_num_predict_wire.py
@@ -1,0 +1,50 @@
+# ruff: noqa: S101
+"""
+Pin the library behaviour the ``None`` num_predict constants rely on.
+
+Issue #614: ``CHAT_MODEL_MAX_TOKENS``, ``VLM_NUM_PREDICT`` and
+``SUMMARIZATION_MODEL_PREDICT`` are ``None`` so that no ``num_predict`` reaches
+the Ollama server at all (a ``-2`` sentinel is rejected by Ollama Cloud). That
+only holds while ``langchain-ollama`` drops ``None`` options before the request
+is built; a JSON ``null`` would be rejected by every server, local ones included.
+"""
+
+from __future__ import annotations
+
+from langchain_core.messages import HumanMessage
+from langchain_ollama import ChatOllama
+
+from custom_components.home_generative_agent.const import (
+    CHAT_MODEL_MAX_TOKENS,
+    SUMMARIZATION_MODEL_PREDICT,
+    VLM_NUM_PREDICT,
+)
+
+
+def test_num_predict_constants_are_unset() -> None:
+    assert CHAT_MODEL_MAX_TOKENS is None
+    assert VLM_NUM_PREDICT is None
+    assert SUMMARIZATION_MODEL_PREDICT is None
+
+
+def test_chat_ollama_omits_none_num_predict_from_request_options() -> None:
+    """A ``None`` num_predict must be absent from the wire options, not null."""
+    model = ChatOllama(
+        model="qwen3:0.6b",
+        base_url="http://127.0.0.1:1",
+        num_predict=CHAT_MODEL_MAX_TOKENS,
+        num_ctx=1024,
+    )
+    params = model._chat_params([HumanMessage("hi")])
+    options = params["options"]
+    assert "num_predict" not in options
+    assert options["num_ctx"] == 1024
+    assert None not in options.values()
+
+
+def test_chat_ollama_keeps_explicit_num_predict() -> None:
+    """The same path must still forward a real cap (the video constants)."""
+    model = ChatOllama(
+        model="qwen3:0.6b", base_url="http://127.0.0.1:1", num_predict=256
+    )
+    assert model._chat_params([HumanMessage("hi")])["options"]["num_predict"] == 256


### PR DESCRIPTION
Fixes #614.

## What

`CHAT_MODEL_MAX_TOKENS`, `VLM_NUM_PREDICT`, and `SUMMARIZATION_MODEL_PREDICT` were hard-coded to `-2` (Ollama's native "fill context" sentinel). Against an Ollama Cloud-backed model this is rejected with `max_tokens must be positive, got: -2`.

This implements the preferred/minimal fix from the issue discussion: set all three constants to `None` instead of a fixed value. `langchain-ollama` and the `ollama` client both drop `None` options before the request is sent, so the server falls back to its own default — fill-context on current local servers, the model's own default on Ollama Cloud. Avoids a hard-coded positive cap, which would risk truncating reasoning-model output (gpt-oss, qwen3) the same way the video pipeline's fixed caps were specifically tuned to avoid.

`VIDEO_VLM_NUM_PREDICT` / `VIDEO_SUMMARY_NUM_PREDICT` are unchanged, as requested.

## Also

- `docs/constants.md` rows updated for the three constants.
- Two assertions in `test_fallback_setup.py` expected a non-`None` `num_predict` on the chat/summarization fallback paths; flipped to expect `None` since that's now the intended value.

## Not done here

I haven't been able to confirm from my end yet whether the original report's Ollama instance is actually Cloud-backed (`ollama --version` / `ollama show gpt-oss` / Apple Silicon check) — will follow up with that in the issue. This PR applies your preferred fix regardless, since it's safe either way per your analysis (no-op on local servers that still accept `-2`, and fixes the Cloud case).

## Testing

Couldn't run the full `make test` locally (sandbox is Python 3.12, repo requires 3.14 + full HA package), so I ran `ruff format --check` and `ruff check` against the changed file (both clean) and manually traced every call site of the three constants in `__init__.py` plus the existing test suite to find and update the two assertions that would otherwise regress. Would appreciate CI/maintainer review on the rest.