### PR TITLE
fix: build the Anthropic SDK client once, off the event loop (issues #618, #587)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.39.5] - 2026-09-11
+
+### Fixed
+
+- Conversations on the Anthropic provider no longer block Home Assistant's event loop on every turn. Each request was constructing a fresh Anthropic SDK client on the loop, and since anthropic 0.98 that constructor reads `~/.config/anthropic/active_config` from disk to warn about environment-shadowed credentials, which Home Assistant flags as a stability problem. The cause is that the provider is wrapped in `configurable_fields`, and LangChain honours per-call configuration by rebuilding the model object on every call, which discarded the lazily cached client each time. Home Assistant reports each blocking call site once per start and then only at debug level, so the log made it look like a one-off. The client is now built once, in a worker thread, before the provider is published, and every per-request copy inherits it; the SDK's platform headers, which read `/etc/os-release` on the first request, are computed there too. If that build fails at setup the Anthropic provider is left unset and the fallback chain takes over, instead of every turn retrying the build on the loop. Thanks to [@andrewvlahopoulos](https://github.com/andrewvlahopoulos) for the report. ([#618](https://github.com/goruck/home-generative-agent/issues/618), [#587](https://github.com/goruck/home-generative-agent/issues/587))
+- The test suite cannot observe this behaviour: the development environment resolves anthropic 0.97.0, the last release without the credential-discovery module, while a fresh install resolves 0.125.0. The fix was verified against 0.125.0 directly; pinning or CI-testing the newest allowed SDK is filed as a follow-up in `TODOS.md`.
+
 ## [3.39.4] - 2026-09-10
 
 ### Fixed

--- a/TODOS.md
+++ b/TODOS.md
@@ -2,6 +2,17 @@
 
 ## Agent
 
+### The `anthropic` SDK floats across 30 releases the test venv never sees
+
+**What:** `manifest.json` pins `langchain-anthropic==1.4.3`, which only constrains `anthropic` to `>=0.96.0,<1.0.0`. The dev venv sits on 0.97.0, the last release without `anthropic/lib/credentials/`; a fresh Home Assistant install resolves 0.125.0. Everything that module does at client construction (credential auto-discovery, the `active_config` read, the env-shadow warning) is invisible to `make test` and CI, which is why [#587](https://github.com/goruck/home-generative-agent/issues/587) and [#618](https://github.com/goruck/home-generative-agent/issues/618) were only ever seen on live boxes. `core/anthropic_client.py` now keeps that construction off the loop regardless of SDK version, but the blind spot itself remains.
+
+**Why:** Deferred from the #618 fix, which is a behaviour change, not a dependency decision. Pinning `anthropic` explicitly in `manifest.json` trades "silently newer on every install" for "must be bumped by hand", and `langchain-anthropic` may itself tighten the floor on its next release; the right pin depends on when that lands.
+
+**How to apply:** Either pin `anthropic==<tested version>` in `manifest.json` and add it to the `make testdeps` install so the venv and installs agree, or keep the float and add a CI job that installs the newest allowed `anthropic` and runs the provider tests (`test_anthropic_shared_client.py`) against it. Whichever is chosen, `make lint`'s manifest check should cover it.
+
+**Effort:** S
+**Priority:** P2
+
 ### Ollama exact token count sends non-option keys inside `options`
 
 **What:** `_count_ollama_tokens` (`agent/token_counter.py`) copies `chat_model_options` wholesale into the `/api/generate` request's `options` object before overriding `num_predict` to 0. That dict also carries `keep_alive` and, when a reasoning model is configured, `reasoning`, which are top-level request parameters, not runner options. Ollama logs an invalid-option warning for each and ignores them, so the count still works, but the request is malformed on every exact count and a stricter server (Ollama Cloud rejects unknown values more readily, see [#614](https://github.com/goruck/home-generative-agent/issues/614)) could start refusing it.

--- a/custom_components/home_generative_agent/__init__.py
+++ b/custom_components/home_generative_agent/__init__.py
@@ -50,23 +50,7 @@ from homeassistant.helpers.target import (
 )
 from homeassistant.util import dt as dt_util
 from homeassistant.util.ssl import SSL_ALPN_HTTP11, client_context
-from langchain_anthropic import ChatAnthropic
 from langchain_core.runnables import ConfigurableField
-
-# langchain_anthropic caches the sync httpx client with @lru_cache but omits it
-# for the async path, causing a repeated blocking SSL context creation inside the
-# HA event loop. Patch parity: cache the async function the same way.
-try:
-    import langchain_anthropic.chat_models as _lc_anthropic_chat
-
-    if not hasattr(_lc_anthropic_chat._get_default_async_httpx_client, "cache_info"):  # noqa: SLF001  # type: ignore[reportPrivateImportUsage]
-        from functools import lru_cache as _lru_cache
-
-        _lc_anthropic_chat._get_default_async_httpx_client = _lru_cache(  # noqa: SLF001  # type: ignore[reportPrivateImportUsage]
-            _lc_anthropic_chat._get_default_async_httpx_client  # noqa: SLF001  # type: ignore[reportPrivateImportUsage]
-        )
-except Exception:  # noqa: BLE001, S110
-    pass
 from langchain_google_genai import ChatGoogleGenerativeAI, GoogleGenerativeAIEmbeddings
 from langchain_ollama import ChatOllama, OllamaEmbeddings
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
@@ -251,6 +235,7 @@ from .const import (
     VLM_REPEAT_PENALTY,
     VLM_TOP_P,
 )
+from .core.anthropic_client import SharedClientChatAnthropic, async_prime_async_client
 from .core.database_guard import (
     async_clear_database_issue,
     async_sync_database_issue,
@@ -2053,30 +2038,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: HGAConfigEntry) -> bool:
         # stable system prefix gets its own explicit breakpoint per call in
         # core/prompt_cache.py (issue #617).
         try:
-            anthropic_provider = ChatAnthropic(  # type: ignore[call-arg]
+            anthropic_chat = SharedClientChatAnthropic(  # type: ignore[call-arg]
                 anthropic_api_key=anthropic_secret,  # type: ignore[call-arg]
                 model=RECOMMENDED_ANTHROPIC_CHAT_MODEL,  # type: ignore[call-arg]
                 model_kwargs={"cache_control": dict(CACHE_CONTROL_EPHEMERAL)},
                 streaming=True,
-            ).configurable_fields(
+            )
+            # Build the SDK client (and its SSL context) in a thread once,
+            # BEFORE the provider is published: the per-request copies
+            # configurable_fields makes inherit it instead of constructing
+            # their own on the event loop (issues #587, #618). If the build
+            # fails here it would fail the same way on the loop, so the
+            # provider stays unset and the fallback chain takes over.
+            await async_prime_async_client(hass, anthropic_chat)
+            anthropic_provider = anthropic_chat.configurable_fields(
                 model=ConfigurableField(id="model"),
                 temperature=ConfigurableField(id="temperature"),
                 thinking=ConfigurableField(id="thinking"),
                 max_tokens=ConfigurableField(id="max_tokens"),
             )
-            # Pre-warm the now-cached async httpx client in a thread so the first
-            # API call doesn't trigger a blocking SSL context load in the event loop.
-            _warm_fn = getattr(
-                globals().get("_lc_anthropic_chat"),
-                "_get_default_async_httpx_client",
-                None,
-            )
-            if callable(_warm_fn):
-                await hass.async_add_executor_job(
-                    partial(
-                        _warm_fn, base_url="https://api.anthropic.com", timeout=None
-                    )
-                )
         except Exception:
             LOGGER.exception("Anthropic provider init failed; continuing without it.")
 

--- a/custom_components/home_generative_agent/core/anthropic_client.py
+++ b/custom_components/home_generative_agent/core/anthropic_client.py
@@ -1,0 +1,138 @@
+"""
+Anthropic chat model whose SDK client is built once, off the event loop.
+
+``ChatAnthropic`` builds its ``anthropic.AsyncClient`` lazily in a
+``cached_property`` on first use. The provider is wrapped in
+``configurable_fields`` so the chat, vision and summarization models can each
+select their own model name and sampling parameters, and
+``RunnableConfigurableFields._prepare`` honours those by constructing a *fresh*
+``ChatAnthropic`` through ``__init__`` on every call. A ``cached_property``
+lives in the instance ``__dict__`` and is not a model field, so it never
+carries across: every request constructed a new SDK client on the calling
+thread, i.e. inside the event loop.
+
+Since anthropic 0.98 the client constructor auto-discovers credentials on disk
+(``~/.config/anthropic/active_config``) so it can warn when an environment
+variable shadows them. That is blocking file I/O. Home Assistant's loop
+protection reports it on the first turn after every start and deduplicates the
+report per call site, so the log understated how often it happened: it was
+every turn (issues #587 and #618).
+
+``_prepare`` copies every *declared* model field into the fresh instance, so
+this subclass declares the client as one. Setup builds it once in an executor
+through :func:`async_prime_async_client`; every per-request copy then inherits
+the built client and touches neither the disk nor the SSL context. The copy
+also inherits the client parameters the client was built from and compares
+them with its own before reusing it, so a copy that somehow differs in API
+key, base URL, timeout, retries, headers or proxy builds its own client the
+way the base class would instead of silently talking to the wrong endpoint.
+Today that cannot happen: only model, temperature, thinking and max_tokens
+are configurable, and a credential change reloads the entry. The client dies
+with the provider on unload, so a rotated key is not retained.
+
+The fields are typed ``Any`` on purpose. ``anthropic`` is imported only for
+type checking, and a pydantic field annotated with an unresolvable name fails
+at class creation, which happens when ``__init__`` imports this module,
+outside the per-provider try/except. That would take down the whole
+integration rather than one provider.
+
+Only the async client is shared. The integration never calls the sync client
+(token counting is approximated locally), so priming it would spend a second
+SSL context load at startup for a path that is never taken. A primed model
+cannot be deep-copied (the httpx client holds a lock); nothing in the
+integration deep-copies models, and the base class has the same property
+after its first request.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+from functools import cached_property
+from typing import TYPE_CHECKING, Any
+
+from langchain_anthropic import ChatAnthropic
+from pydantic import Field
+
+if TYPE_CHECKING:
+    import anthropic
+    from homeassistant.core import HomeAssistant
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _on_event_loop() -> bool:
+    """Return True when called from a thread that is running an event loop."""
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return False
+    return True
+
+
+class SharedClientChatAnthropic(ChatAnthropic):
+    """``ChatAnthropic`` that shares its async SDK client across per-request copies."""
+
+    shared_async_client: Any = Field(default=None, exclude=True, repr=False)
+    """The primed ``anthropic.AsyncClient``; copied into every per-request instance."""
+
+    shared_client_params: Any = Field(default=None, exclude=True, repr=False)
+    """The client parameters ``shared_async_client`` was built from."""
+
+    def _shared_client_params(self) -> dict[str, Any]:
+        """Return everything the base class feeds into the SDK client constructor."""
+        return {**self._client_params, "anthropic_proxy": self.anthropic_proxy}
+
+    @cached_property
+    def _async_client(self) -> anthropic.AsyncClient:
+        try:
+            params = self._shared_client_params()
+            if (
+                self.shared_async_client is not None
+                and self.shared_client_params == params
+            ):
+                return self.shared_async_client
+            client = super()._async_client
+        except AttributeError as exc:
+            # pydantic's __getattr__ turns an AttributeError raised inside a
+            # property into "no attribute '_async_client'", hiding the real
+            # cause (typically an SDK or langchain-anthropic release renaming
+            # something this module reaches into). Keep the whole chain.
+            causes: list[str] = []
+            cur: BaseException | None = exc
+            while cur is not None:
+                causes.append(str(cur))
+                cur = cur.__cause__ or cur.__context__
+            msg = "Anthropic client construction failed: " + " <- ".join(causes)
+            raise RuntimeError(msg) from exc
+        if _on_event_loop():
+            LOGGER.warning(
+                "Built an Anthropic SDK client on the event loop; setup did not "
+                "prime it (client parameters changed or priming failed)"
+            )
+        else:
+            LOGGER.debug(
+                "Built the Anthropic SDK client on thread %s",
+                threading.current_thread().name,
+            )
+        self.shared_async_client = client
+        self.shared_client_params = params
+        return client
+
+
+async def async_prime_async_client(
+    hass: HomeAssistant, model: SharedClientChatAnthropic
+) -> None:
+    """
+    Build ``model``'s SDK client in an executor so no request has to.
+
+    Also computes the SDK's platform headers there: the SDK resolves them on
+    the first request per process by reading ``/etc/os-release`` and probing
+    the interpreter, both blocking, and memoises the result process-wide.
+    """
+
+    def _build() -> None:
+        model._async_client.platform_headers()  # noqa: SLF001
+
+    await hass.async_add_executor_job(_build)

--- a/custom_components/home_generative_agent/manifest.json
+++ b/custom_components/home_generative_agent/manifest.json
@@ -36,5 +36,5 @@
     "langchain-anthropic==1.4.3"
   ],
   "single_config_entry": true,
-  "version": "3.39.4"
+  "version": "3.39.5"
 }

--- a/tests/custom_components/home_generative_agent/test_anthropic_shared_client.py
+++ b/tests/custom_components/home_generative_agent/test_anthropic_shared_client.py
@@ -1,0 +1,260 @@
+# ruff: noqa: S101
+"""
+Issue #618: the Anthropic SDK client is built once, off the event loop.
+
+``configurable_fields`` rebuilds ``ChatAnthropic`` through ``__init__`` on
+every call, which discards the lazily cached SDK client; the SDK constructor
+reads ``~/.config/anthropic/active_config`` (anthropic >= 0.98), so each turn
+blocked the loop on file I/O. These tests pin the per-call rebuild that the
+workaround exists for, and the sharing that neutralises it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
+
+import pytest
+from langchain_anthropic import ChatAnthropic
+from langchain_core.runnables import ConfigurableField
+from pydantic import SecretStr
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+from custom_components.home_generative_agent.core.anthropic_client import (
+    LOGGER,
+    SharedClientChatAnthropic,
+    async_prime_async_client,
+)
+
+_CONFIG = {"configurable": {"model": "claude-sonnet-4-6", "temperature": 0.7}}
+_INSTANCES: list[_FakeSdkClient] = []
+
+
+class _FakeSdkClient:
+    """Stands in for ``anthropic.AsyncClient``; records the constructing thread."""
+
+    def __init__(self, **params: Any) -> None:
+        self.params = params
+        self.thread = threading.current_thread().name
+        self.platform_headers_thread: str | None = None
+        _INSTANCES.append(self)
+
+    def platform_headers(self) -> dict[str, str]:
+        self.platform_headers_thread = threading.current_thread().name
+        return {}
+
+
+@pytest.fixture(autouse=True)
+def _isolated(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    # ChatAnthropic reads the base URL from the environment; a developer box
+    # pointing at a proxy must not change what these tests assert.
+    for var in ("ANTHROPIC_API_URL", "ANTHROPIC_BASE_URL", "ANTHROPIC_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    _INSTANCES.clear()
+    yield
+    _INSTANCES.clear()
+
+
+@pytest.fixture
+def sdk_ctor() -> Iterator[Any]:
+    with patch("anthropic.AsyncClient", side_effect=_FakeSdkClient) as ctor:
+        yield ctor
+
+
+def _model(cls: type[ChatAnthropic] = SharedClientChatAnthropic, **kwargs: Any) -> Any:
+    kwargs.setdefault("anthropic_api_key", SecretStr("sk-test"))
+    kwargs.setdefault("model", "claude-sonnet-4-6")
+    return cls(streaming=True, **kwargs)  # type: ignore[call-arg]
+
+
+def _provider(cls: type[ChatAnthropic] = SharedClientChatAnthropic, **kw: Any) -> Any:
+    return _model(cls, **kw).configurable_fields(
+        model=ConfigurableField(id="model"),
+        temperature=ConfigurableField(id="temperature"),
+        thinking=ConfigurableField(id="thinking"),
+        max_tokens=ConfigurableField(id="max_tokens"),
+    )
+
+
+def _prime_in_thread(model: Any) -> None:
+    thread = threading.Thread(target=lambda: model._async_client, name="executor")
+    thread.start()
+    thread.join()
+
+
+def _per_call_copy(provider: Any) -> Any:
+    """Return the concrete model a single ``ainvoke`` would run against."""
+    bound = provider.with_config(config=_CONFIG)
+    prepared, _ = bound._prepare(bound.config)
+    return prepared
+
+
+def test_plain_chat_anthropic_rebuilds_the_sdk_client_every_call(sdk_ctor: Any) -> None:
+    """
+    Pin the upstream behaviour the workaround exists for: one client per call.
+
+    If this starts failing, langchain-core carries the cached client across
+    ``_prepare`` and ``SharedClientChatAnthropic`` may no longer be needed.
+    """
+    provider = _provider(ChatAnthropic)
+    _prime_in_thread(provider.default)
+    assert sdk_ctor.call_count == 1
+
+    for _ in range(3):
+        copy = _per_call_copy(provider)
+        assert copy is not provider.default
+        _ = copy._async_client
+    assert sdk_ctor.call_count == 4
+    assert [c.thread for c in _INSTANCES] == ["executor"] + ["MainThread"] * 3
+
+
+def test_shared_client_is_built_once_and_reused_by_every_copy(
+    sdk_ctor: Any, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.DEBUG, logger=LOGGER.name)
+    provider = _provider()
+    _prime_in_thread(provider.default)
+    assert sdk_ctor.call_count == 1
+    primed = provider.default._async_client
+    assert primed.thread == "executor"
+
+    for _ in range(3):
+        copy = _per_call_copy(provider)
+        assert isinstance(copy, SharedClientChatAnthropic)
+        assert copy is not provider.default
+        assert "_async_client" not in copy.__dict__
+        assert copy._async_client is primed
+
+    assert sdk_ctor.call_count == 1
+    assert "on the event loop" not in caplog.text
+    assert caplog.text.count("Built the Anthropic SDK client") == 1
+
+
+def test_bind_tools_and_model_copy_keep_the_shared_client(sdk_ctor: Any) -> None:
+    """Every LangChain path that derives a model from the primed one shares it."""
+    provider = _provider()
+    _prime_in_thread(provider.default)
+    primed = provider.default._async_client
+
+    bound = provider.with_config(config=_CONFIG).bind_tools(
+        [{"name": "t", "description": "d", "input_schema": {"type": "object"}}]
+    )
+    assert bound.bound._async_client is primed
+    assert provider.default.model_copy(update={"temperature": 0.1})._async_client is (
+        primed
+    )
+    assert sdk_ctor.call_count == 1
+
+
+def test_equal_params_share_across_independent_models(sdk_ctor: Any) -> None:
+    """Sharing is by value of the client parameters, not by object identity."""
+    primed = _model(default_headers={"X-A": "1", "X-B": "2"})
+    _prime_in_thread(primed)
+    same = _model(
+        default_headers={"X-B": "2", "X-A": "1"},
+        shared_async_client=primed.shared_async_client,
+        shared_client_params=primed.shared_client_params,
+    )
+    assert same._async_client is primed._async_client
+    assert sdk_ctor.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"anthropic_api_key": SecretStr("sk-other")},
+        {"anthropic_api_url": "https://proxy.local"},
+        {"anthropic_proxy": "http://proxy:3128"},
+        {"max_retries": 9},
+        {"default_request_timeout": 30.0},
+        {"default_headers": {"X-A": "1"}},
+    ],
+)
+async def test_copy_with_different_client_params_builds_its_own_client(
+    sdk_ctor: Any, caplog: pytest.LogCaptureFixture, kwargs: dict[str, Any]
+) -> None:
+    """A copy must never reuse a client built for another endpoint or key."""
+    caplog.set_level(logging.DEBUG, logger=LOGGER.name)
+    primed = _model()
+    _prime_in_thread(primed)
+    other = _model(
+        shared_async_client=primed.shared_async_client,
+        shared_client_params=primed.shared_client_params,
+        **kwargs,
+    )
+
+    own = other._async_client
+
+    assert own is not primed._async_client
+    assert sdk_ctor.call_count == 2
+    assert other.shared_async_client is own
+    assert "on the event loop" in caplog.text
+
+
+def test_shared_client_passes_the_base_class_parameters(sdk_ctor: Any) -> None:
+    """Sharing changes where the client is built, not how."""
+    assert sdk_ctor.call_count == 0
+    provider = _provider()
+    client = _per_call_copy(provider)._async_client
+    assert client.params["api_key"] == "sk-test"
+    assert client.params["base_url"] == "https://api.anthropic.com"
+    assert "http_client" in client.params
+    assert client.params["default_headers"]["User-Agent"]
+
+
+@pytest.mark.usefixtures("sdk_ctor")
+def test_serialization_omits_the_client() -> None:
+    provider = _provider()
+    _prime_in_thread(provider.default)
+    dumped = provider.default.to_json()
+    assert "shared_async_client" not in dumped.get("kwargs", {})
+    assert "shared_client_params" not in dumped.get("kwargs", {})
+    assert "shared_async_client" not in repr(provider.default)
+
+
+def test_attribute_error_inside_construction_is_not_masked_by_pydantic() -> None:
+    """Pydantic turns a swallowed AttributeError into 'no attribute _async_client'."""
+    model = _model()
+
+    def _renamed(_self: Any) -> Any:
+        msg = "renamed"
+        raise AttributeError(msg)
+
+    with (
+        patch.object(ChatAnthropic, "_client_params", property(_renamed)),
+        pytest.raises(RuntimeError, match="renamed"),
+    ):
+        _ = model._async_client
+
+
+async def test_async_prime_builds_the_client_in_the_executor(sdk_ctor: Any) -> None:
+    executor_threads: list[str] = []
+
+    class _Hass:
+        async def async_add_executor_job(
+            self, func: Callable[..., Any], *args: Any
+        ) -> Any:
+            def _run() -> Any:
+                executor_threads.append(threading.current_thread().name)
+                return func(*args)
+
+            return await asyncio.get_running_loop().run_in_executor(None, _run)
+
+    provider = _provider()
+    await async_prime_async_client(_Hass(), provider.default)  # type: ignore[arg-type]
+
+    assert sdk_ctor.call_count == 1
+    primed = provider.default._async_client
+    assert primed.thread == executor_threads[0] != "MainThread"
+    # The SDK's platform headers read /etc/os-release on first use; the prime
+    # takes that read off the loop as well.
+    assert primed.platform_headers_thread == executor_threads[0]
+
+    copy = _per_call_copy(provider)
+    assert copy._async_client is primed
+    assert sdk_ctor.call_count == 1

--- a/tests/custom_components/home_generative_agent/test_fallback_setup.py
+++ b/tests/custom_components/home_generative_agent/test_fallback_setup.py
@@ -14,6 +14,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 import custom_components.home_generative_agent as hga_component
 from custom_components.home_generative_agent.const import (
+    CONF_ANTHROPIC_API_KEY,
     CONF_CHAT_MODEL_PROVIDER,
     CONF_EMBEDDING_MODEL_PROVIDER,
     CONF_EXPLAIN_ENABLED,
@@ -684,3 +685,84 @@ async def test_setup_gemini3_chat_binds_recommended_temperature(
     assert fallback_config["model"] == "gemini-3.5-flash"
     assert fallback_config["temperature"] == GEMINI_3_RECOMMENDED_TEMPERATURE
     assert fallback_config["top_p"] is None
+
+
+def _anthropic_primary_setup_data() -> FallbackSetupData:
+    """Chat on Anthropic with an Ollama fallback; everything else on OpenAI."""
+    data = _fallback_setup_data()
+    anthropic_provider = ModelProviderConfig(
+        entry_id="anthropic1",
+        name="Anthropic",
+        provider_type="anthropic",
+        capabilities={"chat"},
+        data={"settings": {"api_key": "sk-ant-test"}},
+        deployment="cloud",
+    )
+    data.providers[anthropic_provider.entry_id] = anthropic_provider
+    data.options[CONF_CHAT_MODEL_PROVIDER] = "anthropic"
+    data.options[CONF_ANTHROPIC_API_KEY] = "sk-ant-test"
+    data.fallback_chains["chat"] = [anthropic_provider, data.providers["ollama1"]]
+    return data
+
+
+def _patch_anthropic_provider(
+    monkeypatch: pytest.MonkeyPatch, prime: Any
+) -> FakeRunnable:
+    """Make Anthropic healthy, stub its model class, and install ``prime``."""
+
+    async def _healthy(*_args: Any, **_kwargs: Any) -> bool:
+        return True
+
+    fake = FakeRunnable("anthropic")
+    monkeypatch.setattr(hga_component, "anthropic_healthy", _healthy)
+    monkeypatch.setattr(
+        hga_component, "SharedClientChatAnthropic", lambda *_a, **_kw: fake
+    )
+    monkeypatch.setattr(hga_component, "async_prime_async_client", prime)
+    return fake
+
+
+@pytest.mark.asyncio
+async def test_setup_primes_the_anthropic_client_before_publishing_it(
+    hass: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The SDK client is primed once, off the loop, on the instance the chain uses."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+    hass.data.setdefault(DOMAIN, {})["http_registered"] = True
+    data = _anthropic_primary_setup_data()
+    _patch_setup_dependencies(hass, monkeypatch, data)
+    prime = AsyncMock()
+    fake = _patch_anthropic_provider(monkeypatch, prime)
+
+    assert await cast("Any", hga_component).async_setup_entry(hass, entry) is True
+
+    prime.assert_awaited_once_with(hass, fake)
+    chat_model = entry.runtime_data.chat_model
+    assert isinstance(chat_model, FallbackChatModel)
+    primary = cast("FakeConfiguredModel", chat_model.chain[0][0])
+    assert primary.base is fake
+    assert chat_model.chain[0][2] == "anthropic1"
+
+
+@pytest.mark.asyncio
+async def test_setup_drops_the_anthropic_provider_when_priming_fails(
+    hass: Any, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A client that cannot be built off the loop is never built on it (#618)."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+    hass.data.setdefault(DOMAIN, {})["http_registered"] = True
+    data = _anthropic_primary_setup_data()
+    _patch_setup_dependencies(hass, monkeypatch, data)
+    prime = AsyncMock(side_effect=RuntimeError("executor down"))
+    fake = _patch_anthropic_provider(monkeypatch, prime)
+
+    assert await cast("Any", hga_component).async_setup_entry(hass, entry) is True
+
+    prime.assert_awaited_once()
+    assert fake.configured == []
+    chat_model = entry.runtime_data.chat_model
+    assert isinstance(chat_model, FakeConfiguredModel)
+    assert chat_model.base.name == "ollama"
+    assert "Anthropic provider init failed; continuing without it." in caplog.text

--- a/tests/custom_components/home_generative_agent/test_provider_streaming.py
+++ b/tests/custom_components/home_generative_agent/test_provider_streaming.py
@@ -32,7 +32,7 @@ def test_openai_provider_has_stream_usage_true() -> None:
 
 def test_anthropic_provider_has_streaming_true() -> None:
     """ChatAnthropic construction includes streaming=True."""
-    block = _provider_block("anthropic_provider = ChatAnthropic(")
+    block = _provider_block("anthropic_chat = SharedClientChatAnthropic(")
     assert "streaming=True" in block
 
 
@@ -43,9 +43,14 @@ def test_openai_provider_http_client_preserved() -> None:
     assert "http_async_client=http_async_client" in block
 
 
-def test_anthropic_provider_prewarm_preserved() -> None:
-    """Anthropic async-client pre-warm call is still present after streaming change."""
-    assert "_get_default_async_httpx_client" in _INIT
+def test_anthropic_provider_primed_before_publish() -> None:
+    """The SDK client is primed off the loop before the provider exists (#587, #618)."""
+    start = _INIT.index("anthropic_chat = SharedClientChatAnthropic(")
+    end = _INIT.index("except Exception:", start)
+    block = _INIT[start:end]
+    prime = block.index("await async_prime_async_client(hass, anthropic_chat)")
+    publish = block.index("anthropic_provider = anthropic_chat.configurable_fields(")
+    assert prime < publish
 
 
 async def test_stream_usage_metadata_flows_through_invoke_model() -> None:


### PR DESCRIPTION
Fixes #618
Fixes #587

## What was wrong

Every conversation turn against the Anthropic provider constructed a new `anthropic.AsyncClient` on the Home Assistant event loop, not just the first one. Both reports are right: #587 saw the blocking-call warning once per start, #618 says it is every turn. HA's loop protection keys its report on the call site and logs it once at WARNING, then only at DEBUG, so the log understated it.

The provider is wrapped in `configurable_fields`, and langchain-core's `RunnableConfigurableFields._prepare` honours per-call config by rebuilding `ChatAnthropic` through `__init__` on every call (`configurable.py:456`). The SDK client lives in a `cached_property`, which is instance state rather than a declared field, so it never carried into those copies. Since anthropic 0.98 the client constructor runs `_warn_env_shadow → _has_auto_discoverable_credentials → _read_active_config_pointer`, a synchronous `read_text` of `~/.config/anthropic/active_config`. Reproduced against anthropic 0.125.0 with the real `_prepare` path: one file read per turn, on the calling thread. Priming the default instance in an executor (the #587 plan) was tested and does not work, because the primed instance never serves a request.

## The fix

- `core/anthropic_client.py`: `SharedClientChatAnthropic` declares the primed client, and the client parameters it was built from, as `Field(default=None, exclude=True, repr=False)` fields. `_prepare` copies every declared field into the fresh instance, so every per-request copy inherits the client; `bind_tools` and `model_copy` do too. A copy whose client parameters differ (API key, base URL, timeout, retries, headers, proxy) builds its own client the way the base class would, and logs at WARNING if that ever happens on the loop. An `AttributeError` raised inside the property is re-raised as `RuntimeError` with the cause chain, because pydantic's `__getattr__` would otherwise mask it as "no attribute `_async_client`". The fields are typed `Any` on purpose: a type-checking-only name in a field annotation fails at class creation, which would take down the whole integration at import rather than one provider.
- `__init__.py`: the client is built in an executor **before** the provider is published. If the build fails, the provider stays unset and the fallback chain takes over, so the existing "continuing without it" log becomes true instead of every turn retrying the build on the loop. The prime also calls `platform_headers()`, which otherwise reads `/etc/os-release` on the first request per process. The module-level `lru_cache` shim for langchain_anthropic's async httpx builder is deleted: the pinned 1.4.3 already caches it, and the prime reaches the same cache key as the old pre-warm (`base_url`, `timeout=None`, same order), so the SSL context load stays off the loop.

## Review

gstack `/review`: five specialists, Claude adversarial, red team, and a detached Codex pass all ran on the first cut (a module-level registry keyed on client parameters). Zero critical findings; the informational findings converged on three points, all addressed:

- Prime failure left the provider live (three Claude passes and Codex's headline). Fixed by the ordering above; pinned by a setup test through the real `async_setup_entry`.
- The registry was more machinery than the job needed (simplification pass). Replaced by the field shape, which also dissolved the rotated-key retention, the unlocked miss path, and the ambiguous debug log.
- The old httpx shim was dead on the pinned library and its comment contradicted the new module. Deleted.

Left alone on purpose: Codex's note that environment-derived SDK headers are outside the parameter comparison describes a mid-process environment change, which HA does not do.

## Tests

- `test_anthropic_shared_client.py` (14): pins the upstream per-call rebuild the workaround exists for; sharing across copies, `bind_tools`, and `model_copy`; sharing by parameter value across independent instances; six parametrised cases where a copy with different client parameters must build its own; base-class parameters passed through unchanged; serialization and repr omit the client; the `AttributeError` chain; the prime runs in the executor and covers `platform_headers()`.
- `test_fallback_setup.py` (+2): the prime is awaited once on the instance the chain uses; a prime that raises leaves the chat model on the Ollama fallback with the provider never configured.
- `test_provider_streaming.py`: the source assertion now bounds structurally and checks prime precedes publish.
- Verified against the real anthropic 0.125.0 SDK, not mocks: one credential read total, on the executor thread, none on the main thread across five turns.

Full suite: 3217 passed, 1 skipped. `make lint` clean. pyright: 0 errors on the touched files.

## Follow-up

`manifest.json` pins `langchain-anthropic==1.4.3`, which lets `anthropic` float from 0.96 to 0.125; the dev venv sits on 0.97.0, the last release without the credentials module, so `make test` cannot observe this class of defect. Filed as a P2 in `TODOS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015FzuxXjNxbKfjtacmsn82U
