### PR TITLE
fix: stop re-ingesting the agent's own turns into its thread (issue #621)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.39.4] - 2026-09-10
+
+### Fixed
+
+- The agent no longer answers the previous question instead of the new one after a few turns in the same conversation. Every turn's user message (and, for a turn that answered without tools, the reply too) was being appended to the conversation thread a second time on the following turn, under a fresh message id, so the stale copy sat directly before the new request and the model frequently answered it instead: a question about free disk space got the previous turn's movie count. The cause was the chat_log history filter, which exists to pick up turns handled by *another* agent sharing the conversation (Home Assistant's built-in agent on a shared pipeline) but could not tell those from the agent's own turns, which the LangGraph checkpointer already holds. The design dates from when the integration wrote nothing to chat_log; populating it for Show Details in v3.11.0 silently turned every own turn into a duplicate. The filter now groups chat_log into turns, recognises its own turns by `agent_id`, and ingests only foreign turns that follow its latest own turn. The per-entity high-water mark is gone, so two conversations served at once (a voice satellite plus the chat box) no longer starve each other of that shared-agent history either. Threads also stop carrying a stale copy of every turn, which was eating into `max_messages_in_context`. Thanks to [@andrewvlahopoulos](https://github.com/andrewvlahopoulos) for the trace that pinned the shape. ([#621](https://github.com/goruck/home-generative-agent/issues/621), [#590](https://github.com/goruck/home-generative-agent/issues/590))
+- Two related holes in the non-streaming path (schema-first YAML mode) are closed with it: a turn that failed with any error now still records its own entry in chat_log, so the foreign history already checkpointed with that request is not prepended again on the next turn; and the chat_log backfill for Show Details now writes only the messages produced this turn. It sliced the returned thread by the input length, but the graph returns the whole checkpointed thread, so from the second turn on it also wrote every earlier reply to chat_log again. Messages ingested from chat_log now carry an id derived from their position, so a turn cancelled before it could leave its mark only upserts the same messages next time instead of appending duplicates.
+- Conversations continued under a fixed, user-supplied `conversation_id` (for example `conversation.process` calls from an automation) keep the history already duplicated by earlier versions until it is trimmed past `max_messages_in_context`; start such a conversation under a new id for an immediate fix. Frontend and voice-satellite conversations start fresh after the restart.
+
 ## [3.39.3] - 2026-09-10
 
 ### Fixed

--- a/custom_components/home_generative_agent/conversation.py
+++ b/custom_components/home_generative_agent/conversation.py
@@ -180,16 +180,19 @@ else:
 
 def _convert_content(
     content: conversation.UserContent | conversation.AssistantContent,
+    message_id: str,
 ) -> HumanMessage | AIMessage:
     """
     Convert HA native chat messages to LangChain messages.
 
     Only called with UserContent or tool-call-free AssistantContent (filtered
-    upstream — see message_history comprehension in _async_handle_message).
+    upstream — see _async_get_message_history). The id is derived from the
+    entry's position in chat_log so that ingesting the same entry twice
+    upserts the message in the thread instead of appending a second copy.
     """
     if isinstance(content, conversation.UserContent):
-        return HumanMessage(content=content.content or "")
-    return AIMessage(content=content.content or "")
+        return HumanMessage(content=content.content or "", id=message_id)
+    return AIMessage(content=content.content or "", id=message_id)
 
 
 def _normalize_ai_content(content: str | list) -> str | None:
@@ -287,9 +290,9 @@ def _populate_chat_log_from_response(
     """
     Backfill chat_log with LangGraph response messages for HA Show Details.
 
-    Walks new_messages (messages produced this turn, sliced from
-    response["messages"][len(app_input["messages"]):]) and appends AssistantContent
-    and ToolResultContent entries so HA's "Show Details" panel renders the full tool
+    Walks new_messages (the messages produced this turn: everything after the
+    current request in the returned thread) and appends AssistantContent and
+    ToolResultContent entries so HA's "Show Details" panel renders the full tool
     call / result chain.
 
     All ToolInput entries use external=True because LangGraph, not HA, executed the
@@ -789,8 +792,6 @@ class HGAConversationEntity(conversation.ConversationEntity, AbstractConversatio
             model="Home Generative Agent",
             entry_type=dr.DeviceEntryType.SERVICE,
         )
-        self.message_history_len = 0
-
         # CONTROL tells Home Assistant this agent controls entities.  Its only
         # consumer is assist_pipeline, which uses it to route *state questions*
         # and media search to the agent instead of answering them locally --
@@ -861,46 +862,82 @@ class HGAConversationEntity(conversation.ConversationEntity, AbstractConversatio
     def _async_get_message_history(
         self, chat_log: conversation.ChatLog
     ) -> list[HumanMessage | AIMessage]:
-        """Extract and slice the relevant chat log history."""
-        # Include only HA User/Assistant messages not already seen by this entity.
-        #
-        # Exclude every part of a turn that used tools, not just the
-        # AssistantContent carrying the tool_calls. A tool-using turn writes
-        # three entries — tool_calls, ToolResultContent, then the spoken text —
-        # and the spoken text alone ("Turned on the light") is indistinguishable
-        # from a turn that answered without acting. Ingesting it teaches the
-        # model that such a request is answered with prose and no tool call:
-        # the conversation then repeats that shape and every device command
-        # silently becomes a lie (issue #588). This matters most for turns
-        # handled by ANOTHER agent sharing the conversation — HA's built-in
-        # agent, say — whose tool calls the checkpointer never saw. HGA's own
-        # tool-using turns are already persisted in full by LangGraph, so
-        # dropping their chat_log echo also removes a duplicate.
-        message_history: list[HumanMessage | AIMessage] = []
-        turn_used_tools = False
-        for m in chat_log.content:
-            if isinstance(m, conversation.UserContent):
-                turn_used_tools = False
-                message_history.append(_convert_content(m))
-            elif isinstance(m, conversation.ToolResultContent):
-                turn_used_tools = True
-            elif isinstance(m, conversation.AssistantContent):
-                # `is not None` keeps the original inclusion predicate exactly;
-                # only the turn-level suppression below is new.
-                if m.tool_calls is not None:
-                    turn_used_tools = True
-                elif not turn_used_tools:
-                    message_history.append(_convert_content(m))
-        # The last chat log entry will be the current user request—add it later.
-        message_history = message_history[:-1]
+        """
+        Return the chat_log turns that the agent's own thread does not hold yet.
 
-        mhlen = len(message_history)
-        if mhlen <= self.message_history_len:
-            message_history = []
-        else:
-            diff = mhlen - self.message_history_len
-            message_history = message_history[-diff:]
-            self.message_history_len = mhlen
+        The LangGraph checkpointer already persists, in full, every turn this
+        entity handled: the thread is keyed on the conversation_id. The only
+        chat_log content worth ingesting is therefore what ANOTHER agent added
+        to the same conversation — Home Assistant's built-in agent answering a
+        quick local command on a shared pipeline, say — because the checkpointer
+        never saw it. Re-ingesting one of our own turns appends a second copy
+        under a fresh message id, and that stale copy then sits directly before
+        the new request, which the model frequently answers instead of the new
+        question (issue #621).
+
+        Turns are grouped from each UserContent. A turn is ours when its final
+        entry is an AssistantContent we wrote: HA's built-in agent stamps its
+        tool_calls and ToolResultContent with the pipeline's agent id (ours, on
+        an HGA pipeline) but speaks the result under its own id, so only the
+        last entry tells the two apart. Every foreign turn BEFORE our latest
+        own turn was ingested when that turn ran, so only the foreign turns
+        after it are new; the walk is stateless and per-conversation by
+        construction. The trailing user-only turn is the current request,
+        which the caller appends. Ingested messages carry an id derived from
+        their chat_log position, so a turn that failed or was cancelled before
+        it could leave our mark only upserts the same messages next time.
+
+        A foreign turn that used tools contributes only the user's message.
+        A tool-using turn writes three entries — tool_calls, ToolResultContent,
+        then the spoken text — and the spoken text alone ("Turned on the
+        light") is indistinguishable from a turn that answered without acting.
+        Ingesting it teaches the model that such a request is answered with
+        prose and no tool call, after which every device command silently
+        becomes a lie (issue #588).
+        """
+        turns: list[list[tuple[int, Any]]] = []
+        for index, m in enumerate(chat_log.content):
+            if isinstance(m, conversation.UserContent):
+                turns.append([(index, m)])
+            elif turns and isinstance(
+                m, conversation.AssistantContent | conversation.ToolResultContent
+            ):
+                turns[-1].append((index, m))
+
+        # The last chat_log entry is the current user request; the caller adds it.
+        if turns and len(turns[-1]) == 1:
+            turns.pop()
+
+        def _is_own(turn: list[tuple[int, Any]]) -> bool:
+            _, last = turn[-1]
+            return (
+                isinstance(last, conversation.AssistantContent)
+                and last.agent_id == self.entity_id
+            )
+
+        def _used_tools(turn: list[tuple[int, Any]]) -> bool:
+            # `is not None` keeps the #588 inclusion predicate exactly: an
+            # empty-but-present tool_calls list still marks the turn.
+            return any(
+                isinstance(entry, conversation.ToolResultContent)
+                or entry.tool_calls is not None
+                for _, entry in turn[1:]
+            )
+
+        last_own = max((i for i, turn in enumerate(turns) if _is_own(turn)), default=-1)
+
+        def _message_id(index: int) -> str:
+            return f"chat_log:{chat_log.conversation_id}:{index}"
+
+        message_history: list[HumanMessage | AIMessage] = []
+        for turn in turns[last_own + 1 :]:
+            index, user = turn[0]
+            message_history.append(_convert_content(user, _message_id(index)))
+            if _used_tools(turn):
+                continue
+            message_history.extend(
+                _convert_content(entry, _message_id(index)) for index, entry in turn[1:]
+            )
 
         return message_history
 
@@ -1052,10 +1089,24 @@ class HGAConversationEntity(conversation.ConversationEntity, AbstractConversatio
 
         try:
             response = await app.ainvoke(input=input_data, config=config)
-        except HomeAssistantError as err:
+        except Exception as err:
             _LOGGER.exception("LangGraph error during conversation processing.")
-            msg = f"Something went wrong: {err}"
-            raise HomeAssistantError(msg) from err
+            # Leave our mark on the turn even though it failed. LangGraph
+            # checkpoints the input before the first node runs, so the thread
+            # already holds this request and any foreign history prepended to
+            # it; without an own entry HA drops the whole turn from chat_log as
+            # one with no assistant message, and _async_get_message_history
+            # would see no boundary next turn (issue #621, review finding).
+            chat_log.async_add_assistant_content_without_tools(
+                conversation.AssistantContent(
+                    agent_id=self.entity_id,
+                    content=_streaming_failure_content(err),
+                )
+            )
+            if isinstance(err, HomeAssistantError):
+                msg = f"Something went wrong: {err}"
+                raise HomeAssistantError(msg) from err
+            raise HomeAssistantError(_streaming_failure_content(err)) from err
 
         trace.async_conversation_trace_append(
             trace.ConversationTraceEventType.AGENT_DETAIL,
@@ -1078,8 +1129,23 @@ class HGAConversationEntity(conversation.ConversationEntity, AbstractConversatio
 
         # Backfill chat_log with the messages produced this turn so HA's
         # "Show Details" panel renders the full tool call / result chain.
-        # Slice off history + current HumanMessage — only net-new messages.
-        new_messages = response["messages"][len(input_data["messages"]) :]
+        # ainvoke returns the whole checkpointed thread, not input plus output,
+        # so slicing by the input length would replay earlier turns' replies
+        # into chat_log once the thread holds more than this turn. Net-new is
+        # everything after the current request, found by the id stamped on it.
+        # The request is absent only when this turn's own trim-and-summarize
+        # removed it; the final reply is then all Show Details can carry.
+        thread = response["messages"]
+        request_id = input_data["messages"][-1].id
+        request_index = next(
+            (i for i in range(len(thread) - 1, -1, -1) if thread[i].id == request_id),
+            None,
+        )
+        if request_index is None:
+            _LOGGER.debug("Request was summarized away; backfilling the reply only.")
+            new_messages = thread[-1:]
+        else:
+            new_messages = thread[request_index + 1 :]
 
         # Guard: async_get_result_from_chat_log requires last entry to be
         # AssistantContent, which means the last new message must be an
@@ -1410,8 +1476,13 @@ class HGAConversationEntity(conversation.ConversationEntity, AbstractConversatio
             debug=LANGCHAIN_LOGGING_LEVEL == "debug",
         )
 
-        # Agent input: message history + current user request.
-        messages = [*message_history, HumanMessage(content=user_input.text)]
+        # Agent input: message history + current user request. The request
+        # carries an explicit id so the non-streaming path can find it in the
+        # returned thread (add_messages keeps a caller-supplied id).
+        messages = [
+            *message_history,
+            HumanMessage(content=user_input.text, id=ulid.ulid_now()),
+        ]
         app_input: State = {
             "messages": messages,
             "summary": "",
@@ -1439,11 +1510,13 @@ class HGAConversationEntity(conversation.ConversationEntity, AbstractConversatio
         else:
             await self._async_run_astream(app, app_input, app_config, chat_log, tools)
 
-        # Guard against an empty chat log (e.g. HomeAssistantError swallowed mid-stream
-        # before any AssistantContent was committed).
-        # async_get_result_from_chat_log raises if no AssistantContent is present.
-        if not any(
-            isinstance(msg, conversation.AssistantContent) for msg in chat_log.content
+        # Guard against a turn that committed no reply (e.g. a HomeAssistantError
+        # swallowed mid-stream and a state recovery that raised too). Earlier
+        # turns' replies do not count: async_get_result_from_chat_log reads the
+        # LAST entry, and HA drops the whole turn from chat_log unless we leave
+        # our mark on it (see _async_get_message_history).
+        if not chat_log.content or not isinstance(
+            chat_log.content[-1], conversation.AssistantContent
         ):
             chat_log.async_add_assistant_content_without_tools(
                 conversation.AssistantContent(

--- a/custom_components/home_generative_agent/manifest.json
+++ b/custom_components/home_generative_agent/manifest.json
@@ -36,5 +36,5 @@
     "langchain-anthropic==1.4.3"
   ],
   "single_config_entry": true,
-  "version": "3.39.3"
+  "version": "3.39.4"
 }

--- a/tests/custom_components/home_generative_agent/test_conversation_units.py
+++ b/tests/custom_components/home_generative_agent/test_conversation_units.py
@@ -9,12 +9,13 @@ homeassistant.components.conversation import chain before importing conversation
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import inspect
 import re
 import sys
 import types
 from enum import IntFlag
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 from zoneinfo import ZoneInfo
 
@@ -22,6 +23,12 @@ import pytest
 from homeassistant.const import CONF_LLM_HASS_API
 from homeassistant.exceptions import HomeAssistantError, TemplateError
 from homeassistant.helpers import llm as ha_llm
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.graph import END, START, MessagesState, StateGraph
+
+if TYPE_CHECKING:
+    from langchain_core.runnables import RunnableConfig
 
 from custom_components.home_generative_agent.const import (
     CONF_CRITICAL_ACTION_PIN_ENABLED,
@@ -1133,8 +1140,11 @@ def test_control_feature_absent_when_stored_api_list_is_empty() -> None:
 
 
 # ---------------------------------------------------------------------------
-# _async_get_message_history: a tool-using turn must not be ingested as prose
+# _async_get_message_history: only foreign turns reach the thread (#588, #621, #590)
 # ---------------------------------------------------------------------------
+
+HGA_AGENT_ID = "conversation.home_generative_agent"
+FOREIGN_AGENT_ID = "conversation.home_assistant"
 
 
 def _mk_content(cls: Any, **kwargs: Any) -> Any:
@@ -1153,11 +1163,57 @@ def _mk_content(cls: Any, **kwargs: Any) -> Any:
         return obj
 
 
-def _history(content: list) -> list:
-    """Run _async_get_message_history against a fresh entity counter."""
-    fake_self = cast("Any", types.SimpleNamespace(message_history_len=0))
-    chat_log = cast("Any", types.SimpleNamespace(content=content))
+def _history(content: list, entity: Any | None = None) -> list:
+    """Run _async_get_message_history for this entity over a chat_log."""
+    fake_self = entity if entity is not None else _entity()
+    chat_log = cast(
+        "Any", types.SimpleNamespace(content=content, conversation_id="conv-1")
+    )
     return HGAConversationEntity._async_get_message_history(fake_self, chat_log)
+
+
+def _entity() -> Any:
+    """Build a bare entity: the filter needs nothing beyond its own entity_id."""
+    return cast("Any", types.SimpleNamespace(entity_id=HGA_AGENT_ID))
+
+
+def _own_tool_turn(question: str, answer: str) -> list:
+    """Build what HGA itself writes to chat_log for a turn that called a tool."""
+    return [
+        _mk_content(ha_conversation.UserContent, content=question),
+        _mk_content(
+            ha_conversation.AssistantContent,
+            agent_id=HGA_AGENT_ID,
+            content=None,
+            tool_calls=[object()],
+        ),
+        _mk_content(
+            ha_conversation.ToolResultContent,
+            agent_id=HGA_AGENT_ID,
+            tool_call_id="call_1",
+            tool_name="plex_library",
+            tool_result={"movies": 1389},
+        ),
+        _mk_content(
+            ha_conversation.AssistantContent,
+            agent_id=HGA_AGENT_ID,
+            content=answer,
+            tool_calls=None,
+        ),
+    ]
+
+
+def _plain_turn(agent_id: str, question: str, answer: str) -> list:
+    """Build a user question answered in prose, with no tool call, by `agent_id`."""
+    return [
+        _mk_content(ha_conversation.UserContent, content=question),
+        _mk_content(
+            ha_conversation.AssistantContent,
+            agent_id=agent_id,
+            content=answer,
+            tool_calls=None,
+        ),
+    ]
 
 
 def test_message_history_drops_spoken_text_of_a_tool_using_turn() -> None:
@@ -1176,20 +1232,20 @@ def test_message_history_drops_spoken_text_of_a_tool_using_turn() -> None:
         _mk_content(ha_conversation.UserContent, content="Turn on the garage light."),
         _mk_content(
             ha_conversation.AssistantContent,
-            agent_id="conversation.home_assistant",
+            agent_id=FOREIGN_AGENT_ID,
             content=None,
             tool_calls=[object()],
         ),
         _mk_content(
             ha_conversation.ToolResultContent,
-            agent_id="conversation.home_assistant",
+            agent_id=FOREIGN_AGENT_ID,
             tool_call_id="01M16N286Y2A5T0BVZ163SMKT7",
             tool_name="HassTurnOn",
             tool_result={"speech": {"plain": {"speech": "Turned on the light"}}},
         ),
         _mk_content(
             ha_conversation.AssistantContent,
-            agent_id="conversation.home_assistant",
+            agent_id=FOREIGN_AGENT_ID,
             content="Turned on the light",
             tool_calls=None,
         ),
@@ -1208,12 +1264,12 @@ def test_message_history_drops_spoken_text_of_a_tool_using_turn() -> None:
 
 
 def test_message_history_keeps_a_genuine_toolless_reply() -> None:
-    """A turn that really answered without tools is still ingested."""
+    """A foreign turn that really answered without tools is still ingested."""
     content = [
         _mk_content(ha_conversation.UserContent, content="what can you do?"),
         _mk_content(
             ha_conversation.AssistantContent,
-            agent_id="conversation.home_generative_agent",
+            agent_id=FOREIGN_AGENT_ID,
             content="I can control your home.",
             tool_calls=None,
         ),
@@ -1234,27 +1290,27 @@ def test_message_history_tool_flag_resets_on_the_next_user_turn() -> None:
         _mk_content(ha_conversation.UserContent, content="Turn on the garage light."),
         _mk_content(
             ha_conversation.AssistantContent,
-            agent_id="conversation.home_assistant",
+            agent_id=FOREIGN_AGENT_ID,
             content=None,
             tool_calls=[object()],
         ),
         _mk_content(
             ha_conversation.ToolResultContent,
-            agent_id="conversation.home_assistant",
+            agent_id=FOREIGN_AGENT_ID,
             tool_call_id="call_1",
             tool_name="HassTurnOn",
             tool_result={},
         ),
         _mk_content(
             ha_conversation.AssistantContent,
-            agent_id="conversation.home_assistant",
+            agent_id=FOREIGN_AGENT_ID,
             content="Turned on the light",
             tool_calls=None,
         ),
         _mk_content(ha_conversation.UserContent, content="thanks"),
         _mk_content(
             ha_conversation.AssistantContent,
-            agent_id="conversation.home_generative_agent",
+            agent_id=FOREIGN_AGENT_ID,
             content="You're welcome.",
             tool_calls=None,
         ),
@@ -1283,7 +1339,7 @@ def test_message_history_non_none_tool_calls_still_excluded() -> None:
         _mk_content(ha_conversation.UserContent, content="hello"),
         _mk_content(
             ha_conversation.AssistantContent,
-            agent_id="conversation.home_generative_agent",
+            agent_id=FOREIGN_AGENT_ID,
             content="Hi there.",
             tool_calls=[],
         ),
@@ -1294,6 +1350,372 @@ def test_message_history_non_none_tool_calls_still_excluded() -> None:
 
     assert [type(m).__name__ for m in history] == ["HumanMessage"]
     assert history[0].content == "hello"
+
+
+def test_message_history_skips_the_entitys_own_turns() -> None:
+    """
+    Nothing HGA itself said is fed back into its own thread.
+
+    Regression for issue #621. The LangGraph checkpointer already holds every
+    turn this entity handled, so re-ingesting the chat_log echo of one appends a
+    second copy under a fresh message id. The stale copy then sits directly
+    before the new request and the model answers it instead — a question about
+    free disk space got the previous turn's movie count. Both a tool-using turn
+    and a plain prose turn must contribute nothing.
+    """
+    content = [
+        *_own_tool_turn("How many movies are in my library?", "1,389 movies."),
+        *_plain_turn(HGA_AGENT_ID, "Thanks!", "Any time."),
+        _mk_content(
+            ha_conversation.UserContent, content="How much free space is left?"
+        ),
+    ]
+
+    assert _history(content) == [], "our own turns are already in the thread"
+
+
+def test_message_history_ingests_only_foreign_turns_after_our_latest_turn() -> None:
+    """
+    A foreign turn older than our latest turn was ingested when that turn ran.
+
+    Replaces the per-entity high-water mark with a stateless rule: everything
+    before HGA's most recent own turn is already in the thread; only foreign
+    turns after it are new.
+    """
+    content = [
+        *_plain_turn(FOREIGN_AGENT_ID, "what time is it?", "It is 4:42 AM."),
+        *_own_tool_turn("Turn on the garage light.", "Done."),
+        *_plain_turn(FOREIGN_AGENT_ID, "and the date?", "September 10th."),
+        _mk_content(ha_conversation.UserContent, content="Turn it off again."),
+    ]
+
+    history = _history(content)
+
+    assert [(type(m).__name__, m.content) for m in history] == [
+        ("HumanMessage", "and the date?"),
+        ("AIMessage", "September 10th."),
+    ], "only the foreign turn after our latest own turn is new"
+
+
+def test_message_history_is_per_conversation() -> None:
+    """
+    Two conversations served by one entity do not starve each other.
+
+    Regression for issue #590: the old counter lived on the entity while
+    chat_log is per conversation, so a second conversation got no history until
+    it outgrew the first. The walk now needs no entity state at all.
+    """
+    entity = _entity()
+    conv_a = [
+        *_plain_turn(FOREIGN_AGENT_ID, "A question", "A answer"),
+        _mk_content(ha_conversation.UserContent, content="A follow-up"),
+    ]
+    conv_b = [
+        *_plain_turn(FOREIGN_AGENT_ID, "B question", "B answer"),
+        _mk_content(ha_conversation.UserContent, content="B follow-up"),
+    ]
+
+    assert [m.content for m in _history(conv_a, entity)] == ["A question", "A answer"]
+    assert [m.content for m in _history(conv_b, entity)] == ["B question", "B answer"]
+    assert [m.content for m in _history(conv_a, entity)] == ["A question", "A answer"]
+
+
+def test_message_history_own_failed_turn_still_marks_the_boundary() -> None:
+    """
+    A turn we failed still counts as ours, so foreign history is not replayed.
+
+    The non-streaming path records its failure as an own AssistantContent;
+    the foreign turn before it was already prepended to the failed request
+    and checkpointed, so it must not be ingested a second time.
+    """
+    content = [
+        *_plain_turn(FOREIGN_AGENT_ID, "what time is it?", "It is 4:42 AM."),
+        _mk_content(ha_conversation.UserContent, content="Turn on the garage light."),
+        _mk_content(
+            ha_conversation.AssistantContent,
+            agent_id=HGA_AGENT_ID,
+            content="I'm sorry, I was unable to respond: Something went wrong",
+            tool_calls=None,
+        ),
+        _mk_content(ha_conversation.UserContent, content="Try again."),
+    ]
+
+    assert _history(content) == []
+
+
+def test_message_history_locally_handled_intent_is_a_foreign_turn() -> None:
+    """
+    A turn HA's built-in agent handled on our pipeline is not ours.
+
+    With prefer_local_intents the default agent stamps its tool_calls and
+    ToolResultContent with the pipeline's agent id — this entity's — but the
+    pipeline speaks the result under conversation.home_assistant. Judging the
+    turn by any entry would swallow it and every foreign turn before it; the
+    user's message must survive (the #588 rule drops the rest).
+    """
+    content = [
+        *_plain_turn(FOREIGN_AGENT_ID, "what time is it?", "It is 4:42 AM."),
+        _mk_content(ha_conversation.UserContent, content="Turn on the garage light."),
+        _mk_content(
+            ha_conversation.AssistantContent,
+            agent_id=HGA_AGENT_ID,
+            content=None,
+            tool_calls=[object()],
+        ),
+        _mk_content(
+            ha_conversation.ToolResultContent,
+            agent_id=HGA_AGENT_ID,
+            tool_call_id="01M16N286Y2A5T0BVZ163SMKT7",
+            tool_name="HassTurnOn",
+            tool_result={"speech": {"plain": {"speech": "Turned on the light"}}},
+        ),
+        _mk_content(
+            ha_conversation.AssistantContent,
+            agent_id=FOREIGN_AGENT_ID,
+            content="Turned on the light",
+            tool_calls=None,
+        ),
+        _mk_content(ha_conversation.UserContent, content="Turn it off again."),
+    ]
+
+    assert [m.content for m in _history(content)] == [
+        "what time is it?",
+        "It is 4:42 AM.",
+        "Turn on the garage light.",
+    ]
+
+
+def test_message_history_ids_make_re_ingestion_an_upsert() -> None:
+    """
+    Ingesting the same foreign turn twice leaves one copy in the thread.
+
+    A turn of ours that fails or is cancelled before it leaves its mark means
+    the foreign history prepended to it is offered again next turn. The ids
+    derive from chat_log position, so add_messages replaces in place.
+    """
+    content = [
+        *_plain_turn(FOREIGN_AGENT_ID, "what time is it?", "It is 4:42 AM."),
+        _mk_content(ha_conversation.UserContent, content="Turn on the garage light."),
+    ]
+    first = _history(content)
+    second = _history(content)
+    assert [m.id for m in first] == [m.id for m in second]
+    assert first[0].id == "chat_log:conv-1:0"
+
+    graph = StateGraph(MessagesState)
+    graph.add_node("agent", _no_op_node)
+    graph.add_edge(START, "agent")
+    graph.add_edge("agent", END)
+    app = graph.compile(checkpointer=MemorySaver())
+    config: RunnableConfig = {"configurable": {"thread_id": "conv-1"}}
+    app.invoke({"messages": first}, config)
+    app.invoke({"messages": second}, config)
+
+    assert [m.content for m in app.get_state(config).values["messages"]] == [
+        "what time is it?",
+        "It is 4:42 AM.",
+    ]
+
+
+def _no_op_node(state: MessagesState) -> dict[str, Any]:  # noqa: ARG001
+    return {"messages": []}
+
+
+def _runner_entity() -> Any:
+    """Build an entity with just what _async_run_ainvoke touches."""
+    entity = HGAConversationEntity.__new__(HGAConversationEntity)
+    entity.hass = MagicMock()
+    entity.entity_id = HGA_AGENT_ID
+    entity.entry = cast(
+        "Any",
+        types.SimpleNamespace(runtime_data=types.SimpleNamespace(options={})),
+    )
+    return entity
+
+
+class _RecordedContent:
+    """Kwargs-accepting stand-in: the suite's HA import stub takes no arguments."""
+
+    def __init__(self, **fields: Any) -> None:
+        self.tool_calls = None
+        self.__dict__.update(fields)
+
+
+class _FakeAssistantContent(_RecordedContent):
+    pass
+
+
+class _FakeToolResultContent(_RecordedContent):
+    pass
+
+
+def _patch_runner_deps() -> list[Any]:
+    """Patch what the runner touches that the stubbed venv cannot provide."""
+    module = "custom_components.home_generative_agent.conversation"
+    return [
+        patch(
+            f"{module}._fix_entity_ids_in_text", side_effect=lambda text, _hass: text
+        ),
+        patch(f"{module}.trace.async_conversation_trace_append"),
+        patch(f"{module}.conversation.AssistantContent", _FakeAssistantContent),
+        patch(f"{module}.conversation.ToolResultContent", _FakeToolResultContent),
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("error", "expected_text"),
+    [
+        (
+            HomeAssistantError("Model invocation failed: 429"),
+            "I'm sorry, I was unable to respond: Model invocation failed: 429",
+        ),
+        (
+            RuntimeError("psycopg lost the connection to db://secret"),
+            "I'm sorry, I was unable to respond (RuntimeError). Please try again.",
+        ),
+    ],
+)
+async def test_non_streaming_failure_leaves_an_own_chat_log_entry(
+    error: Exception, expected_text: str
+) -> None:
+    """
+    A failed non-streaming turn still writes our AssistantContent.
+
+    Without it HA discards the whole turn from chat_log (no assistant message
+    was added), the boundary rule in _async_get_message_history sees no own
+    turn, and the foreign history already checkpointed with the failed request
+    is offered again next turn (issue #621 review finding). Any exception
+    counts, not only HomeAssistantError, and arbitrary ones surface only their
+    class name.
+    """
+    request = HumanMessage(content="Turn on the garage light.", id="req-1")
+    app = types.SimpleNamespace(ainvoke=AsyncMock(side_effect=error))
+    written: list[Any] = []
+    chat_log = types.SimpleNamespace(
+        content=written,
+        async_add_assistant_content_without_tools=written.append,
+    )
+    entity = _runner_entity()
+
+    with contextlib.ExitStack() as stack:
+        for patcher in _patch_runner_deps():
+            stack.enter_context(patcher)
+        with pytest.raises(HomeAssistantError):
+            await entity._async_run_ainvoke(
+                app,
+                cast("Any", {"messages": [request]}),
+                cast("Any", {}),
+                cast("Any", chat_log),
+                None,
+            )
+
+    assert len(written) == 1
+    assert written[0].agent_id == HGA_AGENT_ID
+    assert written[0].content == expected_text
+    assert "db://secret" not in written[0].content
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_backfill_only_writes_this_turns_messages() -> None:
+    """
+    The runner gets the whole thread back; only this turn reaches chat_log.
+
+    The old slice `response["messages"][len(input):]` assumed the response was
+    input plus output. With a checkpointed thread it is the full history, so
+    from the second turn on every earlier reply was written to chat_log again.
+    """
+    request = HumanMessage(content="How much free space is left?", id="req-2")
+    thread = [
+        HumanMessage(content="How many movies are in my library?", id="req-1"),
+        AIMessage(content="", tool_calls=[{"name": "plex", "args": {}, "id": "c1"}]),
+        ToolMessage(content="1389", tool_call_id="c1", name="plex"),
+        AIMessage(content="You have 1,389 movies."),
+        request,
+        AIMessage(content="", tool_calls=[{"name": "disk", "args": {}, "id": "c2"}]),
+        ToolMessage(content="2 TB", tool_call_id="c2", name="disk"),
+        AIMessage(content="About 2 TB free."),
+    ]
+    app = types.SimpleNamespace(ainvoke=AsyncMock(return_value={"messages": thread}))
+
+    written: list[Any] = []
+    chat_log = types.SimpleNamespace(
+        content=written,
+        async_add_assistant_content_without_tools=written.append,
+    )
+    entity = _runner_entity()
+
+    with contextlib.ExitStack() as stack:
+        for patcher in _patch_runner_deps():
+            stack.enter_context(patcher)
+        await entity._async_run_ainvoke(
+            app,
+            cast("Any", {"messages": [request]}),
+            cast("Any", {}),
+            cast("Any", chat_log),
+            None,
+        )
+
+    contents = [getattr(entry, "content", None) for entry in written]
+    assert "You have 1,389 movies." not in contents, (
+        "the previous turn's reply must not be written to chat_log again"
+    )
+    assert [type(entry).__name__.removeprefix("_Fake") for entry in written] == [
+        "AssistantContent",
+        "ToolResultContent",
+        "AssistantContent",
+    ]
+    assert written[-1].content == "About 2 TB free."
+
+
+def test_message_history_thread_holds_each_user_message_once() -> None:
+    """
+    End to end through the real reducer: four turns, no duplicate messages.
+
+    Mirrors the trace in issue #621. The chat_log grows the way HGA writes it,
+    the filter's output is prepended to each request exactly as
+    _async_handle_message_active does, and the thread is checkpointed by
+    LangGraph's add_messages reducer. Every user message must appear once.
+    """
+    turns = [
+        ("How many movies are in my library?", "You have 1,389 movies."),
+        ("How much free space is left?", "About 2 TB free."),
+        ("Did the backup run?", "Yes, last night."),
+        ("What's for dinner?", "Pasta?"),
+    ]
+    answers = iter(answer for _, answer in turns)
+
+    def agent(state: MessagesState) -> dict[str, Any]:  # noqa: ARG001
+        return {
+            "messages": [
+                AIMessage(
+                    content="", tool_calls=[{"name": "t", "args": {}, "id": "c"}]
+                ),
+                AIMessage(content=next(answers)),
+            ]
+        }
+
+    graph = StateGraph(MessagesState)
+    graph.add_node("agent", agent)
+    graph.add_edge(START, "agent")
+    graph.add_edge("agent", END)
+    app = graph.compile(checkpointer=MemorySaver())
+    config: RunnableConfig = {"configurable": {"thread_id": "conv-1"}}
+
+    entity = _entity()
+    chat_log: list = []
+    for question, answer in turns:
+        chat_log.append(_mk_content(ha_conversation.UserContent, content=question))
+        history = _history(chat_log, entity)
+        app.invoke({"messages": [*history, HumanMessage(content=question)]}, config)
+        chat_log.extend(_own_tool_turn(question, answer)[1:])
+
+    thread = app.get_state(config).values["messages"]
+    human = [m.content for m in thread if isinstance(m, HumanMessage)]
+    assert human == [question for question, _ in turns], (
+        "each user message must be in the thread exactly once, in order"
+    )
+    assert len(thread) == 3 * len(turns)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #621
Fixes #590

## What was wrong

Every turn's user message (and, for a turn that answered without tools, the reply too) was appended to the LangGraph thread a second time on the following turn, under a fresh message id. The stale copy sat directly before the new request and the model frequently answered it instead of the new question. Reproduced through the real filter and a real `MessagesState` + `MemorySaver` graph over four turns; the output matched the reporter's trace shape exactly:

```
HumanMessage  'How many movies are in my library?'
AIMessage     ''                      <- tool call
AIMessage     'You have 1,389 movies.'
HumanMessage  'How many movies are in my library?'   <- duplicate, fresh id
HumanMessage  'How much free space is left?'
...
```

`_async_get_message_history` exists to pick up chat_log turns handled by *another* agent sharing the conversation (HA's built-in agent on a shared pipeline). Its per-entity high-water mark only stopped the same chat_log entry from being read twice; it could not tell this entity's own turns, which the checkpointer already holds, from foreign ones. Each own turn came back through the filter exactly once, on the next turn.

The filter was written when the integration wrote nothing to chat_log, and HA discards a chat_log update that adds no assistant content, so it saw an empty log and worked. Populating chat_log for Show Details (033f9ab, #369, v3.11.0) silently turned every own turn into a duplicate; #588 later hid the AI half of tool-using turns, leaving the user-message duplicate in the report.

## The fix

- Group chat_log into turns. A turn is ours when its **final** entry is an `AssistantContent` we wrote. (Any-entry matching is wrong: with `prefer_local_intents`, HA's default agent stamps its tool_calls and `ToolResultContent` with the pipeline's agent id, i.e. ours, but speaks the result under `conversation.home_assistant`. Verified in `default_agent.py` and `assist_pipeline/pipeline.py`.)
- Ingest only the foreign turns after our latest own turn. Everything before it was ingested when that turn ran, so the walk is stateless and per-conversation by construction. That removes the per-entity counter whose shared state starved concurrent conversations, so this also fixes #590.
- Ingested messages carry an id derived from their chat_log position (`chat_log:<conversation_id>:<index>`), so a turn that fails or is cancelled before it can leave our mark only upserts the same messages next time instead of appending duplicates.
- The #588 rule is kept: a foreign tool-using turn contributes only the user's message.

Two holes in the non-streaming (schema-first YAML) path found in review are closed with it:

- A turn that failed returned without any own chat_log entry, so HA discarded the turn and the foreign history already checkpointed with that request would be offered again. The runner now records any exception as an own `AssistantContent` (sanitised text for non-`HomeAssistantError`s) before re-raising.
- The Show Details backfill sliced `response["messages"]` by the input length, but `ainvoke` returns the whole checkpointed thread, so from the second turn on every earlier reply was written to chat_log again. The request now carries an explicit id and the backfill takes everything after it.

The end-of-turn guard now checks the last chat_log entry rather than any entry, which is what `async_get_result_from_chat_log` reads.

## Review

- Detached Codex pass: 3 findings. P1 (failed own turn leaves no boundary) fixed as above; two P2 edges (re-entrant nested `async_get_chat_log`, entity rename inside a 5-minute chat_log lifetime) accepted as not worth code.
- `/code-review medium`: 7 confirmed findings, all addressed: local-intent ownership (regression vs main), cancelled-turn re-ingestion (ids), non-`HomeAssistantError` failures, last-entry guard, dead request-id fallback, source-grep test replaced by behavioural tests, and a changelog note for fixed user-supplied `conversation_id`s that keep their already-duplicated history until trimmed.

## Tests

Nine new regressions, each verified to fail without its fix: own turns skipped, foreign-after-own only, per-conversation (#590), own failed turn still a boundary, local-intent turn is foreign, position ids make re-ingestion an upsert, a four-turn run through the real `add_messages` reducer asserting each user message appears once, the runner's failure branch (parametrised over `HomeAssistantError` and a generic exception), and the backfill driven through the real runner. The existing #588 tests now name a foreign agent where they assert a reply is kept.

Full suite: 3200+ passed. `make lint` clean. pyright: 0 errors on the touched files.

## Known trade-off

In no-database mode the `MemorySaver` thread is lost on a config-entry reload while chat_log survives for up to 5 minutes; the old counter re-ingested that history by accident, the new rule does not. No-database mode already loses every conversation on reload, so this is not called out separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EenAgfG76zww3aBRxnzZyv
